### PR TITLE
Deal with the #if #else #elif situation

### DIFF
--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -1,30 +1,127 @@
 ===================================
-If, elif and else directives
+If and endif directives
 ===================================
 
-namespace foo {
-
+string a = 
 #if WIN32
-
-class win32 {}
-
-#elif MACOSX
-
-class macosx {}
-
+  "Win32"
 #endif
-
-}
+  ;
 
 ---
 
 (compilation_unit
-  (namespace_declaration (identifier_name)
-    (preprocessor_directive)
-    (class_declaration (identifier_name) (class_body))
-    (preprocessor_directive)
-    (class_declaration (identifier_name) (class_body))
-    (preprocessor_directive)))
+  (field_declaration
+    (variable_declaration
+     (predefined_type)
+     (variable_declarator
+      (identifier_name)
+      (equals_value_clause
+        (preprocessor_directive)
+        (string_literal))))
+  (preprocessor_directive)))
+
+===================================
+If and elif directives
+===================================
+
+string a = 
+#if WIN32
+  "Win32"
+#elif MACOS
+  "MacOS"
+#endif
+  ;
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+     (predefined_type)
+     (variable_declarator
+      (identifier_name)
+      (equals_value_clause
+        (preprocessor_directive)
+        (string_literal))))
+  (preprocessor_directive)))
+
+===================================
+If and else directives
+===================================
+
+string a = 
+#if WIN32
+  "Win32"
+#else
+  "Unknown"
+#endif
+  ;
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+     (predefined_type)
+     (variable_declarator
+      (identifier_name)
+      (equals_value_clause
+        (preprocessor_directive)
+        (string_literal))))
+  (preprocessor_directive)))
+
+===================================
+If, elif and else directives
+===================================
+
+string a = 
+#if WIN32
+  "Win32"
+#elif MACOS
+  "MacOS"
+#else
+  "Unknown"
+#endif
+  ;
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+     (predefined_type)
+     (variable_declarator
+      (identifier_name)
+      (equals_value_clause
+        (preprocessor_directive)
+        (string_literal))))
+  (preprocessor_directive)))
+
+===================================
+If and error directives
+===================================
+
+string a = 
+#if WIN32
+  "Win32"
+#else
+#error Compilation will now stop.
+#endif
+  ;
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+     (predefined_type)
+     (variable_declarator
+      (identifier_name)
+      (equals_value_clause
+        (preprocessor_directive)
+        (string_literal))))
+  (preprocessor_directive)))
 
 ===========================
 Region directives

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,8 +1,5 @@
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1725.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Utilities/LateboundReflectionDelegateFactoryTests.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json/JsonReader.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json/Linq/JToken.cs
+examples/nunit/src/CommonAssemblyInfo.cs
 examples/nunit/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs
-examples/nunit/src/NUnitFramework/tests/Internal/RuntimeFrameworkTests.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7173,7 +7173,7 @@
                     },
                     {
                       "type": "PATTERN",
-                      "value": "\\*[^/]"
+                      "value": "\\*[^\\/]"
                     }
                   ]
                 }
@@ -7231,19 +7231,11 @@
               },
               {
                 "type": "STRING",
-                "value": "else"
-              },
-              {
-                "type": "STRING",
-                "value": "elif"
+                "value": "define"
               },
               {
                 "type": "STRING",
                 "value": "endif"
-              },
-              {
-                "type": "STRING",
-                "value": "define"
               },
               {
                 "type": "STRING",
@@ -7280,6 +7272,53 @@
               {
                 "type": "STRING",
                 "value": "nullable"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "else"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "elif"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": ".*"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "PATTERN",
+                          "value": "[^#]"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "#[\\s\\u00A0]*(else|elif|define|undef|warning|error|line|region|endregion|pragma|nullable)"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "#[\\s\\u00A0]*endif"
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
A bunch of parsing breaks because people do things like this:

```csharp
string a = 
#if WIN32
  "Win32"
#elif MACOS
  "MacOS"
#endif
  ;
```

If we just discard pre-processor instructions we end up with an invalid syntax tree.

I thought if we can make `#else` and `#elif` consume up to and including the `#endif` then this problem goes away.

This PR does that reducing the number of parsing file failures by another 5.  It does however break nested `#if` statements so one file regresses.  This isn't ideal but losing one file from the test suite and gaining 5 seems worth it especially given those 5 are actual source files and the 1 regressing is an assemblyinfo.cs

This brings example file coverage to 99.7%