### PR TITLE
Add type parameter variance

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -70,7 +70,7 @@ class F<T> {}
 (compilation_unit
   (class_declaration
     (identifier_name)
-     (type_parameter_list (identifier_name))
+     (type_parameter_list (type_parameter (identifier_name)))
      (class_body)))
 
 =====================================
@@ -86,8 +86,25 @@ internal class F<T1, T2> {}
    (modifier)
    (identifier_name)
     (type_parameter_list
-      (identifier_name)
-      (identifier_name))
+      (type_parameter (identifier_name))
+      (type_parameter (identifier_name)))
+    (class_body)))
+
+=====================================
+Class with co-variant and contra-variant type parameters
+=====================================
+
+internal class F<in T1, out T2> {}
+
+---
+
+(compilation_unit
+ (class_declaration
+   (modifier)
+   (identifier_name)
+    (type_parameter_list
+      (type_parameter (identifier_name))
+      (type_parameter (identifier_name)))
     (class_body)))
 
 =====================================
@@ -102,7 +119,7 @@ public class F<T> where T:struct {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
     (class_body)))
@@ -119,7 +136,7 @@ public class F<T> where T:class {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
     (class_body)))
@@ -136,7 +153,7 @@ public class F<T> where T: new() {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (constructor_constraint)))
@@ -154,7 +171,7 @@ public class F<T> where T: I {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name))))
@@ -172,7 +189,7 @@ public class F<T> where T: I, new() {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint
@@ -193,8 +210,8 @@ private class F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
     (modifier)
     (identifier_name)
     (type_parameter_list
-      (identifier_name)
-      (identifier_name))
+      (type_parameter (identifier_name))
+      (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name)))

--- a/corpus/interfaces.txt
+++ b/corpus/interfaces.txt
@@ -125,7 +125,7 @@ private interface IOne<T1> : ITwo { }
   (interface_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (base_list
       (identifier_name))
     (class_body)))
@@ -142,7 +142,7 @@ private interface IOne<T1> : ITwo where T1:T2 { }
   (interface_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (base_list (identifier_name))
      (type_parameter_constraints_clause
       (identifier_name)
@@ -162,8 +162,8 @@ private interface IOne<T1, T3> : ITwo where T1:T2 where T3:new() { }
     (modifier)
     (identifier_name)
     (type_parameter_list
-      (identifier_name)
-      (identifier_name))
+      (type_parameter (identifier_name))
+      (type_parameter (identifier_name)))
     (base_list (identifier_name))
      (type_parameter_constraints_clause
       (identifier_name)

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -133,7 +133,7 @@ class Z {
         (identifier_name)
         (equals_value_clause (character_literal (escape_sequence))))))
   (delegate_declaration (void_keyword) (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (parameter_list)
     (type_parameter_constraints_clause (identifier_name) (type_parameter_constraint)))
   (delegate_declaration (void_keyword) (identifier_name)

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -573,7 +573,9 @@ class A {
       (method_declaration (void_keyword) (identifier_name) (parameter_list)
       (block
         (local_function_statement (modifier) (void_keyword) (identifier_name)
-          (type_parameter_list (identifier_name) (identifier_name))
+          (type_parameter_list 
+            (type_parameter (identifier_name))
+            (type_parameter (identifier_name)))
           (parameter_list
             (parameter (identifier_name) (identifier_name))
             (parameter (identifier_name) (identifier_name)))
@@ -603,7 +605,9 @@ class A {
       (parameter_list)
       (block
         (local_function_statement (void_keyword) (identifier_name)
-          (type_parameter_list (identifier_name) (identifier_name))
+          (type_parameter_list
+            (type_parameter (identifier_name))
+            (type_parameter (identifier_name)))
           (parameter_list
             (parameter (identifier_name) (identifier_name))
             (parameter (identifier_name) (identifier_name)))

--- a/corpus/structs.txt
+++ b/corpus/structs.txt
@@ -10,7 +10,7 @@ public struct F<T> where T:struct {}
   (struct_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
     (class_body)))
@@ -27,7 +27,7 @@ public struct F<T> where T:class {}
   (struct_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
     (class_body)))
@@ -44,7 +44,7 @@ public struct F<T> where T: new() {}
   (struct_declaration
     (modifier)
     (identifier_name)
-    (type_parameter_list (identifier_name))
+    (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (constructor_constraint)))
@@ -78,8 +78,8 @@ private struct F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
     (modifier)
     (identifier_name)
      (type_parameter_list
-      (identifier_name)
-      (identifier_name))
+      (type_parameter (identifier_name))
+      (type_parameter (identifier_name)))
      (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name)))

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -64,7 +64,7 @@ class A {
       (method_declaration
         (void_keyword)
         (identifier_name)
-        (type_parameter_list (identifier_name))
+        (type_parameter_list (type_parameter (identifier_name)))
         (parameter_list
           (parameter (identifier_name) (identifier_name)))
         (block)))))
@@ -87,7 +87,7 @@ class A {
       (method_declaration
         (void_keyword)
         (identifier_name)
-        (type_parameter_list (identifier_name))
+        (type_parameter_list (type_parameter (identifier_name)))
         (parameter_list
           (parameter (identifier_name) (identifier_name)))
         (type_parameter_constraints_clause
@@ -116,8 +116,8 @@ class A {
         (void_keyword)
         (identifier_name)
         (type_parameter_list
-          (identifier_name)
-          (identifier_name))
+          (type_parameter (identifier_name))
+          (type_parameter (identifier_name)))
         (parameter_list
           (parameter (identifier_name) (identifier_name))
           (parameter (identifier_name) (identifier_name)))

--- a/grammar.js
+++ b/grammar.js
@@ -40,7 +40,7 @@ module.exports = grammar({
     [$.qualified_name, $.explicit_interface_specifier],
 
     [$._identifier_or_global, $.enum_member_declaration],
-    [$._identifier_or_global, $.type_parameter_list],
+    [$._identifier_or_global, $.type_parameter],
     [$._identifier_or_global, $.generic_name],
 
     [$._expression, $.parameter],
@@ -358,7 +358,13 @@ module.exports = grammar({
 
     explicit_interface_specifier: $ => prec(PREC.DOT, seq($._name, '.')),
 
-    type_parameter_list: $ => seq('<', commaSep1($.identifier_name), '>'),
+    type_parameter_list: $ => seq('<', commaSep1($.type_parameter), '>'),
+
+    type_parameter: $ => seq(
+      optional($.attribute_list),
+      optional(choice('in', 'out')),
+      $.identifier_name
+    ),
 
     type_parameter_constraints_clause: $ => seq(
       'where', $._identifier_or_global, ':', commaSep1($.type_parameter_constraint)

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -4,7 +4,6 @@ examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Serialization/SerializationEr
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Utilities/LateboundReflectionDelegateFactoryTests.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json/JsonReader.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json/Linq/IJEnumerable.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json/Linq/JContainer.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json/Linq/JToken.cs
 examples/nunit/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1535,7 +1535,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier_name"
+              "name": "type_parameter"
             },
             {
               "type": "REPEAT",
@@ -1548,7 +1548,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "identifier_name"
+                    "name": "type_parameter"
                   }
                 ]
               }
@@ -1558,6 +1558,48 @@
         {
           "type": "STRING",
           "value": ">"
+        }
+      ]
+    },
+    "type_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "in"
+                },
+                {
+                  "type": "STRING",
+                  "value": "out"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier_name"
         }
       ]
     },
@@ -7292,7 +7334,7 @@
     ],
     [
       "_identifier_or_global",
-      "type_parameter_list"
+      "type_parameter"
     ],
     [
       "_identifier_or_global",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -16321,6 +16321,25 @@
     }
   },
   {
+    "type": "type_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "identifier_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "type_parameter_constraint",
     "named": true,
     "fields": {},
@@ -16367,7 +16386,7 @@
       "required": true,
       "types": [
         {
-          "type": "identifier_name",
+          "type": "type_parameter",
           "named": true
         }
       ]


### PR DESCRIPTION
Add support for generic type parameter co-variance and contra-variance (`in` or `out` before the type identifier).

Only reduces known-failures by 1 file but also introduced `type_parameter` to capture `in` and `out` with the associated identifier.