### PR TITLE
Handle `{{` escaping in interpolated strings

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -242,11 +242,13 @@ class A {
 
 
 ==================================================
-interpolated string literals 
+interpolated string literals
 ==================================================
 
 class A {
   string s = $"hello";
+  string esc = $"ab\"\t";
+  string double = $"{{nope}}";
 }
 
 ---
@@ -261,6 +263,27 @@ class A {
           (identifier_name)
           (equals_value_clause
             (interpolated_string_expression
+              (interpolated_string_text))))))
+      (field_declaration
+        (variable_declaration
+          (predefined_type)
+          (variable_declarator
+            (identifier_name)
+            (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_string_text)
+              (interpolated_string_text
+                (escape_sequence))
+              (interpolated_string_text
+                (escape_sequence)))))))
+      (field_declaration
+        (variable_declaration
+          (predefined_type)
+          (variable_declarator
+            (identifier_name)
+            (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_string_text)
               (interpolated_string_text)))))))))
 
 ==================================================
@@ -337,7 +360,7 @@ class A {
               (interpolated_string_text)))))))))
 
 ==================================================
-interpolated verbatim string literals 
+interpolated verbatim string literals
 ==================================================
 
 class A {
@@ -381,7 +404,7 @@ class A {
               (interpolated_verbatim_string_text)
               (interpolation (identifier_name))
               (interpolated_verbatim_string_text)))))))))
-              
+
 ==================================================
 interpolated verbatim string literals with formatted expressions
 ==================================================
@@ -429,4 +452,4 @@ class A {
               (interpolated_verbatim_string_text)
               (interpolation (identifier_name)
                 (interpolation_alignment_clause (prefix_unary_expression (integer_literal))))
-              (interpolated_verbatim_string_text)))))))))              
+              (interpolated_verbatim_string_text)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1015,6 +1015,7 @@ module.exports = grammar({
     ),
 
     interpolated_string_text: $ => choice(
+      '{{',
       token.immediate(prec(1, /[^{"\\\n]+/)),
       $.escape_sequence
     ),

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,5 +1,4 @@
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1725.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerCollectionsTests.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Utilities/LateboundReflectionDelegateFactoryTests.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5098,6 +5098,10 @@
       "type": "CHOICE",
       "members": [
         {
+          "type": "STRING",
+          "value": "{{"
+        },
+        {
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "PREC",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -18583,6 +18583,10 @@
     "named": false
   },
   {
+    "type": "{{",
+    "named": false
+  },
+  {
     "type": "|",
     "named": false
   },


### PR DESCRIPTION
Interpolated strings did not recognize `{{` was an escape mechanism for `{`.

Reduces failure by 1 more file, now 99.5%.