### PR TITLE
Corpus coverage for element_binding_expression

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1035,6 +1035,7 @@ Generic type name no type args
 
 ref VeryLargeStruct reflocal = ref veryLargeStruct;
 ref var elementRef = ref arr[0];
+
 ---
 
 (compilation_unit
@@ -1060,3 +1061,49 @@ ref var elementRef = ref arr[0];
               (bracketed_argument_list
                 (argument
                   (integer_literal))))))))))
+
+=====================================
+Element binding expression
+=====================================
+
+var x = new Dictionary<string,int> { ["a"] = 65 };
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier_name)
+        (equals_value_clause
+          (object_creation_expression
+            (generic_name
+              (identifier_name)
+              (type_argument_list (predefined_type) (predefined_type)))
+            (initializer_expression
+              (assignment_expression
+                (element_binding_expression
+                  (bracketed_argument_list (argument (string_literal))))
+                (assignment_operator)
+                (integer_literal)))))))))
+
+=====================================
+Conditional access to element (should be implicit_element_access)
+=====================================
+
+var x = dict?["a"];
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier_name)
+        (equals_value_clause
+          (conditional_access_expression
+            (identifier_name)
+              (element_binding_expression
+                (bracketed_argument_list (argument (string_literal))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -956,7 +956,6 @@ module.exports = grammar({
 
     element_access_expression: $ => seq($._expression, $.bracketed_argument_list),
 
-    // TODO: Add test coverage for this.
     element_binding_expression: $ => $.bracketed_argument_list,
 
     implicit_array_creation_expression: $ => seq(
@@ -967,6 +966,7 @@ module.exports = grammar({
       $.initializer_expression
     ),
 
+    // TODO: Conflicts with element_binding_expression as same pattern.
     implicit_element_access: $ => $.bracketed_argument_list,
 
     implicit_stack_alloc_array_creation_expression: $ => seq(
@@ -1248,7 +1248,7 @@ module.exports = grammar({
       $.element_access_expression,
       $.element_binding_expression,
       $.implicit_array_creation_expression,
-      // $.implicit_element_access,
+      //$.implicit_element_access,
       $.implicit_stack_alloc_array_creation_expression,
       $.initializer_expression,
       $._instance_expression,


### PR DESCRIPTION
Just adds test coverage for `element_binding_expression`.

The grammar.txt from Roslyn shows both an `element_binding_expression` and a `implicit_element_access` however they both map to `bracketed_argument_list` from inside `expression` so impossible to disambiguate there.

Probably fine just to leave this as-is and let `implicit_element_access` map to `element_binding_expression`.