### PR TITLE
Added support for @$"string"

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -377,6 +377,7 @@ interpolated verbatim string literals
 
 class A {
   string s = $@"hello";
+  string s = @$"hello";
 }
 
 ---
@@ -384,6 +385,14 @@ class A {
 (compilation_unit (class_declaration
   (identifier)
   (declaration_list
+    (field_declaration
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_verbatim_string_text))))))
     (field_declaration
       (variable_declaration
         (predefined_type)

--- a/grammar.js
+++ b/grammar.js
@@ -996,6 +996,7 @@ module.exports = grammar({
     interpolated_string_expression: $ => choice(
       seq('$"', repeat($._interpolated_string_content), '"'),
       seq('$@"', repeat($._interpolated_verbatim_string_content), '"'),
+      seq('@$"', repeat($._interpolated_verbatim_string_content), '"'),
     ),
 
     _interpolated_string_content: $ => choice(


### PR DESCRIPTION
This order of the symbols was a new feature in C# 8.

see https://github.com/tree-sitter/tree-sitter-c-sharp/issues/77#issuecomment-698772814