### PR TITLE
Added ref_expression

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1003,3 +1003,36 @@ var t = typeof(Tuple<,,,>);
             (generic_name
               (identifier_name)
               (type_argument_list))))))))
+
+=====================================
+Generic type name no type args
+=====================================
+
+ref VeryLargeStruct reflocal = ref veryLargeStruct;
+ref var elementRef = ref arr[0];
+---
+
+(compilation_unit
+  (field_declaration
+    (modifier)
+    (variable_declaration
+      (identifier_name)
+      (variable_declarator
+        (identifier_name)
+        (equals_value_clause
+          (ref_expression
+            (identifier_name))))))
+  (field_declaration
+    (modifier)
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier_name)
+        (equals_value_clause
+          (ref_expression
+            (element_access_expression
+              (identifier_name)
+              (bracketed_argument_list
+                (argument
+                  (integer_literal))))))))))
+                  

--- a/grammar.js
+++ b/grammar.js
@@ -184,7 +184,7 @@ module.exports = grammar({
       ';'
     ),
 
-    modifier: $ => choice(
+    modifier: $ => prec.right(choice(
       'abstract',
       'async',
       'const',
@@ -204,7 +204,7 @@ module.exports = grammar({
       'unsafe',
       'virtual',
       'volatile'
-    ),
+    )),
 
     variable_declaration: $ => seq($._type, commaSep1($.variable_declarator)),
 
@@ -220,7 +220,7 @@ module.exports = grammar({
       ']'
     ),
 
-    argument: $ => seq(
+    argument: $ => prec(1, seq(
       optional($.name_colon),
       choice(
         seq(
@@ -233,7 +233,7 @@ module.exports = grammar({
           $.identifier_name
         )
       )
-    ),
+    )),
 
     equals_value_clause: $ => seq('=', $._expression),
 
@@ -282,7 +282,7 @@ module.exports = grammar({
       optional($.equals_value_clause)
     ),
 
-    parameter_modifier: $ => choice('ref', 'out', 'this'),
+    parameter_modifier: $ => prec.right(choice('ref', 'out', 'this')),
 
     parameter_array: $ => seq(
       repeat($.attribute_list),
@@ -1162,8 +1162,7 @@ module.exports = grammar({
       optional($._expression)
     )),
 
-    // TODO: Conflicts with modifier
-    ref_expression: $ => seq('ref', $._expression),
+    ref_expression: $ => prec.right(seq('ref', $._expression)),
 
     ref_type_expression: $ => seq(
       '__reftype',
@@ -1258,7 +1257,7 @@ module.exports = grammar({
       $.prefix_unary_expression,
       // $.query_expression,
       $.range_expression,
-      // $.ref_expression,
+      $.ref_expression,
       $.ref_type_expression,
       $.ref_value_expression,
       $.size_of_expression,

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -6,7 +6,6 @@ examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/Cr
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/CreateJsonDeclaratively.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/Samples/Linq/QueryJsonLinq.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Documentation/SerializationTests.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1552.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1593.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1619.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1725.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -624,85 +624,89 @@
       ]
     },
     "modifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "abstract"
-        },
-        {
-          "type": "STRING",
-          "value": "async"
-        },
-        {
-          "type": "STRING",
-          "value": "const"
-        },
-        {
-          "type": "STRING",
-          "value": "extern"
-        },
-        {
-          "type": "STRING",
-          "value": "fixed"
-        },
-        {
-          "type": "STRING",
-          "value": "internal"
-        },
-        {
-          "type": "STRING",
-          "value": "new"
-        },
-        {
-          "type": "STRING",
-          "value": "override"
-        },
-        {
-          "type": "STRING",
-          "value": "partial"
-        },
-        {
-          "type": "STRING",
-          "value": "private"
-        },
-        {
-          "type": "STRING",
-          "value": "protected"
-        },
-        {
-          "type": "STRING",
-          "value": "public"
-        },
-        {
-          "type": "STRING",
-          "value": "readonly"
-        },
-        {
-          "type": "STRING",
-          "value": "ref"
-        },
-        {
-          "type": "STRING",
-          "value": "sealed"
-        },
-        {
-          "type": "STRING",
-          "value": "static"
-        },
-        {
-          "type": "STRING",
-          "value": "unsafe"
-        },
-        {
-          "type": "STRING",
-          "value": "virtual"
-        },
-        {
-          "type": "STRING",
-          "value": "volatile"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "abstract"
+          },
+          {
+            "type": "STRING",
+            "value": "async"
+          },
+          {
+            "type": "STRING",
+            "value": "const"
+          },
+          {
+            "type": "STRING",
+            "value": "extern"
+          },
+          {
+            "type": "STRING",
+            "value": "fixed"
+          },
+          {
+            "type": "STRING",
+            "value": "internal"
+          },
+          {
+            "type": "STRING",
+            "value": "new"
+          },
+          {
+            "type": "STRING",
+            "value": "override"
+          },
+          {
+            "type": "STRING",
+            "value": "partial"
+          },
+          {
+            "type": "STRING",
+            "value": "private"
+          },
+          {
+            "type": "STRING",
+            "value": "protected"
+          },
+          {
+            "type": "STRING",
+            "value": "public"
+          },
+          {
+            "type": "STRING",
+            "value": "readonly"
+          },
+          {
+            "type": "STRING",
+            "value": "ref"
+          },
+          {
+            "type": "STRING",
+            "value": "sealed"
+          },
+          {
+            "type": "STRING",
+            "value": "static"
+          },
+          {
+            "type": "STRING",
+            "value": "unsafe"
+          },
+          {
+            "type": "STRING",
+            "value": "virtual"
+          },
+          {
+            "type": "STRING",
+            "value": "volatile"
+          }
+        ]
+      }
     },
     "variable_declaration": {
       "type": "SEQ",
@@ -810,77 +814,81 @@
       ]
     },
     "argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "name_colon"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "ref"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "out"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "in"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "out"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_type"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier_name"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "name_colon"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "ref"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "out"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "in"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "out"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier_name"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
     },
     "equals_value_clause": {
       "type": "SEQ",
@@ -1111,21 +1119,25 @@
       ]
     },
     "parameter_modifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "ref"
-        },
-        {
-          "type": "STRING",
-          "value": "out"
-        },
-        {
-          "type": "STRING",
-          "value": "this"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "ref"
+          },
+          {
+            "type": "STRING",
+            "value": "out"
+          },
+          {
+            "type": "STRING",
+            "value": "this"
+          }
+        ]
+      }
     },
     "parameter_array": {
       "type": "SEQ",
@@ -5760,17 +5772,21 @@
       }
     },
     "ref_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "ref"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "ref"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
     },
     "ref_type_expression": {
       "type": "SEQ",
@@ -6132,6 +6148,10 @@
         {
           "type": "SYMBOL",
           "name": "range_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ref_expression"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -213,6 +213,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -436,6 +440,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -654,6 +662,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -895,6 +907,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -1083,6 +1099,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -1317,6 +1337,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -1531,6 +1555,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -1770,6 +1798,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -2138,6 +2170,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -2354,6 +2390,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -2614,6 +2654,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -2813,6 +2857,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -3223,6 +3271,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -3410,6 +3462,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -3594,6 +3650,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -4155,6 +4215,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -4375,6 +4439,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -4727,6 +4795,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -4911,6 +4983,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -5211,6 +5287,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -5661,6 +5741,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -5944,6 +6028,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -6199,6 +6287,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -6424,6 +6516,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -6608,6 +6704,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -6863,6 +6963,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -7191,6 +7295,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -7473,6 +7581,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -7657,6 +7769,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -7853,6 +7969,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -8076,6 +8196,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -8400,6 +8524,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -8584,6 +8712,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -8932,6 +9064,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -9151,6 +9287,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -9339,6 +9479,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -9953,6 +10097,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -10246,6 +10394,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -10518,6 +10670,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -10707,6 +10863,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -10946,6 +11106,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -11240,6 +11404,201 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
+          "type": "ref_type_expression",
+          "named": true
+        },
+        {
+          "type": "ref_value_expression",
+          "named": true
+        },
+        {
+          "type": "size_of_expression",
+          "named": true
+        },
+        {
+          "type": "stack_alloc_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "switch_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "throw_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "type_of_expression",
+          "named": true
+        },
+        {
+          "type": "verbatim_string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ref_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "anonymous_method_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
+          "type": "await_expression",
+          "named": true
+        },
+        {
+          "type": "base_expression",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "checked_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_access_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "element_access_expression",
+          "named": true
+        },
+        {
+          "type": "element_binding_expression",
+          "named": true
+        },
+        {
+          "type": "identifier_name",
+          "named": true
+        },
+        {
+          "type": "implicit_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "implicit_stack_alloc_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "initializer_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "invocation_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_expression",
+          "named": true
+        },
+        {
+          "type": "make_ref_expression",
+          "named": true
+        },
+        {
+          "type": "member_access_expression",
+          "named": true
+        },
+        {
+          "type": "member_binding_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -11424,6 +11783,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -11646,6 +12009,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -11833,6 +12200,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -12017,6 +12388,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -12373,6 +12748,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -12573,6 +12952,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -12890,6 +13273,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -13086,6 +13473,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -13270,6 +13661,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -13849,6 +14244,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -14169,6 +14568,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -14353,6 +14756,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {
@@ -14607,6 +15014,10 @@
           "named": true
         },
         {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
           "type": "ref_type_expression",
           "named": true
         },
@@ -14823,6 +15234,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
           "named": true
         },
         {


### PR DESCRIPTION
I had to increase the precedence of argument rule to disambiguate the case where an argument is passed by reference.

Please let me know if there is a better way to specify that we prefer `argument` over `ref_expression`