### PR TITLE
Changed initializer_expression to not be a top level expression

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -200,12 +200,13 @@ void b() {
               (anonymous_object_creation_expression (identifier)))))))))
 
 ============================
-Anonymous object creation with single named
+Anonymous object creation with two named
 ============================
 
 void b() {
   var x = new {
-    test = "This"
+    test = "This",
+    arr = {1, 2, 3}
   };
 }
 
@@ -226,7 +227,13 @@ void b() {
               (anonymous_object_creation_expression
                 (name_equals
                   (identifier))
-                (string_literal)))))))))
+                (string_literal)
+                (name_equals
+                  (identifier))
+                (initializer_expression
+                  (integer_literal)
+                  (integer_literal)
+                  (integer_literal))))))))))
 
 ============================
 Checked expressions
@@ -264,6 +271,7 @@ void b() {
   a = new E
   {
     Foo = bar,
+    baz = { ["key"] = { 1 } }
   };
 
   b = new E(1);
@@ -292,8 +300,15 @@ void b() {
           (object_creation_expression
             (identifier)
             (initializer_expression
-              (assignment_expression
-                (identifier) (assignment_operator) (identifier))))))
+              (name_equals (identifier))
+              (identifier)
+              (name_equals (identifier))
+              (initializer_expression
+                (element_binding_equals
+                  (element_binding_expression
+                    (bracketed_argument_list
+                      (argument (string_literal)))))
+                (initializer_expression (integer_literal)))))))
       (expression_statement
         (assignment_expression
           (identifier)
@@ -534,6 +549,7 @@ Implicit array creation
 
 void b() {
   var z = new [] { 1, 2, 3 };
+  int[] args = { 1, 2, 3 };
 }
 
 ---
@@ -554,7 +570,19 @@ void b() {
                 (initializer_expression
                   (integer_literal)
                   (integer_literal)
-                  (integer_literal))))))))))
+                  (integer_literal)))))))
+      (local_declaration_statement
+        (variable_declaration
+          (array_type
+            (predefined_type)
+            (array_rank_specifier))
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (initializer_expression
+                (integer_literal)
+                (integer_literal)
+                (integer_literal)))))))))
 
 ============================
 Implicit multi array creation
@@ -1293,11 +1321,10 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
               (identifier)
               (type_argument_list (predefined_type) (predefined_type)))
             (initializer_expression
-              (assignment_expression
+              (element_binding_equals
                 (element_binding_expression
-                  (bracketed_argument_list (argument (string_literal))))
-                (assignment_operator)
-                (integer_literal)))))))))
+                  (bracketed_argument_list (argument (string_literal)))))
+              (integer_literal))))))))
 
 =====================================
 Conditional access to element (should be implicit_element_access)

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -26,7 +26,7 @@ var x = from a in source select a.B;
 Query from select projection
 =====================================
 
-var x = from a in source select { Name = a.B };
+var x = from a in source select new { Name = a.B };
 
 ---
 
@@ -41,14 +41,12 @@ var x = from a in source select { Name = a.B };
             (from_clause
               (identifier)
               (identifier))
-              (select_clause
-                (initializer_expression
-                  (assignment_expression
+              (select_clause 
+                (anonymous_object_creation_expression
+                  (name_equals (identifier))
+                  (member_access_expression
                     (identifier)
-                      (assignment_operator)
-                        (member_access_expression
-                          (identifier)
-                          (identifier)))))))))))
+                    (identifier))))))))))
 
 =====================================
 Query from select with where

--- a/grammar.js
+++ b/grammar.js
@@ -114,6 +114,8 @@ module.exports = grammar({
       ';'
     ),
 
+    element_binding_equals: $ => prec(1, seq($.element_binding_expression, '=')),
+
     name_equals: $ => prec(1, seq($._identifier_or_global, '=')),
 
     _name: $ => choice(
@@ -245,7 +247,7 @@ module.exports = grammar({
       )
     )),
 
-    equals_value_clause: $ => seq('=', $._expression),
+    equals_value_clause: $ => seq('=', choice($._expression, $.initializer_expression)),
 
     field_declaration: $ => seq(
       repeat($.attribute_list),
@@ -929,7 +931,10 @@ module.exports = grammar({
     ),
 
     _anonymous_object_member_declarator: $ => choice(
-      prec.dynamic(PREC.ASSIGN, seq($.name_equals, $._expression)),
+      prec.dynamic(PREC.ASSIGN, seq(
+        choice($.name_equals, $.element_binding_equals),
+        choice($._expression, $.initializer_expression))
+      ),
       $._expression
     ),
 
@@ -941,7 +946,7 @@ module.exports = grammar({
 
     initializer_expression: $ => seq(
       '{',
-      commaSep(choice($._expression, $.initializer_expression)),
+      commaSep(choice($._anonymous_object_member_declarator, $.initializer_expression)),
       optional(','),
       '}'
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -42,8 +42,6 @@ module.exports = grammar({
   ],
 
   conflicts: $ => [
-    [$.block, $.initializer_expression],
-
     [$.element_access_expression, $.enum_member_declaration],
 
     [$.event_declaration, $.variable_declarator],
@@ -943,7 +941,7 @@ module.exports = grammar({
 
     initializer_expression: $ => seq(
       '{',
-      commaSep($._expression),
+      commaSep(choice($._expression, $.initializer_expression)),
       optional(','),
       '}'
     ),
@@ -1277,7 +1275,6 @@ module.exports = grammar({
       $.element_binding_expression,
       $.implicit_array_creation_expression,
       $.implicit_stack_alloc_array_creation_expression,
-      $.initializer_expression,
       $.interpolated_string_expression,
       $.invocation_expression,
       $.is_pattern_expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -149,6 +149,23 @@
         }
       ]
     },
+    "element_binding_equals": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "element_binding_expression"
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          }
+        ]
+      }
+    },
     "name_equals": {
       "type": "PREC",
       "value": 1,
@@ -949,8 +966,17 @@
           "value": "="
         },
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "initializer_expression"
+            }
+          ]
         }
       ]
     },
@@ -5044,12 +5070,30 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "name_equals"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "name_equals"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "element_binding_equals"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "_expression"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "initializer_expression"
+                  }
+                ]
               }
             ]
           }
@@ -5103,7 +5147,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_expression"
+                      "name": "_anonymous_object_member_declarator"
                     },
                     {
                       "type": "SYMBOL",
@@ -5125,7 +5169,7 @@
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "_expression"
+                            "name": "_anonymous_object_member_declarator"
                           },
                           {
                             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5099,8 +5099,17 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "initializer_expression"
+                    }
+                  ]
                 },
                 {
                   "type": "REPEAT",
@@ -5112,8 +5121,17 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_expression"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "initializer_expression"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -6855,10 +6873,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "initializer_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "interpolated_string_expression"
         },
         {
@@ -8151,10 +8165,6 @@
     }
   ],
   "conflicts": [
-    [
-      "block",
-      "initializer_expression"
-    ],
     [
       "element_access_expression",
       "enum_member_declaration"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -543,6 +543,14 @@
           "named": true
         },
         {
+          "type": "element_binding_equals",
+          "named": true
+        },
+        {
+          "type": "initializer_expression",
+          "named": true
+        },
+        {
           "type": "name_equals",
           "named": true
         }
@@ -1858,6 +1866,21 @@
     }
   },
   {
+    "type": "element_binding_equals",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "element_binding_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "element_binding_expression",
     "named": true,
     "fields": {},
@@ -1988,6 +2011,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "initializer_expression",
           "named": true
         }
       ]
@@ -2536,7 +2563,15 @@
           "named": true
         },
         {
+          "type": "element_binding_equals",
+          "named": true
+        },
+        {
           "type": "initializer_expression",
+          "named": true
+        },
+        {
+          "type": "name_equals",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -170,10 +170,6 @@
         "named": true
       },
       {
-        "type": "initializer_expression",
-        "named": true
-      },
-      {
         "type": "integer_literal",
         "named": true
       },
@@ -2537,6 +2533,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "initializer_expression",
           "named": true
         }
       ]


### PR DESCRIPTION
Corrected test that can not compile in real C# compiler. Also changed initializer_expression slightly as it is no longer a direct child of _expression.
This also allows us to remove the conflict with block rule.

I was working on property patterns and ran into this. It was causing conflicts with the rules I were setting up, so this is also a step on the way for property patterns. But I thought that I would split it into smaller pull requests, as they are easier to discuss.