### PR TITLE
Fixed the parsing of ref local variable declarations

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -747,6 +747,40 @@ class A {
                   (integer_literal))))))))))
 
 =====================================
+Implicit local ref variable
+=====================================
+
+class A {
+  void Test() {
+    ref var value = ref data[i];
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+  (identifier)
+  (declaration_list
+    (method_declaration
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (modifier)
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ref_expression
+                  (element_access_expression
+                    (identifier)
+                    (bracketed_argument_list
+                      (argument (identifier))))))))))))))
+
+=====================================
 Using statement with implicit local variable
 =====================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -207,7 +207,7 @@ module.exports = grammar({
       'protected',
       'public',
       'readonly',
-      prec(1, 'ref'),
+      prec(1, 'ref'), //make sure that 'ref' is treated as a modifier for local variable declarations instead of as a ref expression
       'sealed',
       'static',
       'unsafe',

--- a/grammar.js
+++ b/grammar.js
@@ -207,7 +207,7 @@ module.exports = grammar({
       'protected',
       'public',
       'readonly',
-      'ref',
+      prec(1, 'ref'),
       'sealed',
       'static',
       'unsafe',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -674,8 +674,12 @@
             "value": "readonly"
           },
           {
-            "type": "STRING",
-            "value": "ref"
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "ref"
+            }
           },
           {
             "type": "STRING",


### PR DESCRIPTION
This is done by increasing the precedence value of the ref-modifier, making it higher than the other uses of ref.

Fixes #79 