### PR TITLE
Fix path to binding

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "ts_language_c_sharp_binding",
+      "target_name": "tree_sitter_c_sharp_binding",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "src"

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 try {
-  module.exports = require("./build/Release/ts_language_c_sharp_binding");
+  module.exports = require("./build/Release/tree_sitter_c_sharp_binding");
 } catch (error) {
   try {
-    module.exports = require("./build/Debug/ts_language_c_sharp_binding");
+    module.exports = require("./build/Debug/tree_sitter_c_sharp_binding");
   } catch (_) {
     throw error
   }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 try {
-  module.exports = require("./build/Release/tree_sitter_c_sharp_binding");
+  module.exports = require("./build/Release/ts_language_c_sharp_binding");
 } catch (error) {
   try {
-    module.exports = require("./build/Debug/tree_sitter_c_sharp_binding");
+    module.exports = require("./build/Debug/ts_language_c_sharp_binding");
   } catch (_) {
     throw error
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "tree-sitter-cli": "^0.16.0"
   },
   "scripts": {
-    "test": "tree-sitter test"
+    "test": "tree-sitter test && node test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+console.log("Trying to require index.js in JavaScript");
+require('.')
+console.log("Require successfull");


### PR DESCRIPTION
The filename of the binding has changed, resulting in an error when trying to import `tree-sitter-c-sharp`:
```
  Error {
    code: 'MODULE_NOT_FOUND',
    message: 'Cannot find module \'./build/Release/tree_sitter_c_sharp_binding\'',
  }
```

I have renamed the path in `index.js` and have confirmed this fixes the issue.

I also propose adding an integration test which tries to import the `tree-sitter` grammar(s) in JavaScript to prevent bugs like this from happening.