### PR TITLE
Array rank specifiers are optional

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -480,6 +480,7 @@ Explicit array creation
 
 void b() {
   var z = new int[3] { 1, 2, 3 };
+  var b = new byte[,] { { 1, 2 }, { 2, 3 } };
 }
 
 ---
@@ -503,7 +504,24 @@ void b() {
                 (initializer_expression
                   (integer_literal)
                   (integer_literal)
-                  (integer_literal))))))))))
+                  (integer_literal)))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier_name)
+              (equals_value_clause
+                (array_creation_expression
+                  (array_type
+                    (predefined_type)
+                    (array_rank_specifier))
+                  (initializer_expression
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal)))))))))))
 
 ============================
 Explicit multi array creation
@@ -878,7 +896,7 @@ class Foo {
                     (identifier_name)
                     (equals_value_clause
                       (range_expression
-                        (prefix_unary_expression (integer_literal)))))))                        
+                        (prefix_unary_expression (integer_literal)))))))
               (local_declaration_statement
                 (variable_declaration
                   (implicit_type)

--- a/grammar.js
+++ b/grammar.js
@@ -555,7 +555,9 @@ module.exports = grammar({
 
     array_type: $ => prec(PREC.POSTFIX, seq($._type, $.array_rank_specifier)),
 
-    array_rank_specifier: $ => seq('[', commaSep($._expression), ']'),
+    // Roslyn marks this non-optional and includes omitted_array_size_expression in
+    // expression but we can't match an empty rule everywhere.
+    array_rank_specifier: $ => seq('[', commaSep(optional($._expression)), ']'),
 
     nullable_type: $ => seq($._type, '?'),
 

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -6,7 +6,6 @@ examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/Cr
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/CreateJsonDeclaratively.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/QueryJsonLinq.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/SerializationTests.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1545.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1552.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1593.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1619.cs
@@ -149,14 +148,10 @@ examples/nunit/src/NUnitFramework/testdata/TestDataSpec.cs
 examples/nunit/src/NUnitFramework/testdata/TestFixtureData.cs
 examples/nunit/src/NUnitFramework/testdata/TestFixtureSourceData.cs
 examples/nunit/src/NUnitFramework/testdata/UnhandledExceptions.cs
-examples/nunit/src/NUnitFramework/tests/Assertions/ArrayEqualsFailureMessageFixture.cs
-examples/nunit/src/NUnitFramework/tests/Assertions/ArrayEqualsFixture.cs
 examples/nunit/src/NUnitFramework/tests/Assertions/AssertionHelperTests.cs
 examples/nunit/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
-examples/nunit/src/NUnitFramework/tests/Assertions/TypeAssertTest.cs
 examples/nunit/src/NUnitFramework/tests/Attributes/RangeAttributeTests.cs
 examples/nunit/src/NUnitFramework/tests/Attributes/TestFixtureSourceTests.cs
-examples/nunit/src/NUnitFramework/tests/Attributes/ValueSourceTests.cs
 examples/nunit/src/NUnitFramework/tests/Constraints/CollectionEquivalentConstraintResultTests.cs
 examples/nunit/src/NUnitFramework/tests/Constraints/NUnitEqualityComparerTests.cs
 examples/nunit/src/NUnitFramework/tests/HelperConstraints.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2634,8 +2634,16 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
                   "type": "REPEAT",
@@ -2647,8 +2655,16 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_expression"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       }
                     ]
                   }


### PR DESCRIPTION
Was not supporting syntax like `int [,]` for array specifiers as we don't have `omitted_array_size_expression` as a type of expression as it is the absence of a value.

This allows the numbers to be dropped within `array_rank_specifier` but in theory other places could need it too.

Removes another 5 files from the list that couldn't be parsed.