### PR TITLE
new patterns available in C# 9

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1407,3 +1407,66 @@ var x = name!.Length;
         (equals_value_clause
           (member_access_expression (postfix_unary_expression (identifier))
           (identifier)))))))
+
+=====================================
+Negated pattern
+=====================================
+
+var x = name is not null;
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression 
+            (identifier)
+            (negated_pattern
+              (constant_pattern (null_literal)))))))))
+
+=====================================
+Parenthesized pattern
+=====================================
+
+var x = name is (var a);
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression 
+            (identifier)
+            (parenthesized_pattern
+              (var_pattern (identifier)))))))))
+
+=====================================
+Pattern Combinators and relational pattern
+=====================================
+
+var x = c is < '0' or >= 'A' and <= 'Z';
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression 
+            (identifier)
+            (binary_pattern 
+              (relational_pattern (character_literal)) 
+              (binary_pattern 
+                (relational_pattern (character_literal))
+                (relational_pattern (character_literal))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -66,6 +66,7 @@ module.exports = grammar({
     [$.parameter, $._simple_name],
     [$.parameter, $._expression],
     [$.parameter, $.tuple_element, $.declaration_expression],
+    [$.parameter, $._variable_designation],
     [$.tuple_element, $.variable_declarator],
   ],
 
@@ -774,7 +775,35 @@ module.exports = grammar({
       $.declaration_pattern,
       $.discard,
 //      $.recursive_pattern,
-      $.var_pattern
+      $.var_pattern,
+      $.negated_pattern,
+      $.parenthesized_pattern,
+      $.relational_pattern,
+      $.binary_pattern
+    ),
+
+    parenthesized_pattern: $ => seq('(', $._pattern, ')'),
+
+    relational_pattern: $ => prec.left(choice(
+      seq('<', $._expression),
+      seq('<=', $._expression),
+      seq('>', $._expression),
+      seq('>=', $._expression)
+    )),
+
+    negated_pattern: $ => seq('not', $._pattern),
+
+    binary_pattern: $ => choice(
+      prec.left(PREC.AND, seq(
+        field('left', $._pattern),
+        field('operator', 'and'),
+        field('right', $._pattern)
+      )),
+      prec.left(PREC.OR, seq(
+        field('left', $._pattern),
+        field('operator', 'or'),
+        field('right', $._pattern)
+      )),
     ),
 
     constant_pattern: $ => prec.right($._expression),


### PR DESCRIPTION
implemented parenthesized pattern, negated pattern and binary pattern combinators 'and' and 'or'.

fixes #68 