### PR TITLE
Optimize conflicts + minor tweaks

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -125,6 +125,23 @@ public class F<T> where T:struct {}
     (class_body)))
 
 =====================================
+Class with a type parameter unmanaged constraint
+=====================================
+
+public class F<T> where T:unmanaged {}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    (identifier_name)
+    (type_parameter_list (type_parameter (identifier_name)))
+    (type_parameter_constraints_clause
+      (identifier_name) (type_parameter_constraint))
+    (class_body)))
+
+=====================================
 Class with a type parameter class constraint
 =====================================
 

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -4,8 +4,10 @@ integer literals
 
 const int dec = 1_2;
 const long hex = 0xf_1l;
+const long hex2 = 0Xffff;
 const UInt64 dec = 1uL;
 const UInt16 bin = 0b0100_100;
+const UInt16 bin2 = 0B01010__10;
 ---
 
 (compilation_unit
@@ -18,6 +20,16 @@ const UInt16 bin = 0b0100_100;
     (modifier)
     (variable_declaration
       (predefined_type)
+      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+  (field_declaration
+    (modifier)
+    (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+  (field_declaration
+    (modifier)
+    (variable_declaration
+      (identifier_name)
       (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -153,6 +153,28 @@ class A {
         (block)))))
 
 =======================================
+Class method with in parameter
+=======================================
+
+class A {
+  void HasAnOut(in int a) {
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier_name)
+    (class_body
+      (method_declaration
+        (void_keyword)
+        (identifier_name)
+        (parameter_list
+          (parameter (parameter_modifier) (predefined_type) (identifier_name)))
+        (block)))))
+
+=======================================
 Class method with ref parameter
 =======================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -281,7 +281,7 @@ module.exports = grammar({
       optional($.equals_value_clause)
     ),
 
-    parameter_modifier: $ => prec.right(choice('ref', 'out', 'this')),
+    parameter_modifier: $ => prec.right(choice('ref', 'out', 'this', 'in')),
 
     parameter_array: $ => seq(
       repeat($.attribute_list),
@@ -357,14 +357,11 @@ module.exports = grammar({
     ),
 
     type_parameter_constraint: $ => choice(
-      $._class_or_struct_constraint,
+      'class',
+      'struct',
+      'unmanaged',
       $.constructor_constraint,
       $.type_constraint
-    ),
-
-    _class_or_struct_constraint: $ => choice(
-      'class',
-      'struct'
     ),
 
     constructor_constraint: $ => seq('new', '(', ')'),

--- a/grammar.js
+++ b/grammar.js
@@ -1330,8 +1330,8 @@ module.exports = grammar({
     integer_literal: $ => seq(
       choice(
         (/[0-9_]+/), // Decimal
-        (/0x[0-9a-fA-F_]+/), // Hex
-        (/0b[01_]+/) // Binary
+        (/0[xX][0-9a-fA-F_]+/), // Hex
+        (/0[bB][01_]+/) // Binary
       ),
       optional($._integer_type_suffix)
     ),

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,5 +1,3 @@
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Issues/Issue1725.cs
-examples/Newtonsoft.Json/Src/Newtonsoft.Json.Tests/Utilities/LateboundReflectionDelegateFactoryTests.cs
 examples/Newtonsoft.Json/Src/Newtonsoft.Json/Linq/JToken.cs
 examples/nunit/src/CommonAssemblyInfo.cs
 examples/nunit/src/NUnitFramework/tests/Assertions/CollectionAssertTest.cs

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1180,6 +1180,10 @@
           {
             "type": "STRING",
             "value": "this"
+          },
+          {
+            "type": "STRING",
+            "value": "in"
           }
         ]
       }
@@ -1636,8 +1640,16 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_class_or_struct_constraint"
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "STRING",
+          "value": "struct"
+        },
+        {
+          "type": "STRING",
+          "value": "unmanaged"
         },
         {
           "type": "SYMBOL",
@@ -1646,19 +1658,6 @@
         {
           "type": "SYMBOL",
           "name": "type_constraint"
-        }
-      ]
-    },
-    "_class_or_struct_constraint": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "class"
-        },
-        {
-          "type": "STRING",
-          "value": "struct"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6898,11 +6898,11 @@
             },
             {
               "type": "PATTERN",
-              "value": "0x[0-9a-fA-F_]+"
+              "value": "0[xX][0-9a-fA-F_]+"
             },
             {
               "type": "PATTERN",
-              "value": "0b[01_]+"
+              "value": "0[bB][01_]+"
             }
           ]
         },
@@ -7356,7 +7356,9 @@
     ]
   ],
   "externals": [],
-  "inline": [],
+  "inline": [
+    "return_type"
+  ],
   "supertypes": []
 }
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9,7 +9,75 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "_declaration"
+            "name": "global_attribute_list"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "class_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "constructor_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "conversion_operator_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "delegate_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "destructor_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "enum_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "event_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "extern_alias_directive"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_base_field_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "indexer_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interface_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "method_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "namespace_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "operator_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "property_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "struct_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "using_directive"
           }
         ]
       }
@@ -32,87 +100,6 @@
         {
           "type": "STRING",
           "value": ";"
-        }
-      ]
-    },
-    "_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "global_attribute_list"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "class_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "delegate_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "destructor_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "enum_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "event_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "extern_alias_directive"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_base_field_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "indexer_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interface_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "method_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "namespace_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "conversion_operator_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "constructor_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "destructor_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "property_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "struct_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "using_directive"
         }
       ]
     },
@@ -4977,10 +4964,6 @@
         }
       ]
     },
-    "implicit_element_access": {
-      "type": "SYMBOL",
-      "name": "bracketed_argument_list"
-    },
     "implicit_stack_alloc_array_creation_expression": {
       "type": "SEQ",
       "members": [
@@ -7173,7 +7156,7 @@
                     },
                     {
                       "type": "PATTERN",
-                      "value": "\\*[^/]"
+                      "value": "\\*[^\\/]"
                     }
                   ]
                 }
@@ -7307,8 +7290,20 @@
   ],
   "conflicts": [
     [
+      "block",
+      "initializer_expression"
+    ],
+    [
+      "element_access_expression",
+      "enum_member_declaration"
+    ],
+    [
+      "event_declaration",
+      "variable_declarator"
+    ],
+    [
       "_expression",
-      "generic_name"
+      "declaration_pattern"
     ],
     [
       "_expression",
@@ -7329,10 +7324,6 @@
       "_reserved_identifier"
     ],
     [
-      "qualified_name",
-      "explicit_interface_specifier"
-    ],
-    [
       "_identifier_or_global",
       "enum_member_declaration"
     ],
@@ -7345,30 +7336,8 @@
       "generic_name"
     ],
     [
-      "_expression",
-      "parameter"
-    ],
-    [
-      "_expression",
-      "attribute"
-    ],
-    [
-      "_expression",
-      "parameter",
-      "_identifier_or_global"
-    ],
-    [
-      "_expression",
-      "declaration_pattern"
-    ],
-    [
-      "argument",
-      "parameter_modifier"
-    ],
-    [
-      "modifier",
-      "array_creation_expression",
-      "object_creation_expression"
+      "qualified_name",
+      "explicit_interface_specifier"
     ],
     [
       "_type",
@@ -7383,33 +7352,11 @@
       "attribute"
     ],
     [
-      "element_access_expression",
-      "enum_member_declaration"
-    ],
-    [
-      "block",
-      "initializer_expression"
-    ],
-    [
-      "modifier",
-      "object_creation_expression"
-    ],
-    [
-      "event_declaration",
-      "variable_declarator"
-    ],
-    [
-      "is_pattern_expression",
-      "binary_expression"
-    ],
-    [
       "switch_section"
     ]
   ],
   "externals": [],
-  "inline": [
-    "return_type"
-  ],
+  "inline": [],
   "supertypes": []
 }
 

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -18531,6 +18531,10 @@
     "named": false
   },
   {
+    "type": "unmanaged",
+    "named": false
+  },
+  {
     "type": "unsafe",
     "named": false
   },


### PR DESCRIPTION
- Reduces the number of conflict rules - some were now redundant
- Adds support for `in` parameters
- Adds support for `unmanaged` generic type constraints
- Allows binary literals to use `B`
- Allows hex literals to use `X`

Reduces known-failures by 2 so there are now only 3 files left.  99.8% coverage.