### PR TITLE
Allow whitespace between # and pre-proc, fixes #86

### DIFF
--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -104,4 +104,30 @@ class Of1879 {
       (block
         (preprocessor_call (preprocessor_directive) (integer_literal) (string_literal))
         (preprocessor_call (preprocessor_directive) (identifier))
-        (preprocessor_call (preprocessor_directive) (identifier))))))) 
+        (preprocessor_call (preprocessor_directive) (identifier)))))))
+
+===================================
+Whitespace before preprocessor statements
+===================================
+
+# if WIN32
+  string os = "Win32";
+# elif MACOS
+  string os = "MacOS";
+#     endif
+
+---
+
+(compilation_unit
+  (preprocessor_call (preprocessor_directive) (identifier))
+  (field_declaration
+    (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (string_literal)))))
+  (preprocessor_call (preprocessor_directive) (identifier))
+  (field_declaration
+    (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (string_literal)))))
+  (preprocessor_call (preprocessor_directive)))
+

--- a/grammar.js
+++ b/grammar.js
@@ -1461,6 +1461,7 @@ module.exports = grammar({
     void_keyword: $ => 'void',
 
     preprocessor_call: $ => seq(
+      '#',
       $.preprocessor_directive,
       repeat(choice(
         $.identifier,
@@ -1470,7 +1471,7 @@ module.exports = grammar({
       $._preproc_directive_end
     ),
 
-    preprocessor_directive: $ => /#[a-z]\w*/,
+    preprocessor_directive: $ => /[a-z]+/,
   }
 })
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8095,6 +8095,10 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "STRING",
+          "value": "#"
+        },
+        {
           "type": "SYMBOL",
           "name": "preprocessor_directive"
         },
@@ -8133,7 +8137,7 @@
     },
     "preprocessor_directive": {
       "type": "PATTERN",
-      "value": "#[a-z]\\w*"
+      "value": "[a-z]+"
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4850,6 +4850,10 @@
     "named": false
   },
   {
+    "type": "#",
+    "named": false
+  },
+  {
     "type": "$\"",
     "named": false
   },


### PR DESCRIPTION
Now allows whitespace between the # sign and the directive.