### PR TITLE
Improve tuple destructuring

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -899,6 +899,37 @@ class A {
               (identifier)))))))))
 
 =====================================
+Foreach with tuple pattern
+=====================================
+
+class A {
+  void Sample() {
+    foreach(var (x, y) in z)
+      q += x;
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list (method_declaration
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (for_each_statement
+          (implicit_type)
+          (tuple_pattern (identifier) (identifier))
+          (identifier)
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (assignment_operator)
+              (identifier)))))))))
+
+=====================================
 Unsafe statement
 =====================================
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1030,6 +1030,7 @@ class A {
     var (a, b) = c;
     (a, b) = c;
     var (a, _) = c;
+    var (a, (b, _)) = c;
   }
 }
 
@@ -1065,4 +1066,9 @@ class A {
             (implicit_type)
             (variable_declarator
               (tuple_pattern (identifier) (discard))
+              (equals_value_clause (identifier)))))
+          (local_declaration_statement (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (tuple_pattern (identifier) (tuple_pattern (identifier) (discard)))
               (equals_value_clause (identifier))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -670,7 +670,7 @@ module.exports = grammar({
       choice(
         seq(
           field('type', $._type),
-          field('left', $.identifier)
+          field('left', choice($.identifier, $.tuple_pattern)),
         ), // for_each_statement
         field('left', $._expression), // for_each_variable_statement
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -225,7 +225,7 @@ module.exports = grammar({
 
     tuple_pattern: $ => seq(
       '(',
-      commaSep1(choice($.identifier, $.discard)),
+      commaSep1(choice($.identifier, $.discard, $.tuple_pattern)),
       ')'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -824,6 +824,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "discard"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tuple_pattern"
                 }
               ]
             },
@@ -846,6 +850,10 @@
                       {
                         "type": "SYMBOL",
                         "name": "discard"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "tuple_pattern"
                       }
                     ]
                   }
@@ -3536,8 +3544,17 @@
                   "type": "FIELD",
                   "name": "left",
                   "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "tuple_pattern"
+                      }
+                    ]
                   }
                 }
               ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2101,6 +2101,10 @@
           {
             "type": "_expression",
             "named": true
+          },
+          {
+            "type": "tuple_pattern",
+            "named": true
           }
         ]
       },
@@ -4203,6 +4207,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "tuple_pattern",
           "named": true
         }
       ]


### PR DESCRIPTION
This patch does two things:
1) enables the `tuple_pattern` rule to match itself recursively, enabling tuple matches to nest;
2) augments the `foreach` statement to allow `tuple_pattern` to exist in associated `var` declarations.

Fixes #69. <!-- NICE -->