### PR TITLE
Added the possibility of having a nullable type as the type of a 'par…

### DIFF
--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -317,3 +317,32 @@ class A {
         (identifier)
         (arrow_expression_clause
           (binary_expression (identifier) (identifier)))))))
+
+=======================================
+Class method with nullable parameter list
+=======================================
+
+class A {
+  public int Zero(params int[]? ints) => 0;
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (modifier)
+        (predefined_type)
+        (identifier)
+        (parameter_list
+          (parameter_array
+            (nullable_type
+              (array_type
+                (predefined_type)
+                (array_rank_specifier)))
+            (identifier)))
+        (arrow_expression_clause
+          (integer_literal))))))
+          

--- a/grammar.js
+++ b/grammar.js
@@ -291,7 +291,7 @@ module.exports = grammar({
     parameter_array: $ => seq(
       repeat($.attribute_list),
       'params',
-      $.array_type,
+      choice($.array_type, $.nullable_type),
       $.identifier
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1214,8 +1214,17 @@
           "value": "params"
         },
         {
-          "type": "SYMBOL",
-          "name": "array_type"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "array_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nullable_type"
+            }
+          ]
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3561,6 +3561,10 @@
         {
           "type": "identifier",
           "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
         }
       ]
     }


### PR DESCRIPTION
…ams' parameter

This is a bit too lax as it also allows non-array nullable types to be used, but I think this resulted in the best AST.

fixes #78 

An alternative to this is to have the grammar
be something like: 
seq(
...,
$.array_type,
optional('?'),
...)

This just does not make as clear an AST, in my opinion, but would allow less wrong code to parse.