### PR TITLE
Allow whitespace in preproc, fixes #86

### DIFF
--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -105,3 +105,60 @@ class Of1879 {
         (preprocessor_call (preprocessor_directive) (integer_literal) (string_literal))
         (preprocessor_call (preprocessor_directive) (identifier))
         (preprocessor_call (preprocessor_directive) (identifier))))))) 
+
+===================================
+Spaces in directives
+===================================
+
+class Of1879 {
+  void AMethod() {
+# line 2001 "A Space"
+#  line hidden
+#    line default
+  }
+}
+
+---
+
+(compilation_unit (class_declaration
+  (identifier)
+  (declaration_list
+    (method_declaration
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (preprocessor_call (preprocessor_directive) (integer_literal) (string_literal))
+        (preprocessor_call (preprocessor_directive) (identifier))
+        (preprocessor_call (preprocessor_directive) (identifier))))))) 
+
+===================================
+Directives not in strings or comments
+===================================
+
+class Of1879 {
+  void AMethod() {
+    var s = @"Only a string
+    #if NOPE
+";
+    /* Only a comment
+    #if NOPE
+    */
+  }
+}
+
+---
+
+(compilation_unit (class_declaration
+  (identifier)
+  (declaration_list
+    (method_declaration
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause (verbatim_string_literal)))))
+        (comment))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1474,7 +1474,7 @@ module.exports = grammar({
       $._preproc_directive_end
     ),
 
-    preprocessor_directive: $ => /#[a-z]\w*/,
+    preprocessor_directive: $ => /#[ \t]*[a-z]\w*/,
   }
 })
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8141,7 +8141,7 @@
     },
     "preprocessor_directive": {
       "type": "PATTERN",
-      "value": "#[a-z]\\w*"
+      "value": "#[ \\t]*[a-z]\\w*"
     }
   },
   "extras": [


### PR DESCRIPTION
This gets us around the issue reported in #86 but does not yet start on #16 which I'm not sure has much benefit beyond `#if` `#else` `#elif` and `#endif`.

At least supporting those could let us in theory deal with code like this from JSON.NET that forms part of the test suite:

```csharp
    if (value < DateParseHandling.None ||
#if HAVE_DATE_TIME_OFFSET
        value > DateParseHandling.DateTimeOffset
#else
        value > DateParseHandling.DateTime
#endif
        )
    {
```