### PR TITLE
Support trailing commas in switch expressions.

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -815,6 +815,44 @@ void b() {
                   (discard)
                   (string_literal))))))))))
 
+============================
+switch expression with trailing comma
+============================
+
+void b() {
+  var r = operation switch {
+      1 => "one",
+      2 => "two",
+      _ => "more",
+  };
+}
+
+---
+
+(compilation_unit
+  (method_declaration
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (local_declaration_statement
+        (variable_declaration
+          (implicit_type)
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (switch_expression
+                (identifier)
+                (switch_expression_arm
+                  (constant_pattern (integer_literal))
+                  (string_literal))
+                (switch_expression_arm
+                  (constant_pattern (integer_literal))
+                  (string_literal))
+                (switch_expression_arm
+                  (discard)
+                  (string_literal))))))))))
+
 =====================================
 await Expression
 =====================================

--- a/grammar.js
+++ b/grammar.js
@@ -1192,7 +1192,8 @@ module.exports = grammar({
       $._expression,
       'switch',
       '{',
-      commaSep($.switch_expression_arm),
+        commaSep($.switch_expression_arm),
+        optional(','),
       '}',
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1192,8 +1192,8 @@ module.exports = grammar({
       $._expression,
       'switch',
       '{',
-        commaSep($.switch_expression_arm),
-        optional(','),
+      commaSep($.switch_expression_arm),
+      optional(','),
       '}',
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6389,6 +6389,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "}"
         }


### PR DESCRIPTION
This fixes a lot of errors in dotnet/roslyn. Fixes #70.