### PR TITLE
Simplify the grammar with the goal of shrinking the parser

### DIFF
--- a/corpus/attributes.txt
+++ b/corpus/attributes.txt
@@ -31,7 +31,7 @@ class D {}
         (attribute_argument_list
           (attribute_argument (member_access_expression (identifier_name) (identifier_name))))))
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =======================================
 Attributes with qualified name
@@ -50,7 +50,7 @@ class D {}
         (attribute_argument_list
           (attribute_argument (member_access_expression (identifier_name) (identifier_name))))))
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =======================================
 Attributes on classes
@@ -73,20 +73,20 @@ class A { }
   (class_declaration
     (attribute_list (attribute (identifier_name)))
     (identifier_name)
-    (class_body))
+    (declaration_list))
 
   (class_declaration
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)))
     (identifier_name)
-    (class_body))
+    (declaration_list))
 
   (class_declaration
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =======================================
 Attributes on structs
@@ -102,7 +102,7 @@ struct A { }
     (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
     (attribute_list (attribute (identifier_name)))
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =======================================
 Attributes on fields
@@ -118,7 +118,7 @@ class Zzz {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (attribute_list
           (attribute (identifier_name))
@@ -148,7 +148,7 @@ class Methods {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (attribute_list
           (attribute (identifier_name)))
@@ -194,23 +194,26 @@ enum A { B, C }
   (enum_declaration
     (attribute_list (attribute (identifier_name)))
     (identifier_name)
-    (enum_member_declaration (identifier_name))
-    (enum_member_declaration (identifier_name)))
+    (enum_member_declaration_list
+      (enum_member_declaration (identifier_name))
+      (enum_member_declaration (identifier_name))))
 
   (enum_declaration
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)))
     (identifier_name)
-    (enum_member_declaration (identifier_name))
-    (enum_member_declaration (identifier_name)))
+    (enum_member_declaration_list
+      (enum_member_declaration (identifier_name))
+      (enum_member_declaration (identifier_name))))
 
   (enum_declaration
     (attribute_list (attribute (identifier_name)))
     (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
     (identifier_name)
-    (enum_member_declaration (identifier_name))
-    (enum_member_declaration (identifier_name))))
+    (enum_member_declaration_list
+      (enum_member_declaration (identifier_name))
+      (enum_member_declaration (identifier_name)))))
 
 =======================================
 Attributes on events
@@ -226,7 +229,7 @@ class Zzz {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (event_declaration
         (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
         (attribute_list (attribute (identifier_name)))
@@ -252,7 +255,7 @@ class Zzz {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (event_declaration
         (modifier)
         (identifier_name)

--- a/corpus/attributes.txt
+++ b/corpus/attributes.txt
@@ -8,10 +8,10 @@ Global attributes
 ---
 
 (compilation_unit
-  (global_attribute_list (attribute (identifier_name)))
+  (global_attribute_list (attribute (identifier)))
   (global_attribute_list
-    (attribute (identifier_name))
-    (attribute (identifier_name) (attribute_argument_list))))
+    (attribute (identifier))
+    (attribute (identifier) (attribute_argument_list))))
 
 
 =======================================
@@ -27,10 +27,10 @@ class D {}
   (class_declaration
     (attribute_list
       (attribute
-        (identifier_name)
+        (identifier)
         (attribute_argument_list
-          (attribute_argument (member_access_expression (identifier_name) (identifier_name))))))
-    (identifier_name)
+          (attribute_argument (member_access_expression (identifier) (identifier))))))
+    (identifier)
     (declaration_list)))
 
 =======================================
@@ -46,10 +46,10 @@ class D {}
   (class_declaration
     (attribute_list
       (attribute
-        (qualified_name (identifier_name) (identifier_name))
+        (qualified_name (identifier) (identifier))
         (attribute_argument_list
-          (attribute_argument (member_access_expression (identifier_name) (identifier_name))))))
-    (identifier_name)
+          (attribute_argument (member_access_expression (identifier) (identifier))))))
+    (identifier)
     (declaration_list)))
 
 =======================================
@@ -71,21 +71,21 @@ class A { }
 
 (compilation_unit
   (class_declaration
-    (attribute_list (attribute (identifier_name)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (identifier)
     (declaration_list))
 
   (class_declaration
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)))
+    (identifier)
     (declaration_list))
 
   (class_declaration
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+    (identifier)
     (declaration_list)))
 
 =======================================
@@ -99,9 +99,9 @@ struct A { }
 
 (compilation_unit
   (struct_declaration
-    (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-    (attribute_list (attribute (identifier_name)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+    (attribute_list (attribute (identifier)))
+    (identifier)
     (declaration_list)))
 
 =======================================
@@ -117,16 +117,16 @@ class Zzz {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (attribute_list
-          (attribute (identifier_name))
-          (attribute (identifier_name) (attribute_argument_list)))
+          (attribute (identifier))
+          (attribute (identifier) (attribute_argument_list)))
         (attribute_list
-          (attribute (identifier_name)))
+          (attribute (identifier)))
         (modifier)
-        (variable_declaration (predefined_type) (variable_declarator (identifier_name)))))))
+        (variable_declaration (predefined_type) (variable_declarator (identifier)))))))
 
 =======================================
 Attributes on methods
@@ -147,29 +147,29 @@ class Methods {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (attribute_list
-          (attribute (identifier_name)))
+          (attribute (identifier)))
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block (return_statement (integer_literal))))
       (method_declaration
         (attribute_list
           (attribute_target_specifier)
-          (attribute (identifier_name)))
+          (attribute (identifier)))
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block (return_statement (integer_literal))))
       (method_declaration
         (attribute_list
           (attribute_target_specifier)
-          (attribute (identifier_name)))
+          (attribute (identifier)))
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block (return_statement (integer_literal)))))))
 
@@ -192,28 +192,28 @@ enum A { B, C }
 
 (compilation_unit
   (enum_declaration
-    (attribute_list (attribute (identifier_name)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (identifier)
     (enum_member_declaration_list
-      (enum_member_declaration (identifier_name))
-      (enum_member_declaration (identifier_name))))
+      (enum_member_declaration (identifier))
+      (enum_member_declaration (identifier))))
 
   (enum_declaration
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)))
+    (identifier)
     (enum_member_declaration_list
-      (enum_member_declaration (identifier_name))
-      (enum_member_declaration (identifier_name))))
+      (enum_member_declaration (identifier))
+      (enum_member_declaration (identifier))))
 
   (enum_declaration
-    (attribute_list (attribute (identifier_name)))
-    (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-    (identifier_name)
+    (attribute_list (attribute (identifier)))
+    (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+    (identifier)
     (enum_member_declaration_list
-      (enum_member_declaration (identifier_name))
-      (enum_member_declaration (identifier_name)))))
+      (enum_member_declaration (identifier))
+      (enum_member_declaration (identifier)))))
 
 =======================================
 Attributes on events
@@ -228,14 +228,14 @@ class Zzz {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (event_declaration
-        (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-        (attribute_list (attribute (identifier_name)))
+        (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+        (attribute_list (attribute (identifier)))
         (modifier)
-        (identifier_name)
-        (identifier_name)
+        (identifier)
+        (identifier)
         (accessor_declaration (block))
         (accessor_declaration (block))))))
 
@@ -254,17 +254,17 @@ class Zzz {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (event_declaration
         (modifier)
-        (identifier_name)
-        (identifier_name)
+        (identifier)
+        (identifier)
         (accessor_declaration
-          (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-          (attribute_list (attribute (identifier_name)))
+          (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+          (attribute_list (attribute (identifier)))
           (block))
         (accessor_declaration
-          (attribute_list (attribute (identifier_name)) (attribute (identifier_name) (attribute_argument_list)))
-          (attribute_list (attribute (identifier_name)))
+          (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
+          (attribute_list (attribute (identifier)))
           (block))))))

--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -9,7 +9,7 @@ public class F {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (declaration_list)))
 
 =====================================
@@ -23,8 +23,8 @@ public class F : dynamic { }
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (base_list (identifier_name))
+    (identifier)
+    (base_list (identifier))
     (declaration_list)))
 
 =====================================
@@ -38,11 +38,11 @@ public class F : object, IAlpha, IOmega { }
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (base_list
       (predefined_type)
-      (identifier_name)
-      (identifier_name))
+      (identifier)
+      (identifier))
     (declaration_list)))
 
 =====================================
@@ -56,7 +56,7 @@ public partial class F {}
 (compilation_unit
  (class_declaration
    (modifier) (modifier)
-   (identifier_name)
+   (identifier)
    (declaration_list)))
 
 =====================================
@@ -69,8 +69,8 @@ class F<T> {}
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
-     (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+     (type_parameter_list (type_parameter (identifier)))
      (declaration_list)))
 
 =====================================
@@ -84,10 +84,10 @@ internal class F<T1, T2> {}
 (compilation_unit
  (class_declaration
    (modifier)
-   (identifier_name)
+   (identifier)
     (type_parameter_list
-      (type_parameter (identifier_name))
-      (type_parameter (identifier_name)))
+      (type_parameter (identifier))
+      (type_parameter (identifier)))
     (declaration_list)))
 
 =====================================
@@ -101,10 +101,10 @@ internal class F<in T1, out T2> {}
 (compilation_unit
  (class_declaration
    (modifier)
-   (identifier_name)
+   (identifier)
     (type_parameter_list
-      (type_parameter (identifier_name))
-      (type_parameter (identifier_name)))
+      (type_parameter (identifier))
+      (type_parameter (identifier)))
     (declaration_list)))
 
 =====================================
@@ -118,10 +118,10 @@ public class F<T> where T:struct {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name) (type_parameter_constraint))
+      (identifier) (type_parameter_constraint))
     (declaration_list)))
 
 =====================================
@@ -135,10 +135,10 @@ public class F<T> where T:unmanaged {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name) (type_parameter_constraint))
+      (identifier) (type_parameter_constraint))
     (declaration_list)))
 
 =====================================
@@ -152,10 +152,10 @@ public class F<T> where T:class {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name) (type_parameter_constraint))
+      (identifier) (type_parameter_constraint))
     (declaration_list)))
 
 =====================================
@@ -169,10 +169,10 @@ public class F<T> where T: new() {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name)
+      (identifier)
       (type_parameter_constraint (constructor_constraint)))
     (declaration_list)))
 
@@ -187,11 +187,11 @@ public class F<T> where T: I {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name)
-      (type_parameter_constraint (type_constraint (identifier_name))))
+      (identifier)
+      (type_parameter_constraint (type_constraint (identifier))))
     (declaration_list)))
 
 =====================================
@@ -205,12 +205,12 @@ public class F<T> where T: I, new() {}
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name)
+      (identifier)
       (type_parameter_constraint
-        (type_constraint (identifier_name)))
+        (type_constraint (identifier)))
       (type_parameter_constraint (constructor_constraint)))
     (declaration_list)))
 
@@ -225,18 +225,18 @@ private class F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
 (compilation_unit
   (class_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (type_parameter_list
-      (type_parameter (identifier_name))
-      (type_parameter (identifier_name)))
+      (type_parameter (identifier))
+      (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name)
-      (type_parameter_constraint (type_constraint (identifier_name)))
-      (type_parameter_constraint (type_constraint (identifier_name)))
+      (identifier)
+      (type_parameter_constraint (type_constraint (identifier)))
+      (type_parameter_constraint (type_constraint (identifier)))
       (type_parameter_constraint (constructor_constraint)))
     (type_parameter_constraints_clause
-      (identifier_name)
-      (type_parameter_constraint (type_constraint (identifier_name))))
+      (identifier)
+      (type_parameter_constraint (type_constraint (identifier))))
     (declaration_list)))
 
 =====================================
@@ -251,11 +251,11 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (constructor_declaration
         (modifier)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block)))))
 
@@ -271,14 +271,14 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (constructor_declaration
         (modifier)
-        (identifier_name)
-        (parameter_list (parameter (predefined_type) (identifier_name)))
+        (identifier)
+        (parameter_list (parameter (predefined_type) (identifier)))
         (arrow_expression_clause
-          (assignment_expression (identifier_name) (assignment_operator) (identifier_name)))))))
+          (assignment_expression (identifier) (assignment_operator) (identifier)))))))
 
 =====================================
 Class with static constructor
@@ -294,21 +294,21 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (constructor_declaration
         (modifier)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block))
       (constructor_declaration
         (modifier) (modifier)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block))
       (constructor_declaration
         (modifier) (modifier)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block)))))
 
@@ -324,10 +324,10 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (destructor_declaration
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block)))))
 
@@ -343,14 +343,14 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (destructor_declaration
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (arrow_expression_clause
           (invocation_expression
-            (identifier_name)
+            (identifier)
             (argument_list)))))))
 
 =====================================
@@ -366,14 +366,14 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
           (predefined_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (integer_literal)))))
       (field_declaration
@@ -381,7 +381,7 @@ class Foo {
         (variable_declaration
           (predefined_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (string_literal))))))))
 
@@ -400,16 +400,16 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
-        (bracketed_parameter_list (parameter (predefined_type) (identifier_name)))
+        (bracketed_parameter_list (parameter (predefined_type) (identifier)))
         (accessor_declaration
-          (block (return_statement (identifier_name))))
+          (block (return_statement (identifier))))
         (accessor_declaration
-          (block (expression_statement (assignment_expression (identifier_name) (assignment_operator) (identifier_name)))))))))
+          (block (expression_statement (assignment_expression (identifier) (assignment_operator) (identifier)))))))))
 
 =====================================
 Class with expression bodied indexer
@@ -423,15 +423,15 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
-        (bracketed_parameter_list (parameter (predefined_type) (identifier_name)))
+        (bracketed_parameter_list (parameter (predefined_type) (identifier)))
         (arrow_expression_clause
-          (element_access_expression (identifier_name)
-            (bracketed_argument_list (argument (identifier_name)))))))))
+          (element_access_expression (identifier)
+            (bracketed_argument_list (argument (identifier)))))))))
 
 =====================================
 Class with expression bodied indexer accessors
@@ -449,22 +449,22 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
-        (bracketed_parameter_list (parameter (predefined_type) (identifier_name)))
+        (bracketed_parameter_list (parameter (predefined_type) (identifier)))
         (accessor_declaration
           (arrow_expression_clause
-            (element_access_expression (identifier_name)
-              (bracketed_argument_list (argument (identifier_name))))))
+            (element_access_expression (identifier)
+              (bracketed_argument_list (argument (identifier))))))
         (accessor_declaration
           (arrow_expression_clause
             (assignment_expression 
-              (element_access_expression (identifier_name)
-                (bracketed_argument_list (argument (identifier_name))))
-                (assignment_operator) (identifier_name))))))))
+              (element_access_expression (identifier)
+                (bracketed_argument_list (argument (identifier))))
+                (assignment_operator) (identifier))))))))
 
 =================================
 Method with qualified return type
@@ -479,11 +479,11 @@ class A {
 ---
 
 (compilation_unit
-  (class_declaration (identifier_name)
+  (class_declaration (identifier)
     (declaration_list
       (method_declaration
-        (qualified_name (identifier_name) (identifier_name))
-        (identifier_name)
+        (qualified_name (identifier) (identifier))
+        (identifier)
         (parameter_list)
         (block
           (return_statement (null_literal)))))))

--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -10,7 +10,7 @@ public class F {}
   (class_declaration
     (modifier)
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class base is dynamic
@@ -25,7 +25,7 @@ public class F : dynamic { }
     (modifier)
     (identifier_name)
     (base_list (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class base is object with interfaces
@@ -43,7 +43,7 @@ public class F : object, IAlpha, IOmega { }
       (predefined_type)
       (identifier_name)
       (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Partial class
@@ -57,7 +57,7 @@ public partial class F {}
  (class_declaration
    (modifier) (modifier)
    (identifier_name)
-   (class_body)))
+   (declaration_list)))
 
 =====================================
 Class with a single type parameter
@@ -71,7 +71,7 @@ class F<T> {}
   (class_declaration
     (identifier_name)
      (type_parameter_list (type_parameter (identifier_name)))
-     (class_body)))
+     (declaration_list)))
 
 =====================================
 Class with multiple type parameters
@@ -88,7 +88,7 @@ internal class F<T1, T2> {}
     (type_parameter_list
       (type_parameter (identifier_name))
       (type_parameter (identifier_name)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with co-variant and contra-variant type parameters
@@ -105,7 +105,7 @@ internal class F<in T1, out T2> {}
     (type_parameter_list
       (type_parameter (identifier_name))
       (type_parameter (identifier_name)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with a type parameter struct constraint
@@ -122,7 +122,7 @@ public class F<T> where T:struct {}
     (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with a type parameter unmanaged constraint
@@ -139,7 +139,7 @@ public class F<T> where T:unmanaged {}
     (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with a type parameter class constraint
@@ -156,7 +156,7 @@ public class F<T> where T:class {}
     (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with type parameter new constraint
@@ -174,7 +174,7 @@ public class F<T> where T: new() {}
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (constructor_constraint)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with type parameter identifier constraint
@@ -192,7 +192,7 @@ public class F<T> where T: I {}
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name))))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with type parameter identifier and new constraints
@@ -212,7 +212,7 @@ public class F<T> where T: I, new() {}
       (type_parameter_constraint
         (type_constraint (identifier_name)))
       (type_parameter_constraint (constructor_constraint)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with multiple type parameter constraints
@@ -237,7 +237,7 @@ private class F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name))))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Class with public constructor
@@ -252,7 +252,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (constructor_declaration
         (modifier)
         (identifier_name)
@@ -272,7 +272,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (constructor_declaration
         (modifier)
         (identifier_name)
@@ -295,7 +295,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (constructor_declaration
         (modifier)
         (identifier_name)
@@ -325,7 +325,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (destructor_declaration
         (identifier_name)
         (parameter_list)
@@ -344,7 +344,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (destructor_declaration
         (identifier_name)
         (parameter_list)
@@ -367,7 +367,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
@@ -401,7 +401,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
@@ -424,7 +424,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
@@ -450,7 +450,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (indexer_declaration
         (modifier)
         (predefined_type)
@@ -480,7 +480,7 @@ class A {
 
 (compilation_unit
   (class_declaration (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (qualified_name (identifier_name) (identifier_name))
         (identifier_name)

--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -11,8 +11,8 @@ var a = Assert.Range(from, to);
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (invocation_expression
-            (member_access_expression (identifier_name) (identifier_name))
-            (argument_list (argument (identifier_name)) (argument (identifier_name))))))))) 
+            (member_access_expression (identifier) (identifier))
+            (argument_list (argument (identifier)) (argument (identifier))))))))) 

--- a/corpus/enums.txt
+++ b/corpus/enums.txt
@@ -8,9 +8,9 @@ enum A { One }
 
 (compilation_unit
   (enum_declaration
-    (identifier_name)
+    (identifier)
     (enum_member_declaration_list
-      (enum_member_declaration (identifier_name)))))
+      (enum_member_declaration (identifier)))))
 
 =======================================
 enum with integer values
@@ -22,10 +22,10 @@ enum B { Ten = 10, Twenty = 20 }
 
 (compilation_unit
   (enum_declaration
-    (identifier_name)
+    (identifier)
     (enum_member_declaration_list
-      (enum_member_declaration (identifier_name) (integer_literal))
-      (enum_member_declaration (identifier_name) (integer_literal)))))
+      (enum_member_declaration (identifier) (integer_literal))
+      (enum_member_declaration (identifier) (integer_literal)))))
 
 =======================================
 enum with byte base
@@ -39,11 +39,11 @@ namespace A {
 
 (compilation_unit
   (namespace_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (enum_declaration
-        (identifier_name)
+        (identifier)
         (base_list (predefined_type))
         (enum_member_declaration_list
-          (enum_member_declaration (identifier_name) (integer_literal))
-          (enum_member_declaration (identifier_name) (integer_literal)))))))
+          (enum_member_declaration (identifier) (integer_literal))
+          (enum_member_declaration (identifier) (integer_literal)))))))

--- a/corpus/enums.txt
+++ b/corpus/enums.txt
@@ -9,7 +9,8 @@ enum A { One }
 (compilation_unit
   (enum_declaration
     (identifier_name)
-    (enum_member_declaration (identifier_name))))
+    (enum_member_declaration_list
+      (enum_member_declaration (identifier_name)))))
 
 =======================================
 enum with integer values
@@ -22,8 +23,9 @@ enum B { Ten = 10, Twenty = 20 }
 (compilation_unit
   (enum_declaration
     (identifier_name)
-    (enum_member_declaration (identifier_name) (integer_literal))
-    (enum_member_declaration (identifier_name) (integer_literal))))
+    (enum_member_declaration_list
+      (enum_member_declaration (identifier_name) (integer_literal))
+      (enum_member_declaration (identifier_name) (integer_literal)))))
 
 =======================================
 enum with byte base
@@ -38,8 +40,10 @@ namespace A {
 (compilation_unit
   (namespace_declaration
     (identifier_name)
-    (enum_declaration
-      (identifier_name)
-      (base_list (predefined_type))
-      (enum_member_declaration (identifier_name) (integer_literal))
-      (enum_member_declaration (identifier_name) (integer_literal)))))
+    (declaration_list
+      (enum_declaration
+        (identifier_name)
+        (base_list (predefined_type))
+        (enum_member_declaration_list
+          (enum_member_declaration (identifier_name) (integer_literal))
+          (enum_member_declaration (identifier_name) (integer_literal)))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -13,7 +13,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -41,7 +41,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -72,7 +72,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -790,7 +790,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -815,7 +815,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -845,7 +845,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -891,7 +891,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -943,7 +943,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -981,7 +981,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1206,8 +1206,7 @@ var c = s is "test";
             (identifier_name)
             (declaration_pattern
               (predefined_type)
-              (single_variable_designation
-                (identifier_name))))))))
+              (identifier_name)))))))
   (field_declaration
     (variable_declaration
       (implicit_type)

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -772,7 +772,7 @@ void b() {
                   (constant_pattern (integer_literal))
                   (string_literal))
                 (switch_expression_arm
-                  (discard_pattern)
+                  (discard)
                   (string_literal))))))))))
 
 =====================================

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -12,16 +12,16 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
         (expression_statement
           (conditional_expression
-            (identifier_name)
+            (identifier)
             (string_literal)
             (string_literal))))))))
 
@@ -40,17 +40,17 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
         (expression_statement
           (binary_expression
-            (identifier_name)
-            (identifier_name)))
+            (identifier)
+            (identifier)))
         (expression_statement
           (binary_expression
             (integer_literal)
@@ -71,19 +71,19 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
         (expression_statement
           (prefix_unary_expression
-            (identifier_name)))
+            (identifier)))
         (expression_statement
           (prefix_unary_expression
-            (identifier_name))))))))
+            (identifier))))))))
 
 =====================================
 Cast expressions
@@ -98,15 +98,15 @@ void Test() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement (assignment_expression
-        (identifier_name)
+        (identifier)
         (assignment_operator)
         (binary_expression
-          (cast_expression (identifier_name) (identifier_name))
-          (cast_expression (identifier_name) (identifier_name))))))))
+          (cast_expression (identifier) (identifier))
+          (cast_expression (identifier) (identifier))))))))
 
 ============================
 Anonymous object creation with empty body
@@ -122,14 +122,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-          (identifier_name)
+          (identifier)
             (equals_value_clause
               (anonymous_object_creation_expression))))))))
 
@@ -148,16 +148,16 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-          (identifier_name)
+          (identifier)
             (equals_value_clause
-              (anonymous_object_creation_expression (identifier_name)))))))))
+              (anonymous_object_creation_expression (identifier)))))))))
 
 ============================
 Anonymous object creation with single named
@@ -174,18 +174,18 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-          (identifier_name)
+          (identifier)
             (equals_value_clause
               (anonymous_object_creation_expression
                 (name_equals
-                  (identifier_name))
+                  (identifier))
                 (string_literal)))))))))
 
 ============================
@@ -201,14 +201,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (checked_expression
                 (binary_expression
@@ -236,37 +236,37 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement
         (object_creation_expression
-          (qualified_name (identifier_name) (identifier_name))
+          (qualified_name (identifier) (identifier))
           (argument_list
             (argument (integer_literal))
             (argument (string_literal)))))
       (expression_statement
         (assignment_expression
-          (identifier_name)
+          (identifier)
           (assignment_operator)
           (object_creation_expression
-            (identifier_name)
+            (identifier)
             (initializer_expression
               (assignment_expression
-                (identifier_name) (assignment_operator) (identifier_name))))))
+                (identifier) (assignment_operator) (identifier))))))
       (expression_statement
         (assignment_expression
-          (identifier_name)
+          (identifier)
           (assignment_operator)
           (object_creation_expression
-            (identifier_name)
+            (identifier)
             (argument_list (argument (integer_literal))))))
       (expression_statement
         (assignment_expression
-          (identifier_name)
+          (identifier)
           (assignment_operator)
           (object_creation_expression
-            (identifier_name)
+            (identifier)
             (argument_list (argument (integer_literal)))
             (initializer_expression)))))))
 
@@ -285,14 +285,14 @@ void a() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement
         (anonymous_method_expression
-          (parameter_list (parameter (predefined_type) (identifier_name)))
+          (parameter_list (parameter (predefined_type) (identifier)))
           (block
-            (return_statement (identifier_name))))))))
+            (return_statement (identifier))))))))
 
 ============================
 Lambda expressions
@@ -308,22 +308,22 @@ void a() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement
         (lambda_expression
-          (identifier_name)
-          (binary_expression (identifier_name) (integer_literal))))
+          (identifier)
+          (binary_expression (identifier) (integer_literal))))
       (expression_statement
         (lambda_expression
           (parameter_list
-            (parameter (identifier_name) (identifier_name))
-            (parameter (identifier_name) (identifier_name)))
+            (parameter (identifier) (identifier))
+            (parameter (identifier) (identifier)))
           (block (return_statement
             (invocation_expression
-              (member_access_expression (identifier_name) (identifier_name))
-              (argument_list (argument (identifier_name)))))))))))
+              (member_access_expression (identifier) (identifier))
+              (argument_list (argument (identifier)))))))))))
 
 ============================
 Invocation expressions
@@ -337,18 +337,18 @@ void a() {
 
 (compilation_unit (method_declaration
   (void_keyword)
-  (identifier_name)
+  (identifier)
   (parameter_list)
   (block
     (expression_statement
       (invocation_expression
-        (identifier_name)
+        (identifier)
         (argument_list
-          (argument (identifier_name))
-          (argument (identifier_name))
-          (argument (identifier_name))
-          (argument (identifier_name))
-          (argument (implicit_type) (identifier_name))))))))
+          (argument (identifier))
+          (argument (identifier))
+          (argument (identifier))
+          (argument (identifier))
+          (argument (implicit_type) (identifier))))))))
 
 ============================
 Tuple expressions
@@ -363,16 +363,16 @@ void a() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement (assignment_expression
-        (identifier_name)
+        (identifier)
         (assignment_operator)
         (tuple_expression
-          (argument (identifier_name))
+          (argument (identifier))
           (argument
-            (name_colon (identifier_name))
+            (name_colon (identifier))
             (string_literal))))))))
 
 ============================
@@ -388,14 +388,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (implicit_array_creation_expression
                 (initializer_expression
@@ -416,14 +416,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (implicit_array_creation_expression
                 (initializer_expression
@@ -450,14 +450,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (implicit_stack_alloc_array_creation_expression
                 (initializer_expression
@@ -478,14 +478,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (stack_alloc_array_creation_expression
                 (array_type (predefined_type) (array_rank_specifier))
@@ -508,14 +508,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (array_creation_expression
                 (array_type
@@ -529,7 +529,7 @@ void b() {
           (variable_declaration
             (implicit_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
                 (array_creation_expression
                   (array_type
@@ -556,14 +556,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (array_creation_expression
                 (array_type
@@ -595,17 +595,17 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (make_ref_expression
-                (identifier_name)))))))))
+                (identifier)))))))))
 
 ============================
 Postfix unary
@@ -622,19 +622,19 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
-      (expression_statement (postfix_unary_expression (identifier_name)))
-      (expression_statement (postfix_unary_expression (identifier_name)))
+      (expression_statement (postfix_unary_expression (identifier)))
+      (expression_statement (postfix_unary_expression (identifier)))
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (postfix_unary_expression
-                (identifier_name)))))))))
+                (identifier)))))))))
 
 ============================
 __reftype
@@ -649,17 +649,17 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (ref_type_expression
-                (identifier_name)))))))))
+                (identifier)))))))))
 
 ============================
 __refvalue
@@ -674,17 +674,17 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (ref_value_expression
-                (identifier_name)
+                (identifier)
                 (predefined_type)))))))))
 
 ============================
@@ -700,14 +700,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (size_of_expression
                 (predefined_type)))))))))
@@ -725,14 +725,14 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (type_of_expression
                 (predefined_type)))))))))
@@ -754,17 +754,17 @@ void b() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
           (implicit_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
               (switch_expression
-                (identifier_name)
+                (identifier)
                 (switch_expression_arm
                   (constant_pattern (integer_literal))
                   (string_literal))
@@ -789,16 +789,16 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
         (expression_statement
           (await_expression
-            (identifier_name))))))))
+            (identifier))))))))
 
 =====================================
 throw expression
@@ -814,20 +814,20 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (expression_statement
             (assignment_expression
-              (identifier_name)
+              (identifier)
               (assignment_operator)
               (binary_expression
-                (identifier_name)
-                (throw_expression (identifier_name))))))))))
+                (identifier)
+                (throw_expression (identifier))))))))))
 
 =====================================
 range expressions full
@@ -844,21 +844,21 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (local_declaration_statement
             (variable_declaration
               (implicit_type)
               (variable_declarator
-                (identifier_name)
+                (identifier)
                 (equals_value_clause
                   (element_access_expression
-                    (identifier_name)
+                    (identifier)
                     (bracketed_argument_list
                       (argument
                         (range_expression
@@ -868,7 +868,7 @@ class Foo {
               (variable_declaration
                 (implicit_type)
                   (variable_declarator
-                    (identifier_name)
+                    (identifier)
                     (equals_value_clause
                       (range_expression
                         (integer_literal)
@@ -890,21 +890,21 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (local_declaration_statement
             (variable_declaration
               (implicit_type)
               (variable_declarator
-                (identifier_name)
+                (identifier)
                 (equals_value_clause
                   (element_access_expression
-                    (identifier_name)
+                    (identifier)
                     (bracketed_argument_list
                       (argument
                         (range_expression
@@ -913,7 +913,7 @@ class Foo {
               (variable_declaration
                 (implicit_type)
                   (variable_declarator
-                    (identifier_name)
+                    (identifier)
                     (equals_value_clause
                       (range_expression
                         (prefix_unary_expression (integer_literal)))))))
@@ -921,10 +921,10 @@ class Foo {
                 (variable_declaration
                   (implicit_type)
                   (variable_declarator
-                    (identifier_name)
+                    (identifier)
                     (equals_value_clause
                       (element_access_expression
-                        (identifier_name)
+                        (identifier)
                         (bracketed_argument_list (argument (range_expression)))))))))))))
 
 =====================================
@@ -942,28 +942,28 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (local_declaration_statement
             (variable_declaration
               (implicit_type)
               (variable_declarator
-                (identifier_name)
+                (identifier)
                 (equals_value_clause
                   (conditional_access_expression
-                    (identifier_name)
+                    (identifier)
                     (member_binding_expression
-                    (identifier_name)))))))
+                    (identifier)))))))
           (expression_statement
             (invocation_expression
               (member_access_expression
-                (identifier_name)
-                (identifier_name))
+                (identifier)
+                (identifier))
               (argument_list))))))))
 
 =====================================
@@ -980,18 +980,18 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (expression_statement
             (assignment_expression
-              (identifier_name)
+              (identifier)
               (assignment_operator)
-              (cast_expression (predefined_type) (identifier_name)))))))))
+              (cast_expression (predefined_type) (identifier)))))))))
 
 =====================================
 Generic type name no type args
@@ -1007,21 +1007,21 @@ var t = typeof(Tuple<,,,>);
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (type_of_expression
             (generic_name
-              (identifier_name)
+              (identifier)
               (type_argument_list)))))))
   (field_declaration
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (type_of_expression
             (generic_name
-              (identifier_name)
+              (identifier)
               (type_argument_list))))))))
 
 =====================================
@@ -1037,7 +1037,7 @@ int b = default;
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (default_expression
             (predefined_type))))))
@@ -1045,7 +1045,7 @@ int b = default;
     (variable_declaration
       (predefined_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (default_expression))))))
 
@@ -1062,22 +1062,22 @@ ref var elementRef = ref arr[0];
   (field_declaration
     (modifier)
     (variable_declaration
-      (identifier_name)
+      (identifier)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (ref_expression
-            (identifier_name))))))
+            (identifier))))))
   (field_declaration
     (modifier)
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (ref_expression
             (element_access_expression
-              (identifier_name)
+              (identifier)
               (bracketed_argument_list
                 (argument
                   (integer_literal))))))))))
@@ -1095,11 +1095,11 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (object_creation_expression
             (generic_name
-              (identifier_name)
+              (identifier)
               (type_argument_list (predefined_type) (predefined_type)))
             (initializer_expression
               (assignment_expression
@@ -1121,10 +1121,10 @@ var x = dict?["a"];
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (conditional_access_expression
-            (identifier_name)
+            (identifier)
               (element_binding_expression
                 (bracketed_argument_list (argument (string_literal))))))))))
 
@@ -1143,29 +1143,29 @@ void Test(){
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
     (block
       (expression_statement
         (invocation_expression
           (member_access_expression
-            (identifier_name)
-            (identifier_name))
+            (identifier)
+            (identifier))
           (argument_list
             (argument
-              (identifier_name)))))
+              (identifier)))))
       (expression_statement
         (invocation_expression
           (member_access_expression
             (predefined_type)
-            (identifier_name))
+            (identifier))
           (argument_list
             (argument
-              (identifier_name)))))
+              (identifier)))))
       (expression_statement
         (member_access_expression
           (predefined_type)
-          (identifier_name))))))
+          (identifier))))))
 
 =====================================
 is expression
@@ -1180,10 +1180,10 @@ var b = s is string;
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (binary_expression
-            (identifier_name)
+            (identifier)
             (predefined_type)))))))
 
 =====================================
@@ -1200,21 +1200,21 @@ var c = s is "test";
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (is_pattern_expression
-            (identifier_name)
+            (identifier)
             (declaration_pattern
               (predefined_type)
-              (identifier_name)))))))
+              (identifier)))))))
   (field_declaration
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (is_pattern_expression
-            (identifier_name)
+            (identifier)
               (constant_pattern
                 (string_literal))))))))
 
@@ -1231,13 +1231,13 @@ void Do() {
 (compilation_unit
   (method_declaration
     (void_keyword)
-    (identifier_name)
+    (identifier)
     (parameter_list)
       (block
         (expression_statement
           (invocation_expression
-            (member_access_expression (identifier_name) (identifier_name))
-            (argument_list (argument (identifier_name)) (argument (identifier_name))))))))
+            (member_access_expression (identifier) (identifier))
+            (argument_list (argument (identifier)) (argument (identifier))))))))
 
 =====================================
 Null-forgiving operator
@@ -1252,7 +1252,7 @@ var x = name!.Length;
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
-          (member_access_expression (postfix_unary_expression (identifier_name))
-          (identifier_name)))))))
+          (member_access_expression (postfix_unary_expression (identifier))
+          (identifier)))))))

--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -10,7 +10,7 @@ int x = y;
   (field_declaration
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (identifier_name))))))
+      (variable_declarator (identifier) (equals_value_clause (identifier))))))
 
 =======================================
 indentifiers with keyword names
@@ -24,4 +24,4 @@ int @var = @const;
   (field_declaration
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (identifier_name))))))
+      (variable_declarator (identifier) (equals_value_clause (identifier))))))

--- a/corpus/interfaces.txt
+++ b/corpus/interfaces.txt
@@ -10,7 +10,7 @@ public interface IOne {};
   (interface_declaration
     (modifier)
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface with properties
@@ -28,7 +28,7 @@ interface IOne {
 (compilation_unit
   (interface_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (identifier_name)
@@ -62,7 +62,7 @@ interface IOne {
 (compilation_unit
   (interface_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -94,7 +94,7 @@ private interface IOne : ITwo { }
     (identifier_name)
     (base_list
       (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface base multiple
@@ -111,7 +111,7 @@ private interface IOne : ITwo, IThree { }
     (base_list
       (identifier_name)
       (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface generic
@@ -128,7 +128,7 @@ private interface IOne<T1> : ITwo { }
     (type_parameter_list (type_parameter (identifier_name)))
     (base_list
       (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface generic single constraint
@@ -147,7 +147,7 @@ private interface IOne<T1> : ITwo where T1:T2 { }
      (type_parameter_constraints_clause
       (identifier_name)
        (type_parameter_constraint (type_constraint (identifier_name))))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface generic multiple constraints
@@ -171,7 +171,7 @@ private interface IOne<T1, T3> : ITwo where T1:T2 where T3:new() { }
      (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (constructor_constraint)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Interface in namespace
@@ -184,12 +184,14 @@ namespace A {
 ---
 
 (compilation_unit
-  (namespace_declaration (identifier_name)
-    (interface_declaration
-      (identifier_name)
-      (base_list
-        (identifier_name))
-    (class_body))))
+  (namespace_declaration
+    (identifier_name)
+    (declaration_list
+      (interface_declaration
+        (identifier_name)
+        (base_list
+          (identifier_name))
+        (declaration_list)))))
 
 =======================================
 Interface event declarations
@@ -204,7 +206,7 @@ interface A {
 (compilation_unit
   (interface_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
         (event_field_declaration
           (variable_declaration
             (generic_name (identifier_name)
@@ -224,7 +226,7 @@ interface A {
 (compilation_unit
   (interface_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (indexer_declaration
         (predefined_type)
         (bracketed_parameter_list (parameter (predefined_type) (identifier_name)))
@@ -246,7 +248,7 @@ interface MyDefault {
 (compilation_unit
   (interface_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)

--- a/corpus/interfaces.txt
+++ b/corpus/interfaces.txt
@@ -9,7 +9,7 @@ public interface IOne {};
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (declaration_list)))
 
 =====================================
@@ -27,23 +27,23 @@ interface IOne {
 
 (compilation_unit
   (interface_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration)))))
 
 =====================================
@@ -61,24 +61,24 @@ interface IOne {
 
 (compilation_unit
   (interface_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list))
       (method_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list))
       (method_declaration
         (void_keyword)
-        (identifier_name)
-        (parameter_list (parameter (predefined_type) (identifier_name))))
+        (identifier)
+        (parameter_list (parameter (predefined_type) (identifier))))
       (method_declaration
         (predefined_type)
-        (identifier_name)
-        (parameter_list (parameter (predefined_type) (identifier_name)))))))
+        (identifier)
+        (parameter_list (parameter (predefined_type) (identifier)))))))
 
 =====================================
 Interface base single
@@ -91,9 +91,9 @@ private interface IOne : ITwo { }
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (base_list
-      (identifier_name))
+      (identifier))
     (declaration_list)))
 
 =====================================
@@ -107,10 +107,10 @@ private interface IOne : ITwo, IThree { }
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (base_list
-      (identifier_name)
-      (identifier_name))
+      (identifier)
+      (identifier))
     (declaration_list)))
 
 =====================================
@@ -124,10 +124,10 @@ private interface IOne<T1> : ITwo { }
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (base_list
-      (identifier_name))
+      (identifier))
     (declaration_list)))
 
 =====================================
@@ -141,12 +141,12 @@ private interface IOne<T1> : ITwo where T1:T2 { }
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
-    (base_list (identifier_name))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
+    (base_list (identifier))
      (type_parameter_constraints_clause
-      (identifier_name)
-       (type_parameter_constraint (type_constraint (identifier_name))))
+      (identifier)
+       (type_parameter_constraint (type_constraint (identifier))))
     (declaration_list)))
 
 =====================================
@@ -160,16 +160,16 @@ private interface IOne<T1, T3> : ITwo where T1:T2 where T3:new() { }
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (type_parameter_list
-      (type_parameter (identifier_name))
-      (type_parameter (identifier_name)))
-    (base_list (identifier_name))
+      (type_parameter (identifier))
+      (type_parameter (identifier)))
+    (base_list (identifier))
      (type_parameter_constraints_clause
-      (identifier_name)
-       (type_parameter_constraint (type_constraint (identifier_name))))
+      (identifier)
+       (type_parameter_constraint (type_constraint (identifier))))
      (type_parameter_constraints_clause
-      (identifier_name)
+      (identifier)
       (type_parameter_constraint (constructor_constraint)))
     (declaration_list)))
 
@@ -185,12 +185,12 @@ namespace A {
 
 (compilation_unit
   (namespace_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (interface_declaration
-        (identifier_name)
+        (identifier)
         (base_list
-          (identifier_name))
+          (identifier))
         (declaration_list)))))
 
 =======================================
@@ -205,13 +205,13 @@ interface A {
 
 (compilation_unit
   (interface_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
         (event_field_declaration
           (variable_declaration
-            (generic_name (identifier_name)
-              (type_argument_list (identifier_name)))
-            (variable_declarator (identifier_name)))))))
+            (generic_name (identifier)
+              (type_argument_list (identifier)))
+            (variable_declarator (identifier)))))))
 
 =====================================
 Interface with indexer
@@ -225,11 +225,11 @@ interface A {
 
 (compilation_unit
   (interface_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (indexer_declaration
         (predefined_type)
-        (bracketed_parameter_list (parameter (predefined_type) (identifier_name)))
+        (bracketed_parameter_list (parameter (predefined_type) (identifier)))
         (accessor_declaration)
         (accessor_declaration)))))
 
@@ -247,15 +247,15 @@ interface MyDefault {
 
 (compilation_unit
   (interface_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (predefined_type) (identifier_name)))
+          (parameter (predefined_type) (identifier)))
         (block
           (expression_statement
             (invocation_expression
-              (member_access_expression (identifier_name) (identifier_name))
-              (argument_list (argument (identifier_name))))))))))
+              (member_access_expression (identifier) (identifier))
+              (argument_list (argument (identifier))))))))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -186,7 +186,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (variable_declaration
           (identifier_name)
@@ -244,7 +244,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -267,7 +267,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -310,7 +310,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -334,7 +334,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -358,7 +358,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -383,7 +383,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -405,7 +405,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -429,7 +429,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
@@ -453,7 +453,7 @@ class A {
 
 (compilation_unit (class_declaration
   (identifier_name)
-  (class_body
+  (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -15,32 +15,32 @@ const UInt16 bin2 = 0B01010__10;
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-      (identifier_name)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-      (identifier_name)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal)))))
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-      (identifier_name)
-      (variable_declarator (identifier_name) (equals_value_clause (integer_literal))))))
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
 
 =======================================
 boolean literals
@@ -55,8 +55,8 @@ const bool t = true, u = false;
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (boolean_literal)))
-      (variable_declarator (identifier_name) (equals_value_clause (boolean_literal))))))
+      (variable_declarator (identifier) (equals_value_clause (boolean_literal)))
+      (variable_declarator (identifier) (equals_value_clause (boolean_literal))))))
 
 =======================================
 char literals
@@ -75,27 +75,27 @@ const char uni32 = '\UA0BFf9ca';
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (character_literal)))))
+      (variable_declarator (identifier) (equals_value_clause (character_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (character_literal (escape_sequence))))))
+      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (character_literal (escape_sequence))))))
+      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (character_literal (escape_sequence))))))
+      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (character_literal (escape_sequence)))))))
+      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence)))))))
 
 =======================================
 real literals
@@ -116,37 +116,37 @@ const Decimal m2 = 102.349M;
     (modifier)
     (variable_declaration
     (predefined_type)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-    (identifier_name)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
+    (identifier)
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-    (identifier_name)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
-  (field_declaration
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
+    (identifier)
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
     (predefined_type)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal)))))
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
   (field_declaration
     (modifier)
     (variable_declaration
-    (identifier_name)
-    (variable_declarator (identifier_name) (equals_value_clause (real_literal))))))
+    (predefined_type)
+    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
+  (field_declaration
+    (modifier)
+    (variable_declaration
+    (identifier)
+    (variable_declarator (identifier) (equals_value_clause (real_literal))))))
 
 =======================================
 null literals
@@ -161,7 +161,7 @@ const string x = null;
     (modifier)
     (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier_name) (equals_value_clause (null_literal))))))
+      (variable_declarator (identifier) (equals_value_clause (null_literal))))))
 
 =======================================
 string literals
@@ -185,52 +185,52 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (variable_declaration
-          (identifier_name)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal)))))
+          (identifier)
+          (variable_declarator (identifier) (equals_value_clause (string_literal)))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal)))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal)))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal)))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal)))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal (escape_sequence) (escape_sequence))))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal (escape_sequence) (escape_sequence))))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal (escape_sequence))))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal (escape_sequence))))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal (escape_sequence) (escape_sequence))))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal (escape_sequence) (escape_sequence))))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal (escape_sequence))))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal (escape_sequence))))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (string_literal (escape_sequence))))))
+          (variable_declarator (identifier) (equals_value_clause (string_literal (escape_sequence))))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (verbatim_string_literal)))))
+          (variable_declarator (identifier) (equals_value_clause (verbatim_string_literal)))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (verbatim_string_literal)))))
+          (variable_declarator (identifier) (equals_value_clause (verbatim_string_literal)))))
       (field_declaration
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name) (equals_value_clause (verbatim_string_literal))))))))
+          (variable_declarator (identifier) (equals_value_clause (verbatim_string_literal))))))))
 
 ==================================================
 string literals containing the line comment token
@@ -243,13 +243,13 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause (string_literal (escape_sequence)))))))))
 
 
@@ -266,13 +266,13 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text))))))
@@ -280,7 +280,7 @@ class A {
         (variable_declaration
           (predefined_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text)
@@ -292,7 +292,7 @@ class A {
         (variable_declaration
           (predefined_type)
           (variable_declarator
-            (identifier_name)
+            (identifier)
             (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text)
@@ -309,17 +309,17 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text)
-              (interpolation (identifier_name))
+              (interpolation (identifier))
               (interpolated_string_text)))))))))
 
 ==================================================
@@ -333,17 +333,17 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text)
-              (interpolation (identifier_name) (interpolation_format_clause))
+              (interpolation (identifier) (interpolation_format_clause))
               (interpolated_string_text)))))))))
 
 ==================================================
@@ -357,17 +357,17 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_string_text)
-              (interpolation (identifier_name)
+              (interpolation (identifier)
                 (interpolation_alignment_clause (integer_literal)))
               (interpolated_string_text)))))))))
 
@@ -382,13 +382,13 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_verbatim_string_text)))))))))
@@ -404,17 +404,17 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_verbatim_string_text)
-              (interpolation (identifier_name))
+              (interpolation (identifier))
               (interpolated_verbatim_string_text)))))))))
 
 ==================================================
@@ -428,17 +428,17 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_verbatim_string_text)
-              (interpolation (identifier_name) (interpolation_format_clause))
+              (interpolation (identifier) (interpolation_format_clause))
               (interpolated_verbatim_string_text)))))))))
 
 ==================================================
@@ -452,16 +452,16 @@ class A {
 ---
 
 (compilation_unit (class_declaration
-  (identifier_name)
+  (identifier)
   (declaration_list
     (field_declaration
       (variable_declaration
         (predefined_type)
         (variable_declarator
-          (identifier_name)
+          (identifier)
           (equals_value_clause
             (interpolated_string_expression
               (interpolated_verbatim_string_text)
-              (interpolation (identifier_name)
+              (interpolation (identifier)
                 (interpolation_alignment_clause (prefix_unary_expression (integer_literal))))
               (interpolated_verbatim_string_text)))))))))

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -15,7 +15,7 @@ string a =
     (variable_declaration
      (predefined_type)
      (variable_declarator
-      (identifier_name)
+      (identifier)
       (equals_value_clause
         (preprocessor_directive)
         (string_literal))))
@@ -40,7 +40,7 @@ string a =
     (variable_declaration
      (predefined_type)
      (variable_declarator
-      (identifier_name)
+      (identifier)
       (equals_value_clause
         (preprocessor_directive)
         (string_literal))))
@@ -65,7 +65,7 @@ string a =
     (variable_declaration
      (predefined_type)
      (variable_declarator
-      (identifier_name)
+      (identifier)
       (equals_value_clause
         (preprocessor_directive)
         (string_literal))))
@@ -92,7 +92,7 @@ string a =
     (variable_declaration
      (predefined_type)
      (variable_declarator
-      (identifier_name)
+      (identifier)
       (equals_value_clause
         (preprocessor_directive)
         (string_literal))))
@@ -117,7 +117,7 @@ string a =
     (variable_declaration
      (predefined_type)
      (variable_declarator
-      (identifier_name)
+      (identifier)
       (equals_value_clause
         (preprocessor_directive)
         (string_literal))))
@@ -154,7 +154,7 @@ class A {}
 (compilation_unit
   (preprocessor_directive)
   (preprocessor_directive)
-  (class_declaration (identifier_name) (declaration_list)))
+  (class_declaration (identifier) (declaration_list)))
 
 ===================================
 Warning and error directives
@@ -168,7 +168,7 @@ class Of1879 {
 ---
 
 (compilation_unit
-  (class_declaration (identifier_name)
+  (class_declaration (identifier)
     (declaration_list
       (preprocessor_directive)
       (preprocessor_directive))))
@@ -188,9 +188,9 @@ class Of1879 {
 ---
 
 (compilation_unit
-  (class_declaration (identifier_name)
+  (class_declaration (identifier)
     (declaration_list
-      (method_declaration (void_keyword) (identifier_name) (parameter_list)
+      (method_declaration (void_keyword) (identifier) (parameter_list)
         (block
           (preprocessor_directive)
           (preprocessor_directive)

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -154,7 +154,7 @@ class A {}
 (compilation_unit
   (preprocessor_directive)
   (preprocessor_directive)
-  (class_declaration (identifier_name) (class_body)))
+  (class_declaration (identifier_name) (declaration_list)))
 
 ===================================
 Warning and error directives
@@ -169,7 +169,7 @@ class Of1879 {
 
 (compilation_unit
   (class_declaration (identifier_name)
-    (class_body
+    (declaration_list
       (preprocessor_directive)
       (preprocessor_directive))))
 
@@ -189,7 +189,7 @@ class Of1879 {
 
 (compilation_unit
   (class_declaration (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration (void_keyword) (identifier_name) (parameter_list)
         (block
           (preprocessor_directive)

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -11,16 +11,16 @@ var x = from a in source select a.B;
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
               (select_clause
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name)))))))))
+                  (identifier)
+                  (identifier)))))))))
 
 =====================================
 Query from select projection
@@ -35,20 +35,20 @@ var x = from a in source select { Name = a.B };
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
               (select_clause
                 (initializer_expression
                   (assignment_expression
-                    (identifier_name)
+                    (identifier)
                       (assignment_operator)
                         (member_access_expression
-                          (identifier_name)
-                          (identifier_name)))))))))))
+                          (identifier)
+                          (identifier)))))))))))
 
 =====================================
 Query from select with where
@@ -65,20 +65,20 @@ var x = from a in source
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (where_clause
               (binary_expression
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))
+                  (identifier)
+                  (identifier))
                 (string_literal)))
             (select_clause
-              (identifier_name))))))))
+              (identifier))))))))
 
 =====================================
 Query from select with where and projection
@@ -95,30 +95,30 @@ var x = from a in source
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (where_clause
               (binary_expression
                 (binary_expression
                   (member_access_expression
-                    (identifier_name)
-                    (identifier_name))
+                    (identifier)
+                    (identifier))
                   (string_literal))
                 (binary_expression
                   (member_access_expression
-                    (identifier_name)
-                    (identifier_name))
+                    (identifier)
+                    (identifier))
                   (string_literal))))
               (select_clause
                 (anonymous_object_creation_expression
-                  (name_equals (identifier_name))
+                  (name_equals (identifier))
                   (member_access_expression
-                    (identifier_name)
-                    (identifier_name))))))))))
+                    (identifier)
+                    (identifier))))))))))
 
 =====================================
 Query from select with orderby
@@ -137,24 +137,24 @@ var x = from a in source
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (order_by_clause
               (member_access_expression
-                (identifier_name)
-                (identifier_name)))
+                (identifier)
+                (identifier)))
             (order_by_clause
               (member_access_expression
-                (identifier_name)
-                (identifier_name)))
+                (identifier)
+                (identifier)))
             (order_by_clause
               (integer_literal))
             (select_clause
-              (identifier_name))))))))
+              (identifier))))))))
 
 =====================================
 Query from select with let
@@ -171,23 +171,23 @@ var x = from a in source
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (let_clause
-              (identifier_name)
+              (identifier)
               (anonymous_object_creation_expression
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))
+                  (identifier)
+                  (identifier))
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))))
+                  (identifier)
+                  (identifier))))
             (select_clause
-              (identifier_name))))))))
+              (identifier))))))))
 
 =====================================
 Query from select with join
@@ -204,29 +204,29 @@ var x = from a in sourceA
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (join_clause
-              (identifier_name)
-              (identifier_name)
+              (identifier)
+              (identifier)
               (member_access_expression
-                (identifier_name)
-                (identifier_name))
+                (identifier)
+                (identifier))
               (member_access_expression
-                (identifier_name)
-                (identifier_name)))
+                (identifier)
+                (identifier)))
             (select_clause
               (anonymous_object_creation_expression
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))
+                  (identifier)
+                  (identifier))
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))))))))))
+                  (identifier)
+                  (identifier))))))))))
 
 =====================================
 Query from select with multiple from
@@ -244,31 +244,31 @@ var x = from a in sourceA
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (where_clause
               (binary_expression
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))
+                  (identifier)
+                  (identifier))
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))))
+                  (identifier)
+                  (identifier))))
             (select_clause
               (anonymous_object_creation_expression
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))
+                  (identifier)
+                  (identifier))
                 (member_access_expression
-                  (identifier_name)
-                  (identifier_name))))))))))
+                  (identifier)
+                  (identifier))))))))))
 
 =====================================
 Query from select with group by & continuation
@@ -285,34 +285,34 @@ var x = from a in sourceA
     (variable_declaration
       (implicit_type)
       (variable_declarator
-        (identifier_name)
+        (identifier)
         (equals_value_clause
           (query_expression
             (from_clause
-              (identifier_name)
-              (identifier_name))
+              (identifier)
+              (identifier))
             (group_clause
-              (identifier_name)
+              (identifier)
               (member_access_expression
-                (identifier_name)
-                (identifier_name)))
+                (identifier)
+                (identifier)))
             (query_continuation
-              (identifier_name)
+              (identifier)
               (select_clause
                 (anonymous_object_creation_expression
-                  (name_equals (identifier_name))
+                  (name_equals (identifier))
                   (member_access_expression
-                    (identifier_name)
-                    (identifier_name))
-                  (name_equals (identifier_name))
+                    (identifier)
+                    (identifier))
+                  (name_equals (identifier))
                   (invocation_expression
                     (member_access_expression
-                      (identifier_name)
-                      (identifier_name))
+                      (identifier)
+                      (identifier))
                     (argument_list
                       (argument
                         (lambda_expression
-                          (identifier_name)
+                          (identifier)
                           (member_access_expression
-                            (identifier_name)
-                            (identifier_name)))))))))))))))
+                            (identifier)
+                            (identifier)))))))))))))))

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -17,7 +17,7 @@ using static J.K;
     (qualified_name (identifier_name) (identifier_name)))
   (using_directive
     (qualified_name
-      (alias_qualified_name (identifier_name))
+      (alias_qualified_name (global) (identifier_name))
       (identifier_name)))
   (using_directive
     (name_equals (identifier_name))
@@ -38,8 +38,9 @@ namespace Foo {
 (compilation_unit
   (namespace_declaration
     (identifier_name)
-    (using_directive
-      (identifier_name))))
+    (declaration_list
+      (using_directive
+        (identifier_name)))))
 
 =====================================
 Comments
@@ -72,10 +73,15 @@ namespace A {
 (compilation_unit
   (namespace_declaration
     (identifier_name)
-    (namespace_declaration
-      (qualified_name (qualified_name (identifier_name) (identifier_name)) (identifier_name)))
-    (namespace_declaration
-      (qualified_name (identifier_name) (identifier_name)))))
+    (declaration_list
+      (namespace_declaration
+        (qualified_name
+          (qualified_name (identifier_name) (identifier_name))
+          (identifier_name))
+        (declaration_list))
+      (namespace_declaration
+        (qualified_name (identifier_name) (identifier_name))
+        (declaration_list)))))
 
 =====================================
 Interfaces
@@ -90,7 +96,7 @@ public interface IFoo {
   (interface_declaration
     (modifier)
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Externs
@@ -138,9 +144,9 @@ class Z {
     (type_parameter_constraints_clause (identifier_name) (type_parameter_constraint)))
   (delegate_declaration (void_keyword) (identifier_name)
     (parameter_list (parameter_array (array_type (predefined_type) (array_rank_specifier)) (identifier_name))))
-  (class_declaration (identifier_name) (class_body
+  (class_declaration (identifier_name) (declaration_list
     (delegate_declaration (void_keyword) (identifier_name) (parameter_list)))))
-    
+
 =====================================
 Var declared equal to integer literal
 =====================================
@@ -153,4 +159,3 @@ var a = 1;
     (variable_declaration (implicit_type)
       (variable_declarator (identifier_name)
         (equals_value_clause (integer_literal))))))
-

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -12,18 +12,18 @@ using static J.K;
 
 (compilation_unit
   (using_directive
-    (identifier_name))
+    (identifier))
   (using_directive
-    (qualified_name (identifier_name) (identifier_name)))
+    (qualified_name (identifier) (identifier)))
   (using_directive
     (qualified_name
-      (alias_qualified_name (global) (identifier_name))
-      (identifier_name)))
+      (alias_qualified_name (global) (identifier))
+      (identifier)))
   (using_directive
-    (name_equals (identifier_name))
-    (qualified_name (identifier_name) (identifier_name)))
+    (name_equals (identifier))
+    (qualified_name (identifier) (identifier)))
   (using_directive
-    (qualified_name (identifier_name) (identifier_name))))
+    (qualified_name (identifier) (identifier))))
 
 =====================================
 Nested using directives
@@ -37,10 +37,10 @@ namespace Foo {
 
 (compilation_unit
   (namespace_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (using_directive
-        (identifier_name)))))
+        (identifier)))))
 
 =====================================
 Comments
@@ -72,15 +72,15 @@ namespace A {
 
 (compilation_unit
   (namespace_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (namespace_declaration
         (qualified_name
-          (qualified_name (identifier_name) (identifier_name))
-          (identifier_name))
+          (qualified_name (identifier) (identifier))
+          (identifier))
         (declaration_list))
       (namespace_declaration
-        (qualified_name (identifier_name) (identifier_name))
+        (qualified_name (identifier) (identifier))
         (declaration_list)))))
 
 =====================================
@@ -95,7 +95,7 @@ public interface IFoo {
 (compilation_unit
   (interface_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (declaration_list)))
 
 =====================================
@@ -108,7 +108,7 @@ extern alias A;
 
 (compilation_unit
   (extern_alias_directive
-    (identifier_name)))
+    (identifier)))
 
 
 =====================================
@@ -131,21 +131,21 @@ class Z {
   (delegate_declaration
     (modifier)
     (predefined_type)
-    (identifier_name)
+    (identifier)
     (parameter_list
       (parameter
         (parameter_modifier)
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (equals_value_clause (character_literal (escape_sequence))))))
-  (delegate_declaration (void_keyword) (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+  (delegate_declaration (void_keyword) (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (parameter_list)
-    (type_parameter_constraints_clause (identifier_name) (type_parameter_constraint)))
-  (delegate_declaration (void_keyword) (identifier_name)
-    (parameter_list (parameter_array (array_type (predefined_type) (array_rank_specifier)) (identifier_name))))
-  (class_declaration (identifier_name) (declaration_list
-    (delegate_declaration (void_keyword) (identifier_name) (parameter_list)))))
+    (type_parameter_constraints_clause (identifier) (type_parameter_constraint)))
+  (delegate_declaration (void_keyword) (identifier)
+    (parameter_list (parameter_array (array_type (predefined_type) (array_rank_specifier)) (identifier))))
+  (class_declaration (identifier) (declaration_list
+    (delegate_declaration (void_keyword) (identifier) (parameter_list)))))
 
 =====================================
 Var declared equal to integer literal
@@ -157,5 +157,5 @@ var a = 1;
 (compilation_unit
   (field_declaration
     (variable_declaration (implicit_type)
-      (variable_declarator (identifier_name)
+      (variable_declarator (identifier)
         (equals_value_clause (integer_literal))))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -13,7 +13,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (predefined_type)
       (identifier_name)
       (parameter_list)
@@ -35,7 +35,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -58,7 +58,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -82,7 +82,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -105,7 +105,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -127,7 +127,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -149,7 +149,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list
@@ -176,7 +176,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -200,7 +200,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (predefined_type)
       (identifier_name)
       (parameter_list)
@@ -224,7 +224,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (predefined_type)
       (identifier_name)
       (parameter_list)
@@ -256,7 +256,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (predefined_type)
       (identifier_name)
       (parameter_list
@@ -289,7 +289,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -316,7 +316,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -345,7 +345,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -376,7 +376,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -407,7 +407,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -436,7 +436,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -462,7 +462,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -488,7 +488,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -514,7 +514,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (generic_name
         (identifier_name)
         (type_argument_list (predefined_type)))
@@ -539,7 +539,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -573,7 +573,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration (void_keyword) (identifier_name) (parameter_list)
       (block
         (local_function_statement (modifier) (void_keyword) (identifier_name)
@@ -606,7 +606,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -639,7 +639,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -665,7 +665,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -697,7 +697,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -725,7 +725,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -758,7 +758,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -790,7 +790,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -822,7 +822,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -848,7 +848,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -879,7 +879,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -908,7 +908,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -936,7 +936,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -967,7 +967,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)
@@ -1007,7 +1007,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body (method_declaration
+    (declaration_list (method_declaration
       (void_keyword)
       (identifier_name)
       (parameter_list)

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -12,10 +12,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (predefined_type)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (return_statement (integer_literal)))))))
@@ -34,11 +34,11 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (return_statement))))))
@@ -57,11 +57,11 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list)
         (block
           (while_statement (boolean_literal)
@@ -81,10 +81,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (while_statement (boolean_literal)
@@ -104,10 +104,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (throw_statement))))))
@@ -126,13 +126,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
-        (throw_statement (identifier_name)))))))
+        (throw_statement (identifier)))))))
 
 =====================================
 Do while
@@ -148,16 +148,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list
-        (parameter (predefined_type) (identifier_name)))
+        (parameter (predefined_type) (identifier)))
       (block
         (do_statement
           (block)
-          (identifier_name)))))))
+          (identifier)))))))
 
 =====================================
 Goto statement and label
@@ -175,10 +175,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (goto_statement (label_name))
@@ -199,10 +199,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (predefined_type)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (if_statement (boolean_literal)
@@ -223,10 +223,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (predefined_type)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (if_statement (boolean_literal)
@@ -255,14 +255,14 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (predefined_type)
-      (identifier_name)
+      (identifier)
       (parameter_list
-        (parameter (predefined_type) (identifier_name)))
+        (parameter (predefined_type) (identifier)))
       (block
-        (switch_statement (identifier_name)
+        (switch_statement (identifier)
           (switch_section
             (case_switch_label (integer_literal))
             (case_switch_label (integer_literal))
@@ -288,10 +288,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (try_statement
@@ -315,16 +315,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (try_statement
           (block)
           (catch_clause
-            (catch_declaration (identifier_name) (identifier_name))
+            (catch_declaration (identifier) (identifier))
             (block))))))))
 
 =====================================
@@ -344,16 +344,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (try_statement
           (block)
           (catch_clause
-            (catch_declaration (identifier_name) (identifier_name))
+            (catch_declaration (identifier) (identifier))
             (block))
           (finally_clause
             (block))))))))
@@ -375,19 +375,19 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (try_statement
           (block)
           (catch_clause
-            (catch_declaration (identifier_name) (identifier_name))
+            (catch_declaration (identifier) (identifier))
             (block))
           (catch_clause
-            (catch_declaration (identifier_name) (identifier_name))
+            (catch_declaration (identifier) (identifier))
             (block))))))))
 
 =====================================
@@ -406,17 +406,17 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (try_statement
           (block)
           (catch_clause
-            (catch_declaration (identifier_name) (identifier_name))
-            (catch_filter_clause (binary_expression (identifier_name) (integer_literal)))
+            (catch_declaration (identifier) (identifier))
+            (catch_filter_clause (binary_expression (identifier) (integer_literal)))
             (block))))))))
 
 =====================================
@@ -435,10 +435,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (checked_statement
@@ -461,10 +461,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (checked_statement
@@ -487,10 +487,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (lock_statement
@@ -513,12 +513,12 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (generic_name
-        (identifier_name)
+        (identifier)
         (type_argument_list (predefined_type)))
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (yield_statement (integer_literal))
@@ -538,17 +538,17 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
             (implicit_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
                 (integer_literal))))))))))
 
@@ -572,22 +572,22 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
-      (method_declaration (void_keyword) (identifier_name) (parameter_list)
+      (method_declaration (void_keyword) (identifier) (parameter_list)
       (block
-        (local_function_statement (modifier) (void_keyword) (identifier_name)
+        (local_function_statement (modifier) (void_keyword) (identifier)
           (type_parameter_list 
-            (type_parameter (identifier_name))
-            (type_parameter (identifier_name)))
+            (type_parameter (identifier))
+            (type_parameter (identifier)))
           (parameter_list
-            (parameter (identifier_name) (identifier_name))
-            (parameter (identifier_name) (identifier_name)))
-          (type_parameter_constraints_clause (identifier_name)
-            (type_parameter_constraint (type_constraint (identifier_name))))
+            (parameter (identifier) (identifier))
+            (parameter (identifier) (identifier)))
+          (type_parameter_constraints_clause (identifier)
+            (type_parameter_constraint (type_constraint (identifier))))
           (block
-            (return_statement (binary_expression (identifier_name) (identifier_name)))))
-        (local_function_statement (modifier) (modifier) (predefined_type) (identifier_name) (parameter_list)
+            (return_statement (binary_expression (identifier) (identifier)))))
+        (local_function_statement (modifier) (modifier) (predefined_type) (identifier) (parameter_list)
           (block
             (return_statement (integer_literal)))))))))
 
@@ -605,24 +605,24 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
-        (local_function_statement (void_keyword) (identifier_name)
+        (local_function_statement (void_keyword) (identifier)
           (type_parameter_list
-            (type_parameter (identifier_name))
-            (type_parameter (identifier_name)))
+            (type_parameter (identifier))
+            (type_parameter (identifier)))
           (parameter_list
-            (parameter (identifier_name) (identifier_name))
-            (parameter (identifier_name) (identifier_name)))
+            (parameter (identifier) (identifier))
+            (parameter (identifier) (identifier)))
           (arrow_expression_clause
-            (invocation_expression (identifier_name)
+            (invocation_expression (identifier)
               (argument_list
-                (argument (identifier_name))
-                (argument (identifier_name)))))))))))
+                (argument (identifier))
+                (argument (identifier)))))))))))
 
 =====================================
 Explicit local variable with no initializer
@@ -638,17 +638,17 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
             (predefined_type)
             (variable_declarator
-              (identifier_name)))))))))
+              (identifier)))))))))
 
 =====================================
 Explicit local variables with multiple literal initializers
@@ -664,21 +664,21 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
             (predefined_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
                 (integer_literal)))
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
                 (integer_literal))))))))))
 
@@ -696,17 +696,17 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (local_declaration_statement
           (modifier)
           (variable_declaration
             (predefined_type)
-              (variable_declarator (identifier_name)
+              (variable_declarator (identifier)
                 (equals_value_clause
                   (integer_literal))))))))))
 
@@ -724,20 +724,20 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (local_declaration_statement
           (modifier)
           (variable_declaration
             (predefined_type)
-              (variable_declarator (identifier_name)
+              (variable_declarator (identifier)
                 (equals_value_clause
                   (integer_literal)))
-              (variable_declarator (identifier_name)
+              (variable_declarator (identifier)
                 (equals_value_clause
                   (integer_literal))))))))))
 
@@ -757,19 +757,19 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (using_statement
           (variable_declaration
             (implicit_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
-                (identifier_name))))
+                (identifier))))
           (block
             (return_statement))))))))
 
@@ -789,19 +789,19 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (using_statement
           (variable_declaration
-            (identifier_name)
+            (identifier)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
-                (identifier_name))))
+                (identifier))))
           (block
             (return_statement))))))))
 
@@ -821,10 +821,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (using_statement
@@ -847,21 +847,21 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (for_each_statement
           (predefined_type)
-          (identifier_name)
-          (identifier_name)
+          (identifier)
+          (identifier)
           (expression_statement
             (assignment_expression
-              (identifier_name)
+              (identifier)
               (assignment_operator)
-              (identifier_name)))))))))
+              (identifier)))))))))
 
 =====================================
 Foreach existing expression
@@ -878,20 +878,20 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (for_each_statement
-          (identifier_name)
-          (identifier_name)
+          (identifier)
+          (identifier)
           (expression_statement
             (assignment_expression
-              (identifier_name)
+              (identifier)
               (assignment_operator)
-              (identifier_name)))))))))
+              (identifier)))))))))
 
 =====================================
 Unsafe statement
@@ -907,19 +907,19 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (unsafe_statement
           (block
             (expression_statement
               (assignment_expression
-                (identifier_name)
+                (identifier)
                 (assignment_operator)
-                (identifier_name))))))))))
+                (identifier))))))))))
 
 =====================================
 Fixed statement
@@ -935,19 +935,19 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (fixed_statement
           (variable_declaration
             (predefined_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
-                (identifier_name))))
+                (identifier))))
                 (block)))))))
 
 =====================================
@@ -966,30 +966,30 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (for_statement
           (variable_declaration
             (predefined_type)
             (variable_declarator
-              (identifier_name)
+              (identifier)
               (equals_value_clause
                 (integer_literal))))
           (binary_expression
-            (identifier_name)
+            (identifier)
             (integer_literal))
           (postfix_unary_expression
-            (identifier_name))
+            (identifier))
           (block
             (expression_statement
               (assignment_expression
-                (identifier_name)
+                (identifier)
                 (assignment_operator)
-                (identifier_name))))))))))
+                (identifier))))))))))
 
 =====================================
 For no population
@@ -1006,10 +1006,10 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list (method_declaration
       (void_keyword)
-      (identifier_name)
+      (identifier)
       (parameter_list)
       (block
         (for_statement

--- a/corpus/structs.txt
+++ b/corpus/structs.txt
@@ -9,10 +9,10 @@ public struct F<T> where T:struct {}
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name) (type_parameter_constraint))
+      (identifier) (type_parameter_constraint))
     (declaration_list)))
 
 =====================================
@@ -26,10 +26,10 @@ public struct F<T> where T:class {}
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name) (type_parameter_constraint))
+      (identifier) (type_parameter_constraint))
     (declaration_list)))
 
 =====================================
@@ -43,10 +43,10 @@ public struct F<T> where T: new() {}
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
-    (type_parameter_list (type_parameter (identifier_name)))
+    (identifier)
+    (type_parameter_list (type_parameter (identifier)))
     (type_parameter_constraints_clause
-      (identifier_name)
+      (identifier)
       (type_parameter_constraint (constructor_constraint)))
     (declaration_list)))
 
@@ -61,8 +61,8 @@ public struct A : ISomething { }
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
-    (base_list (identifier_name))
+    (identifier)
+    (base_list (identifier))
     (declaration_list)))
 
 =====================================
@@ -76,18 +76,18 @@ private struct F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
      (type_parameter_list
-      (type_parameter (identifier_name))
-      (type_parameter (identifier_name)))
+      (type_parameter (identifier))
+      (type_parameter (identifier)))
      (type_parameter_constraints_clause
-      (identifier_name)
-      (type_parameter_constraint (type_constraint (identifier_name)))
-      (type_parameter_constraint (type_constraint (identifier_name)))
+      (identifier)
+      (type_parameter_constraint (type_constraint (identifier)))
+      (type_parameter_constraint (type_constraint (identifier)))
       (type_parameter_constraint (constructor_constraint)))
     (type_parameter_constraints_clause
-      (identifier_name)
-      (type_parameter_constraint (type_constraint (identifier_name))))
+      (identifier)
+      (type_parameter_constraint (type_constraint (identifier))))
     (declaration_list)))
 
 =====================================
@@ -102,7 +102,7 @@ readonly struct Test {
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (declaration_list)))
 
 =====================================
@@ -117,5 +117,5 @@ ref struct Test {
 (compilation_unit
   (struct_declaration
     (modifier)
-    (identifier_name)
+    (identifier)
     (declaration_list)))

--- a/corpus/structs.txt
+++ b/corpus/structs.txt
@@ -13,7 +13,7 @@ public struct F<T> where T:struct {}
     (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with a type parameter class constraint
@@ -30,7 +30,7 @@ public struct F<T> where T:class {}
     (type_parameter_list (type_parameter (identifier_name)))
     (type_parameter_constraints_clause
       (identifier_name) (type_parameter_constraint))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with type parameter new constraint
@@ -48,7 +48,7 @@ public struct F<T> where T: new() {}
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (constructor_constraint)))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with interface
@@ -63,7 +63,7 @@ public struct A : ISomething { }
     (modifier)
     (identifier_name)
     (base_list (identifier_name))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with multiple type parameter constraints
@@ -88,7 +88,7 @@ private struct F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
     (type_parameter_constraints_clause
       (identifier_name)
       (type_parameter_constraint (type_constraint (identifier_name))))
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with readonly modifier
@@ -103,7 +103,7 @@ readonly struct Test {
   (struct_declaration
     (modifier)
     (identifier_name)
-    (class_body)))
+    (declaration_list)))
 
 =====================================
 Struct with ref modifier
@@ -118,4 +118,4 @@ ref struct Test {
   (struct_declaration
     (modifier)
     (identifier_name)
-    (class_body)))
+    (declaration_list)))

--- a/corpus/type-events.txt
+++ b/corpus/type-events.txt
@@ -10,13 +10,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (event_declaration
         (modifier)
-        (generic_name (identifier_name)
-          (type_argument_list (identifier_name)))
-        (identifier_name)
+        (generic_name (identifier)
+          (type_argument_list (identifier)))
+        (identifier)
         (accessor_declaration (block))
         (accessor_declaration (block))))))
 
@@ -32,13 +32,13 @@ struct A {
 
 (compilation_unit
   (struct_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (event_declaration
         (modifier)
-        (generic_name (identifier_name)
-          (type_argument_list (identifier_name)))
-        (identifier_name)
+        (generic_name (identifier)
+          (type_argument_list (identifier)))
+        (identifier)
         (accessor_declaration (block))
         (accessor_declaration (block))))))
 
@@ -54,12 +54,12 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (event_declaration
         (modifier)
-        (identifier_name)
-        (identifier_name)
-        (accessor_declaration (arrow_expression_clause (invocation_expression (identifier_name) (argument_list))))
-        (accessor_declaration (arrow_expression_clause (invocation_expression (identifier_name) (argument_list))))))))
+        (identifier)
+        (identifier)
+        (accessor_declaration (arrow_expression_clause (invocation_expression (identifier) (argument_list))))
+        (accessor_declaration (arrow_expression_clause (invocation_expression (identifier) (argument_list))))))))
 

--- a/corpus/type-events.txt
+++ b/corpus/type-events.txt
@@ -11,7 +11,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (event_declaration
         (modifier)
         (generic_name (identifier_name)
@@ -33,7 +33,7 @@ struct A {
 (compilation_unit
   (struct_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (event_declaration
         (modifier)
         (generic_name (identifier_name)
@@ -55,7 +55,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (event_declaration
         (modifier)
         (identifier_name)

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -12,24 +12,24 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name))))
+          (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
-          (identifier_name)
-          (variable_declarator (identifier_name))
-          (variable_declarator (identifier_name))))
+          (identifier)
+          (variable_declarator (identifier))
+          (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
-          (generic_name (identifier_name) (type_argument_list
+          (generic_name (identifier) (type_argument_list
             (predefined_type)
-            (generic_name (identifier_name) (type_argument_list (predefined_type)))))
-          (variable_declarator (identifier_name)))))))
+            (generic_name (identifier) (type_argument_list (predefined_type)))))
+          (variable_declarator (identifier)))))))
 
 =======================================
 Struct field declarations
@@ -43,13 +43,13 @@ struct A {
 
 (compilation_unit
   (struct_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
           (predefined_type)
-          (variable_declarator (identifier_name)))))))
+          (variable_declarator (identifier)))))))
 
 =======================================
 Class field nullable type
@@ -64,18 +64,18 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
           (nullable_type (predefined_type))
-          (variable_declarator (identifier_name))))
+          (variable_declarator (identifier))))
       (field_declaration
         (modifier)
         (variable_declaration
-          (nullable_type (identifier_name))
-          (variable_declarator (identifier_name)))))))
+          (nullable_type (identifier))
+          (variable_declarator (identifier)))))))
 
 =======================================
 Class field pointer type
@@ -90,18 +90,18 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
           (pointer_type (predefined_type))
-          (variable_declarator (identifier_name))))
+          (variable_declarator (identifier))))
       (field_declaration
         (modifier)
         (variable_declaration
-          (pointer_type (identifier_name))
-          (variable_declarator (identifier_name)))))))
+          (pointer_type (identifier))
+          (variable_declarator (identifier)))))))
 
 =======================================
 Ref readonly
@@ -115,14 +115,14 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (modifier)
         (modifier)
-        (identifier_name)
-        (identifier_name)
-          (arrow_expression_clause (ref_expression (identifier_name)))))))
+        (identifier)
+        (identifier)
+          (arrow_expression_clause (ref_expression (identifier)))))))
 
 =======================================
 Nullable reference types
@@ -137,13 +137,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (field_declaration
         (variable_declaration
           (nullable_type (predefined_type))
-          (variable_declarator (identifier_name))))
+          (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
-          (nullable_type (identifier_name))
-          (variable_declarator (identifier_name)))))))
+          (nullable_type (identifier))
+          (variable_declarator (identifier)))))))

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -13,7 +13,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
@@ -44,7 +44,7 @@ struct A {
 (compilation_unit
   (struct_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
@@ -65,7 +65,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
@@ -91,7 +91,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (modifier) (modifier)
         (variable_declaration
@@ -116,7 +116,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (modifier)
         (modifier)
@@ -138,7 +138,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (field_declaration
         (variable_declaration
           (nullable_type (predefined_type))

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -13,7 +13,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (modifier)
         (predefined_type)
@@ -37,7 +37,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -60,7 +60,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -83,7 +83,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -111,7 +111,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -144,7 +144,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -166,7 +166,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -188,7 +188,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -210,7 +210,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (void_keyword)
         (identifier_name)
@@ -236,7 +236,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (method_declaration
         (modifier)
         (predefined_type)
@@ -263,7 +263,7 @@ class A : ISomething {
   (class_declaration
     (identifier_name)
     (base_list (identifier_name))
-    (class_body
+    (declaration_list
       (method_declaration
         (predefined_type)
         (explicit_interface_specifier (identifier_name))
@@ -287,7 +287,7 @@ class A {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (modifier)
         (modifier)

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -12,16 +12,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (modifier)
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (predefined_type) (identifier_name)))
+          (parameter (predefined_type) (identifier)))
         (block
-          (return_statement (identifier_name)))))))
+          (return_statement (identifier)))))))
 
 =======================================
 Class method with multiple parameters
@@ -36,14 +36,14 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (identifier_name) (identifier_name))
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier))
+          (parameter (identifier) (identifier)))
         (block)))))
 
 =======================================
@@ -59,14 +59,14 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
-        (type_parameter_list (type_parameter (identifier_name)))
+        (identifier)
+        (type_parameter_list (type_parameter (identifier)))
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (block)))))
 
 =======================================
@@ -82,16 +82,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
-        (type_parameter_list (type_parameter (identifier_name)))
+        (identifier)
+        (type_parameter_list (type_parameter (identifier)))
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (type_parameter_constraints_clause
-          (identifier_name)
+          (identifier)
           (type_parameter_constraint (constructor_constraint)))
         (block)))))
 
@@ -110,23 +110,23 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (type_parameter_list
-          (type_parameter (identifier_name))
-          (type_parameter (identifier_name)))
+          (type_parameter (identifier))
+          (type_parameter (identifier)))
         (parameter_list
-          (parameter (identifier_name) (identifier_name))
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier))
+          (parameter (identifier) (identifier)))
         (type_parameter_constraints_clause
-          (identifier_name)
+          (identifier)
           (type_parameter_constraint (constructor_constraint)))
         (type_parameter_constraints_clause
-          (identifier_name)
-          (type_parameter_constraint (type_constraint (identifier_name)))
+          (identifier)
+          (type_parameter_constraint (type_constraint (identifier)))
           (type_parameter_constraint (constructor_constraint)))
         (block)))))
 
@@ -143,13 +143,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (parameter_modifier) (predefined_type) (identifier_name)))
+          (parameter (parameter_modifier) (predefined_type) (identifier)))
         (block)))))
 
 =======================================
@@ -165,13 +165,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (parameter_modifier) (predefined_type) (identifier_name)))
+          (parameter (parameter_modifier) (predefined_type) (identifier)))
         (block)))))
 
 =======================================
@@ -187,13 +187,13 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (parameter_modifier) (predefined_type) (identifier_name)))
+          (parameter (parameter_modifier) (predefined_type) (identifier)))
         (block)))))
 
 =======================================
@@ -209,15 +209,15 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (void_keyword)
-        (identifier_name)
+        (identifier)
         (parameter_list
           (parameter
             (predefined_type)
-            (identifier_name)
+            (identifier)
             (equals_value_clause (integer_literal))))
         (block)))))
 
@@ -235,16 +235,16 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (method_declaration
         (modifier)
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (parameter_list
-          (parameter (predefined_type) (identifier_name)))
+          (parameter (predefined_type) (identifier)))
         (block
-          (return_statement (identifier_name)))))))
+          (return_statement (identifier)))))))
 
 
 =======================================
@@ -261,17 +261,17 @@ class A : ISomething {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
-    (base_list (identifier_name))
+    (identifier)
+    (base_list (identifier))
     (declaration_list
       (method_declaration
         (predefined_type)
-        (explicit_interface_specifier (identifier_name))
-        (identifier_name)
+        (explicit_interface_specifier (identifier))
+        (identifier)
         (parameter_list
-          (parameter (predefined_type) (identifier_name)))
+          (parameter (predefined_type) (identifier)))
         (block
-          (return_statement (identifier_name)))))))
+          (return_statement (identifier)))))))
 
 
 =======================================
@@ -286,12 +286,12 @@ class A {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (modifier)
         (modifier)
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (arrow_expression_clause
-          (binary_expression (identifier_name) (identifier_name)))))))
+          (binary_expression (identifier) (identifier)))))))

--- a/corpus/type-operators.txt
+++ b/corpus/type-operators.txt
@@ -17,7 +17,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (operator_declaration
         (attribute_list (attribute (identifier_name)))
         (modifier) (modifier)
@@ -53,7 +53,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (operator_declaration
         (modifier) (modifier)
         (predefined_type)
@@ -81,7 +81,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
@@ -106,7 +106,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
@@ -129,7 +129,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)
@@ -162,7 +162,7 @@ class A
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)

--- a/corpus/type-operators.txt
+++ b/corpus/type-operators.txt
@@ -16,26 +16,26 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (operator_declaration
-        (attribute_list (attribute (identifier_name)))
+        (attribute_list (attribute (identifier)))
         (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (block (return_statement (integer_literal))))
       (operator_declaration
         (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name))
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier))
+          (parameter (identifier) (identifier)))
         (block (return_statement (integer_literal))))
       (operator_declaration
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (block (return_statement (integer_literal)))))))
 
 =======================================
@@ -52,18 +52,18 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (operator_declaration
         (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (block (return_statement (boolean_literal))))
       (operator_declaration
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (block (return_statement (boolean_literal)))))))
 
 =======================================
@@ -80,16 +80,16 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
-        (parameter_list (parameter (identifier_name) (identifier_name)))
+        (parameter_list (parameter (identifier) (identifier)))
         (block (return_statement (integer_literal))))
       (conversion_operator_declaration
         (predefined_type)
-        (parameter_list (parameter (identifier_name) (identifier_name)))
+        (parameter_list (parameter (identifier) (identifier)))
         (block (return_statement (integer_literal)))))))
 
 =======================================
@@ -105,12 +105,12 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
-        (parameter_list (parameter (identifier_name) (identifier_name)))
+        (parameter_list (parameter (identifier) (identifier)))
         (arrow_expression_clause (integer_literal))))))
 
 =======================================
@@ -128,23 +128,23 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name))))
+          (parameter (identifier) (identifier))))
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name))
-          (parameter (identifier_name) (identifier_name))))
+          (parameter (identifier) (identifier))
+          (parameter (identifier) (identifier))))
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
-        (parameter_list (parameter (identifier_name) (identifier_name)))))))
+        (parameter_list (parameter (identifier) (identifier)))))))
 
 =======================================
 Class conversion operators with expression body
@@ -161,24 +161,24 @@ class A
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (arrow_expression_clause (integer_literal)))
       (operator_declaration
         (modifier) (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name))
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier))
+          (parameter (identifier) (identifier)))
         (arrow_expression_clause (boolean_literal)))
       (conversion_operator_declaration
         (modifier) (modifier)
         (predefined_type)
         (parameter_list
-          (parameter (identifier_name) (identifier_name)))
+          (parameter (identifier) (identifier)))
         (arrow_expression_clause (integer_literal))))))

--- a/corpus/type-properties.txt
+++ b/corpus/type-properties.txt
@@ -13,23 +13,23 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration)))))
 
 =====================================
@@ -45,24 +45,24 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration
           (block
             (return_statement (integer_literal)))))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration
           (block
             (expression_statement
               (assignment_expression
-                (identifier_name)
+                (identifier)
                 (assignment_operator)
-                (identifier_name)))))))))
+                (identifier)))))))))
 
 =====================================
 Class with double-accessor property bodies
@@ -83,34 +83,34 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration
           (block
-            (return_statement (identifier_name))))
+            (return_statement (identifier))))
         (accessor_declaration
           (block
             (expression_statement
               (assignment_expression
-                (identifier_name)
+                (identifier)
                 (assignment_operator)
-                (identifier_name))))))
+                (identifier))))))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration
           (block
             (expression_statement
               (assignment_expression
-                (identifier_name)
+                (identifier)
                 (assignment_operator)
-                (identifier_name)))))
+                (identifier)))))
         (accessor_declaration
           (block
-            (return_statement (identifier_name))))))))
+            (return_statement (identifier))))))))
 
 =====================================
 Class with bodyless properties and initializers
@@ -126,21 +126,21 @@ class Foo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
+    (identifier)
     (declaration_list
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration)
         (integer_literal))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration)
         (integer_literal))
       (property_declaration
         (predefined_type)
-        (identifier_name)
+        (identifier)
         (accessor_declaration) (accessor_declaration)
         (integer_literal)))))
 
@@ -156,11 +156,11 @@ class Foo: IFoo {
 
 (compilation_unit
   (class_declaration
-    (identifier_name)
-    (base_list (identifier_name))
+    (identifier)
+    (base_list (identifier))
     (declaration_list
       (property_declaration
         (predefined_type)
-        (explicit_interface_specifier (identifier_name))
-        (identifier_name)
+        (explicit_interface_specifier (identifier))
+        (identifier)
         (accessor_declaration)))))

--- a/corpus/type-properties.txt
+++ b/corpus/type-properties.txt
@@ -14,7 +14,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (identifier_name)
@@ -46,7 +46,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (identifier_name)
@@ -84,7 +84,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (identifier_name)
@@ -127,7 +127,7 @@ class Foo {
 (compilation_unit
   (class_declaration
     (identifier_name)
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (identifier_name)
@@ -158,7 +158,7 @@ class Foo: IFoo {
   (class_declaration
     (identifier_name)
     (base_list (identifier_name))
-    (class_body
+    (declaration_list
       (property_declaration
         (predefined_type)
         (explicit_interface_specifier (identifier_name))

--- a/grammar.js
+++ b/grammar.js
@@ -816,11 +816,6 @@ module.exports = grammar({
       ';'
     ),
 
-    _anonymous_function_expression: $=> choice(
-      $.anonymous_method_expression,
-      $.lambda_expression
-    ),
-
     anonymous_method_expression: $ => seq(
       optional('async'),
       'delegate',
@@ -928,11 +923,6 @@ module.exports = grammar({
       $.initializer_expression
     ),
 
-    _instance_expression: $ => choice(
-      $.base_expression,
-      $.this_expression,
-    ),
-
     base_expression: $ => 'base',
 
     this_expression: $ => 'this',
@@ -982,18 +972,6 @@ module.exports = grammar({
       'is',
       $._pattern
     )),
-
-    _literal_expression: $ => choice(
-      $.null_literal,
-      $.boolean_literal,
-      $.character_literal,
-      // We don't bunch real and integer literals together
-      $.real_literal,
-      $.integer_literal,
-      // Or strings and verbatim strings
-      $.string_literal,
-      $.verbatim_string_literal
-    ),
 
     make_ref_expression: $ => seq(
       '__makeref',
@@ -1184,29 +1162,29 @@ module.exports = grammar({
     // TODO: Expressions need work on precedence and conflicts.
 
     _expression: $ => choice(
-      $._anonymous_function_expression,
+      // $.declaration_expression,
+      //$.is_expression,
+      $.anonymous_method_expression,
       $.anonymous_object_creation_expression,
       $.array_creation_expression,
       $.assignment_expression,
       $.await_expression,
+      $.base_expression,
       $.binary_expression,
-      //$.is_expression,
       $.cast_expression,
       $.checked_expression,
       $.conditional_access_expression,
       $.conditional_expression,
-      // $.declaration_expression,
       $.default_expression,
       $.element_access_expression,
       $.element_binding_expression,
       $.implicit_array_creation_expression,
       $.implicit_stack_alloc_array_creation_expression,
       $.initializer_expression,
-      $._instance_expression,
       $.interpolated_string_expression,
       $.invocation_expression,
       $.is_pattern_expression,
-      $._literal_expression,
+      $.lambda_expression,
       $.make_ref_expression,
       $.member_access_expression,
       $.member_binding_expression,
@@ -1222,14 +1200,26 @@ module.exports = grammar({
       $.size_of_expression,
       $.stack_alloc_array_creation_expression,
       $.switch_expression,
+      $.this_expression,
       $.throw_expression,
       $.tuple_expression,
-      $._type,
       $.type_of_expression,
+      $._type,
 
       // These should be reconsidered when the ones above get activated
       alias($._reserved_identifier, $.identifier_name),
-      $.identifier_name
+      $.identifier_name,
+
+      // Literals
+      $.null_literal,
+      $.boolean_literal,
+      $.character_literal,
+      // We don't bunch real and integer literals together
+      $.real_literal,
+      $.integer_literal,
+      // Or strings and verbatim strings
+      $.string_literal,
+      $.verbatim_string_literal
     ),
 
     binary_expression: $ => choice(
@@ -1261,7 +1251,7 @@ module.exports = grammar({
       )
     ),
 
-    // literals - grammar.txt is useless here as it just refs to lexical specification
+    // Literals - grammar.txt is useless here as it just refs to lexical specification
 
     boolean_literal: $ => choice(
       'true',
@@ -1270,7 +1260,7 @@ module.exports = grammar({
 
     character_literal: $ => seq(
       "'",
-      choice(/[^'\\]/, $.escape_sequence),
+      choice(token.immediate(/[^'\\]/), $.escape_sequence),
       "'"
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -59,7 +59,7 @@ module.exports = grammar({
     $._identifier_or_global,
   ],
 
-  word: $ => $.identifier_name,
+  word: $ => $.identifier,
 
   rules: {
     // Intentionally deviates from spec so that we can syntax highlight fragments of code
@@ -87,7 +87,7 @@ module.exports = grammar({
       $.using_directive,
     ),
 
-    extern_alias_directive: $ => seq('extern', 'alias', $.identifier_name, ';'),
+    extern_alias_directive: $ => seq('extern', 'alias', $.identifier, ';'),
 
     using_directive: $ => seq(
       'using',
@@ -101,9 +101,9 @@ module.exports = grammar({
 
     name_equals: $ => prec(1, seq($._identifier_or_global, '=')),
 
-    identifier_name: $ => token(seq(optional('@'), /[a-zA-Z_][a-zA-Z_0-9]*/)), // identifier_token in Roslyn
+    identifier: $ => token(seq(optional('@'), /[a-zA-Z_][a-zA-Z_0-9]*/)), // identifier_token in Roslyn
     global: $ => 'global',
-    _identifier_or_global: $ => choice($.global, $.identifier_name),
+    _identifier_or_global: $ => choice($.global, $.identifier),
 
     _name: $ => choice(
       $.alias_qualified_name,
@@ -118,7 +118,7 @@ module.exports = grammar({
       $._identifier_or_global
     ),
 
-    generic_name: $ => seq($.identifier_name, $.type_argument_list),
+    generic_name: $ => seq($.identifier, $.type_argument_list),
 
     // Intentionally different from Roslyn to avoid non-matching
     // omitted_type_argument in a lot of unnecessary places.
@@ -194,7 +194,7 @@ module.exports = grammar({
     variable_declaration: $ => seq($._type, commaSep1($.variable_declarator)),
 
     variable_declarator: $ => seq(
-      $.identifier_name,
+      $.identifier,
       optional($.bracketed_argument_list),
       optional($.equals_value_clause)
     ),
@@ -215,7 +215,7 @@ module.exports = grammar({
         seq(
           'out',
           $._type,
-          $.identifier_name
+          $.identifier
         )
       )
     )),
@@ -232,7 +232,7 @@ module.exports = grammar({
     constructor_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
-      $.identifier_name,
+      $.identifier,
       $.parameter_list,
       optional($.constructor_initializer),
       $._function_body
@@ -255,7 +255,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       optional($.parameter_modifier),
       optional($._type),
-      $.identifier_name,
+      $.identifier,
       optional($.equals_value_clause)
     ),
 
@@ -265,7 +265,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       'params',
       $.array_type,
-      $.identifier_name
+      $.identifier
     ),
 
     constructor_initializer: $ => seq(
@@ -303,7 +303,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       optional('extern'),
       '~',
-      $.identifier_name,
+      $.identifier,
       $.parameter_list,
       $._function_body
     ),
@@ -313,7 +313,7 @@ module.exports = grammar({
       repeat($.modifier),
       $.return_type,
       optional($.explicit_interface_specifier),
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       $.parameter_list,
       repeat($.type_parameter_constraints_clause),
@@ -327,7 +327,7 @@ module.exports = grammar({
     type_parameter: $ => seq(
       optional($.attribute_list),
       optional(choice('in', 'out')),
-      $.identifier_name
+      $.identifier
     ),
 
     type_parameter_constraints_clause: $ => seq(
@@ -379,7 +379,7 @@ module.exports = grammar({
       'event',
       $._type,
       optional($.explicit_interface_specifier),
-      $.identifier_name,
+      $.identifier,
       choice(
         $._accessor_list,
         ';'
@@ -395,7 +395,7 @@ module.exports = grammar({
     accessor_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
-      choice('get', 'set', 'add', 'remove', $.identifier_name),
+      choice('get', 'set', 'add', 'remove', $.identifier),
       $._function_body
     ),
 
@@ -419,7 +419,7 @@ module.exports = grammar({
       repeat($.modifier),
       $._type,
       optional($.explicit_interface_specifier),
-      $.identifier_name,
+      $.identifier,
       choice(
         seq($._accessor_list, optional(seq('=', $._expression, ';'))), // grammar.txt does not allow bodyless properties.
         seq($.arrow_expression_clause, ';')
@@ -430,7 +430,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'enum',
-      $.identifier_name,
+      $.identifier,
       optional($.base_list),
       $.enum_member_declaration_list,
       optional(';')
@@ -447,7 +447,7 @@ module.exports = grammar({
 
     enum_member_declaration: $ => seq(
       repeat($.attribute_list),
-      $.identifier_name,
+      $.identifier,
       optional(seq('=', $._expression))
     ),
 
@@ -455,7 +455,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'class',
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
@@ -473,7 +473,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'interface',
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
@@ -485,7 +485,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'struct',
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
@@ -498,7 +498,7 @@ module.exports = grammar({
       repeat($.modifier),
       'delegate',
       $.return_type,
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       $.parameter_list,
       repeat($.type_parameter_constraints_clause),
@@ -570,7 +570,7 @@ module.exports = grammar({
       ')'
     ),
 
-    tuple_element: $ => seq($._type, optional($.identifier_name)),
+    tuple_element: $ => seq($._type, optional($.identifier)),
 
     _statement: $ => choice(
       $.block,
@@ -631,7 +631,7 @@ module.exports = grammar({
       'foreach',
       '(',
       choice(
-        seq($._type, $.identifier_name), // for_each_statement
+        seq($._type, $.identifier), // for_each_statement
         $._expression, // for_each_variable_statement
       ),
       'in',
@@ -644,7 +644,7 @@ module.exports = grammar({
     goto_statement: $ => seq(
       'goto',
       choice(
-        alias($.identifier_name, $.label_name),
+        alias($.identifier, $.label_name),
         seq('case', $._expression),
         'default'
       ),
@@ -663,7 +663,7 @@ module.exports = grammar({
     else_clause: $ => seq('else', $._statement),
 
     labeled_statement: $ => seq(
-      alias($.identifier_name, $.label_name),
+      alias($.identifier, $.label_name),
       ':',
       $._statement
     ),
@@ -679,7 +679,7 @@ module.exports = grammar({
     local_function_statement: $ => seq(
       repeat($.modifier),
       $.return_type,
-      $.identifier_name,
+      $.identifier,
       optional($.type_parameter_list),
       $.parameter_list,
       repeat($.type_parameter_constraints_clause),
@@ -731,7 +731,7 @@ module.exports = grammar({
     _variable_designation: $ => choice(
       $.discard,
       $.parenthesized_variable_designation,
-      $.identifier_name
+      $.identifier
     ),
 
     discard: $ => '_',
@@ -788,7 +788,7 @@ module.exports = grammar({
       $.block
     ),
 
-    catch_declaration: $ => seq('(', $._type, optional($.identifier_name), ')'),
+    catch_declaration: $ => seq('(', $._type, optional($.identifier), ')'),
 
     catch_filter_clause: $ => seq('when', '(', $._expression, ')'),
 
@@ -825,7 +825,7 @@ module.exports = grammar({
 
     lambda_expression: $ => prec(-1, seq(
       optional('async'),
-      choice($.parameter_list, $.identifier_name),
+      choice($.parameter_list, $.identifier),
       '=>',
       choice($.block, $._expression)
     )),
@@ -1024,7 +1024,7 @@ module.exports = grammar({
     from_clause: $ => seq(
       'from',
       optional($._type),
-      $.identifier_name,
+      $.identifier,
       'in',
       $._expression
     ),
@@ -1046,7 +1046,7 @@ module.exports = grammar({
     join_clause: $ => seq(
       'join',
       optional($._type),
-      $.identifier_name,
+      $.identifier,
       'in',
       $._expression,
       'on',
@@ -1056,11 +1056,11 @@ module.exports = grammar({
       optional($.join_into_clause)
     ),
 
-    join_into_clause: $ => seq('into', $.identifier_name),
+    join_into_clause: $ => seq('into', $.identifier),
 
     let_clause: $ => seq(
       'let',
-      $.identifier_name,
+      $.identifier,
       '=',
       $._expression
     ),
@@ -1091,7 +1091,7 @@ module.exports = grammar({
 
     select_clause: $ => prec.left(PREC.SELECT, seq('select', $._expression)),
 
-    query_continuation: $ => seq('into', $.identifier_name, $._query_body),
+    query_continuation: $ => seq('into', $.identifier, $._query_body),
 
     range_expression: $ => prec.right(seq(
       optional($._expression),
@@ -1207,8 +1207,8 @@ module.exports = grammar({
       $._type,
 
       // These should be reconsidered when the ones above get activated
-      alias($._reserved_identifier, $.identifier_name),
-      $.identifier_name,
+      alias($._reserved_identifier, $.identifier),
+      $.identifier,
 
       // Literals
       $.null_literal,

--- a/grammar.js
+++ b/grammar.js
@@ -37,15 +37,15 @@ module.exports = grammar({
     [$.event_declaration, $.variable_declarator],
 
     [$._expression, $.declaration_pattern],
-    [$._expression, $._identifier_or_global],
-    [$._expression, $._identifier_or_global, $.generic_name],
-    [$._expression, $._identifier_or_global, $.parameter],
+    [$._expression, $._simple_name],
+    [$._expression, $._simple_name, $.generic_name],
+    [$._expression, $._simple_name, $.parameter],
 
     [$.from_clause, $._reserved_identifier],
 
-    [$._identifier_or_global, $.enum_member_declaration],
-    [$._identifier_or_global, $.type_parameter],
-    [$._identifier_or_global, $.generic_name],
+    [$._simple_name, $.enum_member_declaration],
+    [$._simple_name, $.type_parameter],
+    [$._simple_name, $.generic_name],
 
     [$.qualified_name, $.explicit_interface_specifier],
 
@@ -57,7 +57,8 @@ module.exports = grammar({
   ],
 
   inline: $ => [
-    $.return_type
+    $.return_type,
+    $._identifier_or_global,
   ],
 
   word: $ => $.identifier_name,
@@ -102,7 +103,8 @@ module.exports = grammar({
     name_equals: $ => prec(1, seq($._identifier_or_global, '=')),
 
     identifier_name: $ => token(seq(optional('@'), /[a-zA-Z_][a-zA-Z_0-9]*/)), // identifier_token in Roslyn
-    _identifier_or_global: $ => choice('global', $.identifier_name), // identifier_name in Roslyn
+    global: $ => 'global',
+    _identifier_or_global: $ => choice($.global, $.identifier_name),
 
     _name: $ => choice(
       $.alias_qualified_name,

--- a/grammar.js
+++ b/grammar.js
@@ -731,7 +731,7 @@ module.exports = grammar({
     _variable_designation: $ => choice(
       $.discard,
       $.parenthesized_variable_designation,
-      $.single_variable_designation
+      $.identifier_name
     ),
 
     discard: $ => '_',
@@ -741,8 +741,6 @@ module.exports = grammar({
       commaSep($._variable_designation),
       ')'
     ),
-
-    single_variable_designation: $ => $.identifier_name,
 
     // TODO: Matches everything as optional which won't work.
     // Figure out valid combinations with at least one item to remove ambiguity.

--- a/grammar.js
+++ b/grammar.js
@@ -1283,16 +1283,14 @@ module.exports = grammar({
       /\\[^xuU]/,
     )),
 
-    integer_literal: $ => seq(
+    integer_literal: $ => token(seq(
       choice(
         (/[0-9_]+/), // Decimal
         (/0[xX][0-9a-fA-F_]+/), // Hex
         (/0[bB][01_]+/) // Binary
       ),
-      optional($._integer_type_suffix)
-    ),
-
-    _integer_type_suffix: $ => (/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/),
+      optional(/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/)
+    )),
 
     null_literal: $ => 'null',
 

--- a/grammar.js
+++ b/grammar.js
@@ -701,7 +701,7 @@ module.exports = grammar({
     ),
 
     switch_section: $ => prec.left(seq(
-      repeat1(choice(
+      repeat1(choice( // switch_label
         $.case_switch_label,
         $.case_pattern_switch_label,
         $.default_switch_label
@@ -1162,8 +1162,6 @@ module.exports = grammar({
     // TODO: Expressions need work on precedence and conflicts.
 
     _expression: $ => choice(
-      // $.declaration_expression,
-      //$.is_expression,
       $.anonymous_method_expression,
       $.anonymous_object_creation_expression,
       $.array_creation_expression,
@@ -1175,6 +1173,7 @@ module.exports = grammar({
       $.checked_expression,
       $.conditional_access_expression,
       $.conditional_expression,
+      // $.declaration_expression,
       $.default_expression,
       $.element_access_expression,
       $.element_binding_expression,
@@ -1206,19 +1205,16 @@ module.exports = grammar({
       $.type_of_expression,
       $._type,
 
-      // These should be reconsidered when the ones above get activated
-      alias($._reserved_identifier, $.identifier),
       $.identifier,
+      alias($._reserved_identifier, $.identifier),
 
       // Literals
       $.null_literal,
       $.boolean_literal,
       $.character_literal,
-      // We don't bunch real and integer literals together
-      $.real_literal,
+      $.real_literal, // Don't combine real and integer literals together
       $.integer_literal,
-      // Or strings and verbatim strings
-      $.string_literal,
+      $.string_literal, // Or strings and verbatim strings
       $.verbatim_string_literal
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -63,27 +63,28 @@ module.exports = grammar({
 
   rules: {
     // Intentionally deviates from spec so that we can syntax highlight fragments of code
-    compilation_unit: $ => repeat(
-      choice(
-        $.global_attribute_list,
-        $.class_declaration,
-        $.constructor_declaration,
-        $.conversion_operator_declaration,
-        $.delegate_declaration,
-        $.destructor_declaration,
-        $.enum_declaration,
-        $.event_declaration,
-        $.extern_alias_directive,
-        $._base_field_declaration,
-        $.indexer_declaration,
-        $.interface_declaration,
-        $.method_declaration,
-        $.namespace_declaration,
-        $.operator_declaration,
-        $.property_declaration,
-        $.struct_declaration,
-        $.using_directive,
-        )
+    compilation_unit: $ => repeat($._declaration),
+
+    _declaration: $ => choice(
+      $.global_attribute_list,
+      $.class_declaration,
+      $.constructor_declaration,
+      $.conversion_operator_declaration,
+      $.delegate_declaration,
+      $.destructor_declaration,
+      $.enum_declaration,
+      $.event_declaration,
+      $.extern_alias_directive,
+      $.event_field_declaration,
+      $.field_declaration,
+      $.indexer_declaration,
+      $.interface_declaration,
+      $.method_declaration,
+      $.namespace_declaration,
+      $.operator_declaration,
+      $.property_declaration,
+      $.struct_declaration,
+      $.using_directive,
     ),
 
     extern_alias_directive: $ => seq('extern', 'alias', $.identifier_name, ';'),
@@ -160,21 +161,6 @@ module.exports = grammar({
 
     name_colon: $ => seq($._identifier_or_global, ':'),
 
-    _member_declaration: $ => choice(
-      $._base_field_declaration,
-      $._base_method_declaration,
-      $._base_property_declaration,
-      $._base_type_declaration,
-      $.delegate_declaration,
-      $.enum_member_declaration,
-      $.namespace_declaration,
-    ),
-
-    _base_field_declaration: $ => choice(
-      $.event_field_declaration,
-      $.field_declaration
-    ),
-
     event_field_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
@@ -241,14 +227,6 @@ module.exports = grammar({
       repeat($.modifier),
       $.variable_declaration,
       ';'
-    ),
-
-    _base_method_declaration: $ => choice(
-      $.constructor_declaration,
-      $.conversion_operator_declaration,
-      $.destructor_declaration,
-      $.method_declaration,
-      $.operator_declaration
     ),
 
     constructor_declaration: $ => seq(
@@ -395,12 +373,6 @@ module.exports = grammar({
       '>=', '<='
     ),
 
-    _base_property_declaration: $ => choice(
-      $.event_declaration,
-      $.indexer_declaration,
-      $.property_declaration
-    ),
-
     event_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
@@ -454,37 +426,29 @@ module.exports = grammar({
       ),
     ),
 
-    _base_type_declaration: $ => choice(
-      $.enum_declaration,
-      $._type_declaration,
-    ),
-
     enum_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
       'enum',
       $.identifier_name,
       optional($.base_list),
+      $.enum_member_declaration_list,
+      optional(';')
+    ),
+
+    base_list: $ => seq(':', commaSep1($._type)),
+
+    enum_member_declaration_list: $ => seq(
       '{',
       commaSep($.enum_member_declaration),
       optional(','),
       '}',
-      optional(';')
     ),
-
-    base_list: $ => seq(':', commaSep1($._base_type)),
-    _base_type: $ => $._type,
 
     enum_member_declaration: $ => seq(
       repeat($.attribute_list),
       $.identifier_name,
       optional(seq('=', $._expression))
-    ),
-
-    _type_declaration: $ => choice(
-      $.class_declaration,
-      $.interface_declaration,
-      $.struct_declaration
     ),
 
     class_declaration: $ => seq(
@@ -495,13 +459,13 @@ module.exports = grammar({
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
-      $.class_body,
+      $.declaration_list,
       optional(';')
     ),
 
-    class_body: $ => seq(
+    declaration_list: $ => seq(
       '{',
-      repeat($._member_declaration),
+      repeat($._declaration),
       '}'
     ),
 
@@ -513,7 +477,7 @@ module.exports = grammar({
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
-      $.class_body,
+      $.declaration_list,
       optional(';')
     ),
 
@@ -525,7 +489,7 @@ module.exports = grammar({
       optional($.type_parameter_list),
       optional($.base_list),
       repeat($.type_parameter_constraints_clause),
-      $.class_body,
+      $.declaration_list,
       optional(';')
     ),
 
@@ -544,11 +508,7 @@ module.exports = grammar({
     namespace_declaration: $ => seq(
       'namespace',
       $._name,
-      '{',
-      repeat($.extern_alias_directive),
-      repeat($.using_directive),
-      repeat($._member_declaration),
-      '}',
+      $.declaration_list,
       optional(';')
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -986,7 +986,6 @@ module.exports = grammar({
     )),
 
     _literal_expression: $ => choice(
-      '__arglist',
       $.null_literal,
       $.boolean_literal,
       $.character_literal,

--- a/grammar.js
+++ b/grammar.js
@@ -719,7 +719,7 @@ module.exports = grammar({
     _pattern: $ => choice(
       $.constant_pattern,
       $.declaration_pattern,
-      $.discard_pattern,
+      $.discard,
 //      $.recursive_pattern,
       $.var_pattern
     ),
@@ -729,12 +729,12 @@ module.exports = grammar({
     declaration_pattern: $ => seq($._type, $._variable_designation),
 
     _variable_designation: $ => choice(
-      $.discard_designation,
+      $.discard,
       $.parenthesized_variable_designation,
       $.single_variable_designation
     ),
 
-    discard_designation: $ => '_',
+    discard: $ => '_',
 
     parenthesized_variable_designation: $ => seq(
       '(',
@@ -743,8 +743,6 @@ module.exports = grammar({
     ),
 
     single_variable_designation: $ => $.identifier_name,
-
-    discard_pattern: $ => '_',
 
     // TODO: Matches everything as optional which won't work.
     // Figure out valid combinations with at least one item to remove ambiguity.

--- a/grammar.js
+++ b/grammar.js
@@ -52,8 +52,6 @@ module.exports = grammar({
     [$._type, $.array_creation_expression],
     [$._type, $.stack_alloc_array_creation_expression],
     [$._type, $.attribute],
-
-    [$.switch_section]
   ],
 
   inline: $ => [
@@ -742,13 +740,14 @@ module.exports = grammar({
       '}'
     ),
 
-    switch_section: $ => seq(repeat1($._switch_label), repeat1($._statement)),
-
-    _switch_label: $ => choice(
-      $.case_switch_label,
-      $.case_pattern_switch_label,
-      $.default_switch_label
-    ),
+    switch_section: $ => prec.left(seq(
+      repeat1(choice(
+        $.case_switch_label,
+        $.case_pattern_switch_label,
+        $.default_switch_label
+      )),
+      repeat1($._statement)
+    )),
 
     case_pattern_switch_label: $ => seq(
       'case',

--- a/grammar.txt
+++ b/grammar.txt
@@ -16,10 +16,10 @@ using_directive
   ;
 
 name_equals
-  : identifier_name '='
+  : identifier '='
   ;
 
-identifier_name
+identifier
   : 'global'
   | identifier_token
   ;
@@ -31,12 +31,12 @@ name
   ;
 
 alias_qualified_name
-  : identifier_name '::' simple_name
+  : identifier '::' simple_name
   ;
 
 simple_name
   : generic_name
-  | identifier_name
+  | identifier
   ;
 
 generic_name
@@ -72,7 +72,7 @@ attribute_argument
   ;
 
 name_colon
-  : identifier_name ':'
+  : identifier ':'
   ;
 
 member_declaration
@@ -203,7 +203,7 @@ type_parameter
   ;
 
 type_parameter_constraint_clause
-  : 'where' identifier_name ':' type_parameter_constraint (',' type_parameter_constraint)*
+  : 'where' identifier ':' type_parameter_constraint (',' type_parameter_constraint)*
   ;
 
 type_parameter_constraint
@@ -452,10 +452,10 @@ fixed_statement
 for_statement
   : 'for'
     '('
-     (variable_declaration? | (expression (',' expression)*)?) 
+     (variable_declaration? | (expression (',' expression)*)?)
      ';'
-     expression? 
-     ';' 
+     expression?
+     ';'
      (expression (',' expression)*)?
      ')'
      statement
@@ -1061,7 +1061,7 @@ type_cref
   ;
 
 xml_name_attribute
-  : xml_name '=' ('\'' | '"') identifier_name ('\'' | '"')
+  : xml_name '=' ('\'' | '"') identifier ('\'' | '"')
   ;
 
 xml_text_attribute

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6181,6 +6181,10 @@
           "name": "_type"
         },
         {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
@@ -6188,10 +6192,6 @@
           },
           "named": true,
           "value": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5,82 +5,90 @@
     "compilation_unit": {
       "type": "REPEAT",
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "global_attribute_list"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "class_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "constructor_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "conversion_operator_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "delegate_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "destructor_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "enum_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "event_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "extern_alias_directive"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_base_field_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "indexer_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "interface_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "method_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "namespace_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "operator_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "property_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "struct_declaration"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "using_directive"
-          }
-        ]
+        "type": "SYMBOL",
+        "name": "_declaration"
       }
+    },
+    "_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "global_attribute_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constructor_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conversion_operator_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "delegate_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "destructor_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "event_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "extern_alias_directive"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "event_field_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "indexer_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interface_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "method_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "namespace_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "property_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "using_directive"
+        }
+      ]
     },
     "extern_alias_directive": {
       "type": "SEQ",
@@ -182,12 +190,16 @@
         ]
       }
     },
+    "global": {
+      "type": "STRING",
+      "value": "global"
+    },
     "_identifier_or_global": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "global"
+          "type": "SYMBOL",
+          "name": "global"
         },
         {
           "type": "SYMBOL",
@@ -591,52 +603,6 @@
         }
       ]
     },
-    "_member_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_base_field_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_base_method_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_base_property_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_base_type_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "delegate_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "enum_member_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "namespace_declaration"
-        }
-      ]
-    },
-    "_base_field_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "event_field_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "field_declaration"
-        }
-      ]
-    },
     "event_field_declaration": {
       "type": "SEQ",
       "members": [
@@ -972,31 +938,6 @@
         {
           "type": "STRING",
           "value": ";"
-        }
-      ]
-    },
-    "_base_method_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "constructor_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "conversion_operator_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "destructor_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "method_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator_declaration"
         }
       ]
     },
@@ -1814,23 +1755,6 @@
         }
       ]
     },
-    "_base_property_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "event_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "indexer_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "property_declaration"
-        }
-      ]
-    },
     "event_declaration": {
       "type": "SEQ",
       "members": [
@@ -2149,19 +2073,6 @@
         }
       ]
     },
-    "_base_type_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "enum_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_type_declaration"
-        }
-      ]
-    },
     "enum_declaration": {
       "type": "SEQ",
       "members": [
@@ -2199,6 +2110,61 @@
             }
           ]
         },
+        {
+          "type": "SYMBOL",
+          "name": "enum_member_declaration_list"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "base_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_type"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "enum_member_declaration_list": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "STRING",
           "value": "{"
@@ -2251,58 +2217,8 @@
         {
           "type": "STRING",
           "value": "}"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ";"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
-    },
-    "base_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": ":"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_base_type"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_base_type"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    "_base_type": {
-      "type": "SYMBOL",
-      "name": "_type"
     },
     "enum_member_declaration": {
       "type": "SEQ",
@@ -2338,23 +2254,6 @@
               "type": "BLANK"
             }
           ]
-        }
-      ]
-    },
-    "_type_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "class_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interface_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "struct_declaration"
         }
       ]
     },
@@ -2416,7 +2315,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "class_body"
+          "name": "declaration_list"
         },
         {
           "type": "CHOICE",
@@ -2432,7 +2331,7 @@
         }
       ]
     },
-    "class_body": {
+    "declaration_list": {
       "type": "SEQ",
       "members": [
         {
@@ -2443,7 +2342,7 @@
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "_member_declaration"
+            "name": "_declaration"
           }
         },
         {
@@ -2510,7 +2409,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "class_body"
+          "name": "declaration_list"
         },
         {
           "type": "CHOICE",
@@ -2584,7 +2483,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "class_body"
+          "name": "declaration_list"
         },
         {
           "type": "CHOICE",
@@ -2670,33 +2569,8 @@
           "name": "_name"
         },
         {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "extern_alias_directive"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "using_directive"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_member_declaration"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "declaration_list"
         },
         {
           "type": "CHOICE",
@@ -3703,40 +3577,40 @@
       ]
     },
     "switch_section": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_switch_label"
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "case_switch_label"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "case_pattern_switch_label"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "default_switch_label"
+                }
+              ]
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_statement"
+            }
           }
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
-        }
-      ]
-    },
-    "_switch_label": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "case_switch_label"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "case_pattern_switch_label"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "default_switch_label"
-        }
-      ]
+        ]
+      }
     },
     "case_pattern_switch_label": {
       "type": "SEQ",
@@ -3780,7 +3654,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "discard_pattern"
+          "name": "discard"
         },
         {
           "type": "SYMBOL",
@@ -3814,7 +3688,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "discard_designation"
+          "name": "discard"
         },
         {
           "type": "SYMBOL",
@@ -3822,11 +3696,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "single_variable_designation"
+          "name": "identifier_name"
         }
       ]
     },
-    "discard_designation": {
+    "discard": {
       "type": "STRING",
       "value": "_"
     },
@@ -3875,14 +3749,6 @@
           "value": ")"
         }
       ]
-    },
-    "single_variable_designation": {
-      "type": "SYMBOL",
-      "name": "identifier_name"
-    },
-    "discard_pattern": {
-      "type": "STRING",
-      "value": "_"
     },
     "recursive_pattern": {
       "type": "SEQ",
@@ -4391,19 +4257,6 @@
         {
           "type": "STRING",
           "value": ";"
-        }
-      ]
-    },
-    "_anonymous_function_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "anonymous_method_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "lambda_expression"
         }
       ]
     },
@@ -4996,19 +4849,6 @@
         }
       ]
     },
-    "_instance_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "base_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "this_expression"
-        }
-      ]
-    },
     "base_expression": {
       "type": "STRING",
       "value": "base"
@@ -5225,43 +5065,6 @@
           }
         ]
       }
-    },
-    "_literal_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "__arglist"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "null_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "boolean_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "character_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "real_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "integer_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "verbatim_string_literal"
-        }
-      ]
     },
     "make_ref_expression": {
       "type": "SEQ",
@@ -6215,7 +6018,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_anonymous_function_expression"
+          "name": "anonymous_method_expression"
         },
         {
           "type": "SYMBOL",
@@ -6232,6 +6035,10 @@
         {
           "type": "SYMBOL",
           "name": "await_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "base_expression"
         },
         {
           "type": "SYMBOL",
@@ -6279,10 +6086,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_instance_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "interpolated_string_expression"
         },
         {
@@ -6295,7 +6098,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_literal_expression"
+          "name": "lambda_expression"
         },
         {
           "type": "SYMBOL",
@@ -6359,6 +6162,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "this_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "throw_expression"
         },
         {
@@ -6367,11 +6174,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_type"
+          "name": "type_of_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "type_of_expression"
+          "name": "_type"
         },
         {
           "type": "ALIAS",
@@ -6385,6 +6192,34 @@
         {
           "type": "SYMBOL",
           "name": "identifier_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "null_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "boolean_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "real_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "verbatim_string_literal"
         }
       ]
     },
@@ -6858,8 +6693,11 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "PATTERN",
-              "value": "[^'\\\\]"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[^'\\\\]"
+              }
             },
             {
               "type": "SYMBOL",
@@ -6898,42 +6736,41 @@
       }
     },
     "integer_literal": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "[0-9_]+"
-            },
-            {
-              "type": "PATTERN",
-              "value": "0[xX][0-9a-fA-F_]+"
-            },
-            {
-              "type": "PATTERN",
-              "value": "0[bB][01_]+"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_integer_type_suffix"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_integer_type_suffix": {
-      "type": "PATTERN",
-      "value": "u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[0-9_]+"
+              },
+              {
+                "type": "PATTERN",
+                "value": "0[xX][0-9a-fA-F_]+"
+              },
+              {
+                "type": "PATTERN",
+                "value": "0[bB][01_]+"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "null_literal": {
       "type": "STRING",
@@ -7357,16 +7194,16 @@
     ],
     [
       "_expression",
-      "_identifier_or_global"
+      "_simple_name"
     ],
     [
       "_expression",
-      "_identifier_or_global",
+      "_simple_name",
       "generic_name"
     ],
     [
       "_expression",
-      "_identifier_or_global",
+      "_simple_name",
       "parameter"
     ],
     [
@@ -7374,15 +7211,15 @@
       "_reserved_identifier"
     ],
     [
-      "_identifier_or_global",
+      "_simple_name",
       "enum_member_declaration"
     ],
     [
-      "_identifier_or_global",
+      "_simple_name",
       "type_parameter"
     ],
     [
-      "_identifier_or_global",
+      "_simple_name",
       "generic_name"
     ],
     [
@@ -7400,14 +7237,12 @@
     [
       "_type",
       "attribute"
-    ],
-    [
-      "switch_section"
     ]
   ],
   "externals": [],
   "inline": [
-    "return_type"
+    "return_type",
+    "_identifier_or_global"
   ],
   "supertypes": []
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,6 @@
 {
   "name": "c_sharp",
-  "word": "identifier_name",
+  "word": "identifier",
   "rules": {
     "compilation_unit": {
       "type": "REPEAT",
@@ -103,7 +103,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "STRING",
@@ -166,7 +166,7 @@
         ]
       }
     },
-    "identifier_name": {
+    "identifier": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -203,7 +203,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         }
       ]
     },
@@ -259,7 +259,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -758,7 +758,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -892,7 +892,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "identifier_name"
+                    "name": "identifier"
                   }
                 ]
               }
@@ -960,7 +960,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -1088,7 +1088,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -1149,7 +1149,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         }
       ]
     },
@@ -1360,7 +1360,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -1407,7 +1407,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -1531,7 +1531,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         }
       ]
     },
@@ -1794,7 +1794,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -1869,7 +1869,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "identifier_name"
+              "name": "identifier"
             }
           ]
         },
@@ -2017,7 +2017,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2096,7 +2096,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2232,7 +2232,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2280,7 +2280,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2374,7 +2374,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2448,7 +2448,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2526,7 +2526,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -2867,7 +2867,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier_name"
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -3251,7 +3251,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "identifier_name"
+                  "name": "identifier"
                 }
               ]
             },
@@ -3293,7 +3293,7 @@
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
-                "name": "identifier_name"
+                "name": "identifier"
               },
               "named": true,
               "value": "label_name"
@@ -3384,7 +3384,7 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier_name"
+            "name": "identifier"
           },
           "named": true,
           "value": "label_name"
@@ -3459,7 +3459,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "CHOICE",
@@ -3696,7 +3696,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         }
       ]
     },
@@ -4094,7 +4094,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier_name"
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -4324,7 +4324,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier_name"
+                "name": "identifier"
               }
             ]
           },
@@ -5396,7 +5396,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "STRING",
@@ -5486,7 +5486,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "STRING",
@@ -5535,7 +5535,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         }
       ]
     },
@@ -5548,7 +5548,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "STRING",
@@ -5701,7 +5701,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -6187,11 +6187,11 @@
             "name": "_reserved_identifier"
           },
           "named": true,
-          "value": "identifier_name"
+          "value": "identifier"
         },
         {
           "type": "SYMBOL",
-          "name": "identifier_name"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -20,7 +20,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -47,7 +47,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -161,7 +161,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -404,7 +404,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -681,7 +681,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -860,7 +860,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -975,7 +975,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1218,7 +1218,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1398,7 +1398,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1497,7 +1497,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1783,7 +1783,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -1963,7 +1963,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -2078,7 +2078,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -2495,7 +2495,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -2734,7 +2734,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -2932,7 +2932,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -3047,7 +3047,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -3301,7 +3301,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -3487,7 +3487,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -3681,7 +3681,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -3920,7 +3920,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4159,7 +4159,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4339,7 +4339,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4410,7 +4410,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4560,7 +4560,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4615,7 +4615,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4675,7 +4675,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4742,7 +4742,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -4885,7 +4885,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -5180,7 +5180,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -5478,7 +5478,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -5581,7 +5581,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -5835,7 +5835,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -6022,7 +6022,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -6096,7 +6096,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -6195,7 +6195,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -6354,7 +6354,7 @@
       "required": true,
       "types": [
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -6642,7 +6642,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -6977,7 +6977,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -7272,7 +7272,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -7431,7 +7431,7 @@
       "required": true,
       "types": [
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -7545,7 +7545,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -7788,7 +7788,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -8075,7 +8075,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -8357,7 +8357,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -8476,7 +8476,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -8647,7 +8647,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -8797,7 +8797,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -9044,7 +9044,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -9292,7 +9292,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -9543,7 +9543,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -9786,7 +9786,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -9949,7 +9949,7 @@
       "required": true,
       "types": [
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -10159,7 +10159,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -10402,7 +10402,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -10604,7 +10604,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -10783,7 +10783,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11074,7 +11074,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11313,7 +11313,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11480,7 +11480,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -11527,7 +11527,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11591,7 +11591,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -11610,7 +11610,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -11641,7 +11641,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11676,7 +11676,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11731,7 +11731,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11798,7 +11798,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -11921,7 +11921,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12104,7 +12104,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12151,7 +12151,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -12270,7 +12270,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12433,7 +12433,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12468,7 +12468,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12598,7 +12598,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -12842,7 +12842,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13097,7 +13097,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13287,7 +13287,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13314,7 +13314,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13476,7 +13476,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13715,7 +13715,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -13954,7 +13954,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -14193,7 +14193,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -14432,7 +14432,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -14671,7 +14671,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -14846,7 +14846,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -14927,7 +14927,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -15065,7 +15065,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -15320,7 +15320,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -15686,7 +15686,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -15934,7 +15934,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16173,7 +16173,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16371,7 +16371,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16437,7 +16437,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16488,7 +16488,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16539,7 +16539,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16578,7 +16578,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -16616,7 +16616,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16677,7 +16677,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -16824,7 +16824,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -17043,7 +17043,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -17078,7 +17078,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -17125,7 +17125,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         }
       ]
@@ -17220,7 +17220,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -17459,7 +17459,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -17742,7 +17742,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -18033,7 +18033,7 @@
           "named": true
         },
         {
-          "type": "identifier_name",
+          "type": "identifier",
           "named": true
         },
         {
@@ -18576,7 +18576,7 @@
     "named": false
   },
   {
-    "type": "identifier_name",
+    "type": "identifier",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,10 +36,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -150,6 +154,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -313,7 +321,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -389,6 +397,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -665,6 +677,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -840,6 +856,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -872,7 +892,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -948,6 +968,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -1190,6 +1214,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -1351,7 +1379,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -1363,6 +1391,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -1382,7 +1414,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -1458,6 +1490,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -1664,7 +1700,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -1740,6 +1776,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -1904,7 +1944,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -1916,6 +1956,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -1951,7 +1995,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -2027,6 +2071,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -2344,7 +2392,7 @@
           "named": true
         },
         {
-          "type": "discard_pattern",
+          "type": "discard",
           "named": true
         },
         {
@@ -2364,7 +2412,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -2440,6 +2488,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -2599,7 +2651,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -2675,6 +2727,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -2857,7 +2913,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -2869,6 +2925,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -2904,7 +2964,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -2980,6 +3040,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -3154,7 +3218,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -3230,6 +3294,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -3399,85 +3467,6 @@
     }
   },
   {
-    "type": "class_body",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "class_declaration",
-          "named": true
-        },
-        {
-          "type": "constructor_declaration",
-          "named": true
-        },
-        {
-          "type": "conversion_operator_declaration",
-          "named": true
-        },
-        {
-          "type": "delegate_declaration",
-          "named": true
-        },
-        {
-          "type": "destructor_declaration",
-          "named": true
-        },
-        {
-          "type": "enum_declaration",
-          "named": true
-        },
-        {
-          "type": "enum_member_declaration",
-          "named": true
-        },
-        {
-          "type": "event_declaration",
-          "named": true
-        },
-        {
-          "type": "event_field_declaration",
-          "named": true
-        },
-        {
-          "type": "field_declaration",
-          "named": true
-        },
-        {
-          "type": "indexer_declaration",
-          "named": true
-        },
-        {
-          "type": "interface_declaration",
-          "named": true
-        },
-        {
-          "type": "method_declaration",
-          "named": true
-        },
-        {
-          "type": "namespace_declaration",
-          "named": true
-        },
-        {
-          "type": "operator_declaration",
-          "named": true
-        },
-        {
-          "type": "property_declaration",
-          "named": true
-        },
-        {
-          "type": "struct_declaration",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "class_declaration",
     "named": true,
     "fields": {},
@@ -3494,7 +3483,7 @@
           "named": true
         },
         {
-          "type": "class_body",
+          "type": "declaration_list",
           "named": true
         },
         {
@@ -3609,7 +3598,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -3685,6 +3674,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -3844,7 +3837,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -3920,6 +3913,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -4079,7 +4076,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -4155,6 +4152,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -4405,6 +4406,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -4440,6 +4445,93 @@
     }
   },
   {
+    "type": "declaration_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "constructor_declaration",
+          "named": true
+        },
+        {
+          "type": "conversion_operator_declaration",
+          "named": true
+        },
+        {
+          "type": "delegate_declaration",
+          "named": true
+        },
+        {
+          "type": "destructor_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "event_declaration",
+          "named": true
+        },
+        {
+          "type": "event_field_declaration",
+          "named": true
+        },
+        {
+          "type": "extern_alias_directive",
+          "named": true
+        },
+        {
+          "type": "field_declaration",
+          "named": true
+        },
+        {
+          "type": "global_attribute_list",
+          "named": true
+        },
+        {
+          "type": "indexer_declaration",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "method_declaration",
+          "named": true
+        },
+        {
+          "type": "namespace_declaration",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        },
+        {
+          "type": "property_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "using_directive",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "declaration_pattern",
     "named": true,
     "fields": {},
@@ -4456,11 +4548,15 @@
           "named": true
         },
         {
-          "type": "discard_designation",
+          "type": "discard",
           "named": true
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -4490,10 +4586,6 @@
         {
           "type": "qualified_name",
           "named": true
-        },
-        {
-          "type": "single_variable_designation",
-          "named": true
         }
       ]
     }
@@ -4516,6 +4608,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -4572,6 +4668,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -4651,16 +4751,6 @@
         }
       ]
     }
-  },
-  {
-    "type": "discard_designation",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "discard_pattern",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "do_statement",
@@ -4784,6 +4874,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -5082,6 +5176,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -5376,7 +5474,7 @@
           "named": true
         },
         {
-          "type": "enum_member_declaration",
+          "type": "enum_member_declaration_list",
           "named": true
         },
         {
@@ -5476,6 +5574,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -5630,12 +5732,27 @@
     }
   },
   {
+    "type": "enum_member_declaration_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "enum_member_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "equals_value_clause",
     "named": true,
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -5711,6 +5828,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -5897,6 +6018,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -5956,7 +6081,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -5964,6 +6089,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -5983,7 +6112,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -6059,6 +6188,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -6501,6 +6634,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "goto_statement",
           "named": true
         },
@@ -6832,6 +6969,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "goto_statement",
           "named": true
         },
@@ -7127,6 +7268,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -7396,6 +7541,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -7556,7 +7705,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -7632,6 +7781,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -7911,6 +8064,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -8196,6 +8353,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -8308,6 +8469,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -8462,11 +8627,6 @@
     }
   },
   {
-    "type": "integer_literal",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "interface_declaration",
     "named": true,
     "fields": {},
@@ -8483,7 +8643,7 @@
           "named": true
         },
         {
-          "type": "class_body",
+          "type": "declaration_list",
           "named": true
         },
         {
@@ -8554,7 +8714,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -8630,6 +8790,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -8797,7 +8961,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -8873,6 +9037,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -9120,6 +9288,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -9351,7 +9523,7 @@
           "named": true
         },
         {
-          "type": "discard_pattern",
+          "type": "discard",
           "named": true
         },
         {
@@ -9364,6 +9536,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -9603,6 +9779,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -9975,6 +10155,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -10214,6 +10398,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -10412,6 +10600,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -10580,6 +10772,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -10795,7 +10991,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -10871,6 +11067,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11030,7 +11230,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -11106,6 +11306,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11265,10 +11469,14 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11312,6 +11520,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11372,8 +11584,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "global",
+          "named": true
+        },
         {
           "type": "identifier_name",
           "named": true
@@ -11387,8 +11603,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "global",
+          "named": true
+        },
         {
           "type": "identifier_name",
           "named": true
@@ -11402,54 +11622,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
           "named": true
         },
         {
-          "type": "class_declaration",
-          "named": true
-        },
-        {
-          "type": "constructor_declaration",
-          "named": true
-        },
-        {
-          "type": "conversion_operator_declaration",
-          "named": true
-        },
-        {
-          "type": "delegate_declaration",
-          "named": true
-        },
-        {
-          "type": "destructor_declaration",
-          "named": true
-        },
-        {
-          "type": "enum_declaration",
-          "named": true
-        },
-        {
-          "type": "enum_member_declaration",
-          "named": true
-        },
-        {
-          "type": "event_declaration",
-          "named": true
-        },
-        {
-          "type": "event_field_declaration",
-          "named": true
-        },
-        {
-          "type": "extern_alias_directive",
-          "named": true
-        },
-        {
-          "type": "field_declaration",
+          "type": "declaration_list",
           "named": true
         },
         {
@@ -11457,43 +11637,15 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
         {
-          "type": "indexer_declaration",
-          "named": true
-        },
-        {
-          "type": "interface_declaration",
-          "named": true
-        },
-        {
-          "type": "method_declaration",
-          "named": true
-        },
-        {
-          "type": "namespace_declaration",
-          "named": true
-        },
-        {
-          "type": "operator_declaration",
-          "named": true
-        },
-        {
-          "type": "property_declaration",
-          "named": true
-        },
-        {
           "type": "qualified_name",
-          "named": true
-        },
-        {
-          "type": "struct_declaration",
-          "named": true
-        },
-        {
-          "type": "using_directive",
           "named": true
         }
       ]
@@ -11505,7 +11657,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -11517,6 +11669,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11552,7 +11708,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -11568,6 +11724,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11634,6 +11794,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -11674,7 +11838,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -11750,6 +11914,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -11932,6 +12100,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -12015,7 +12187,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -12091,6 +12263,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -12253,15 +12429,15 @@
       "required": false,
       "types": [
         {
-          "type": "discard_designation",
+          "type": "discard",
+          "named": true
+        },
+        {
+          "type": "identifier_name",
           "named": true
         },
         {
           "type": "parenthesized_variable_designation",
-          "named": true
-        },
-        {
-          "type": "single_variable_designation",
           "named": true
         }
       ]
@@ -12273,7 +12449,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -12285,6 +12461,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -12335,7 +12515,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -12411,6 +12591,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -12575,7 +12759,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -12651,6 +12835,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -12905,6 +13093,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -13080,7 +13272,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -13088,6 +13280,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -13276,6 +13472,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -13432,7 +13632,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -13508,6 +13708,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -13667,7 +13871,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -13743,6 +13947,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -13902,7 +14110,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -13978,6 +14186,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -14216,6 +14428,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -14372,7 +14588,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -14448,6 +14664,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -14602,27 +14822,12 @@
     }
   },
   {
-    "type": "single_variable_designation",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier_name",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "size_of_expression",
     "named": true,
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -14634,6 +14839,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -14714,7 +14923,7 @@
           "named": true
         },
         {
-          "type": "class_body",
+          "type": "declaration_list",
           "named": true
         },
         {
@@ -14753,7 +14962,7 @@
           "named": true
         },
         {
-          "type": "discard_pattern",
+          "type": "discard",
           "named": true
         },
         {
@@ -14773,7 +14982,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -14849,6 +15058,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -15087,7 +15300,7 @@
           "named": true
         },
         {
-          "type": "discard_pattern",
+          "type": "discard",
           "named": true
         },
         {
@@ -15100,6 +15313,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -15386,7 +15603,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -15462,6 +15679,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -15630,7 +15851,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -15706,6 +15927,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -15944,6 +16169,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -16123,7 +16352,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -16135,6 +16364,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16200,6 +16433,10 @@
           "named": true
         },
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -16232,7 +16469,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -16244,6 +16481,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16279,7 +16520,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -16291,6 +16532,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16367,6 +16612,10 @@
       "required": true,
       "types": [
         {
+          "type": "global",
+          "named": true
+        },
+        {
           "type": "identifier_name",
           "named": true
         },
@@ -16413,7 +16662,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -16421,6 +16670,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16560,6 +16813,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16782,15 +17039,15 @@
       "required": true,
       "types": [
         {
-          "type": "discard_designation",
+          "type": "discard",
+          "named": true
+        },
+        {
+          "type": "identifier_name",
           "named": true
         },
         {
           "type": "parenthesized_variable_designation",
-          "named": true
-        },
-        {
-          "type": "single_variable_designation",
           "named": true
         }
       ]
@@ -16814,6 +17071,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -16876,7 +17137,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -16952,6 +17213,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -17111,7 +17376,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "alias_qualified_name",
@@ -17187,6 +17452,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -17462,6 +17731,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -17753,6 +18026,10 @@
         },
         {
           "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
           "named": true
         },
         {
@@ -18103,14 +18380,6 @@
     "named": false
   },
   {
-    "type": "_",
-    "named": false
-  },
-  {
-    "type": "__arglist",
-    "named": false
-  },
-  {
     "type": "__makeref",
     "named": false
   },
@@ -18219,6 +18488,10 @@
     "named": false
   },
   {
+    "type": "discard",
+    "named": true
+  },
+  {
     "type": "do",
     "named": false
   },
@@ -18292,7 +18565,7 @@
   },
   {
     "type": "global",
-    "named": false
+    "named": true
   },
   {
     "type": "goto",
@@ -18321,6 +18594,10 @@
   {
     "type": "int",
     "named": false
+  },
+  {
+    "type": "integer_literal",
+    "named": true
   },
   {
     "type": "interface",


### PR DESCRIPTION
### Motivation 

Thanks to the efforts of @damieng and @initram, this parser is now mostly complete, in the sense that it parses more 99.9% of example files without error, based on a sample of 5441 source files from [3 of the top C# repositories on GitHub](https://github.com/tree-sitter/tree-sitter-c-sharp/blob/3c8b2da4bee2bb6e5489e4ca1d56001845bdd400/script/fetch-examples#L17-L19). After all of these rapid changes, the parser has grown quite large. There are currently 5326 parse states. On my macbook, the parser currently takes **3.3 seconds** to compile, and produces a **4.6 MB** binary.

### Changes

In this PR, I've begun the effort at optimizing the parser for compilation time and binary size, so that it will be usable in a broader range of settings where code size may be a concern.

This optimization involves several kinds of changes:

* Eliminating hidden rules that always wrap one child and are only used in once place (e.g. `_base_field_declaration`). This improves both the binary size (due to fewer symbols and state) and the runtime performance (due to fewer hidden nodes being constructed).
* Using the `inlines` directive to effectively eliminate other hidden rules, which are undesirable for actual parsing, but are useful for avoiding duplication in the grammar (e.g. `_identifier_or_global`).
* Using the `token` function to ensure that certain tokens are indeed treated as single tokens (e.g. `integer_literal`).
* Avoiding duplication where possible (e.g. introducing the generic `declaration_list` rule for all curly-brace-delimited lists of declarations).
* Simplifying the state machine by, where possible, avoiding highly-specific multi-step sequences (e.g. the specific ordering of `extern_alias_directive`, `using_directive`, `_member_declaration` sequence within `namespace_declaration`), and replacing them with simple repeating lists.

### Results

There are now 2308 parse states. On my macbook, the parser now compiles in **1.5 seconds** and produces a **1.9 MB** binary.

*Note* - 1.9 MB may still seem pretty large. But once I enable [this feature](https://github.com/tree-sitter/tree-sitter/pull/334) by default, which I plan to do after the next stable Atom release, it'll go down to **805k**.

### Parse Tree Changes

There are a few small changes to the parse trees. Mainly, the `class_body` node has been renamed to `declaration_list`, which has been reused in more places. I think this is an improvement, as `class_body` was already used in non-class contexts, like interfaces.

### Notes

@damieng, @initram Now that the parser is pretty far along, we might want to start paying slight attention to the parser's size when making changes. If it's helpful, I usually just look at the first few lines of output from `git diff -- src/parser.c`, and look for how the `STATE_COUNT` has changed. Example:

```diff
-#define STATE_COUNT 2308
+#define STATE_COUNT 2508
```

Obviously, it's totally normal to increase the state count when adding support for new features. But when deciding whether or not a given restructuring is beneficial, it's worth weighing the state count as one of the tradeoffs.