### PR TITLE
Add support for target-type new expressions.

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -174,6 +174,31 @@ void b() {
               (anonymous_object_creation_expression))))))))
 
 ============================
+Target-type object creation
+============================
+
+void b() {
+  Friend friend = new("hi");
+}
+
+---
+
+(compilation_unit
+  (method_declaration
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (local_declaration_statement
+        (variable_declaration
+          (identifier)
+          (variable_declarator
+          (identifier)
+            (equals_value_clause
+              (anonymous_object_creation_expression
+                (argument_list (argument (string_literal)))))))))))
+
+============================
 Anonymous object creation with single unnamed
 ============================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -195,7 +195,7 @@ void b() {
           (variable_declarator
           (identifier)
             (equals_value_clause
-              (anonymous_object_creation_expression
+              (implicit_object_creation_expression
                 (argument_list (argument (string_literal)))))))))))
 
 ============================

--- a/grammar.js
+++ b/grammar.js
@@ -18,7 +18,8 @@ const PREC = {
   LOGOR: 4,
   COND: 3,
   ASSIGN: 2,
-  SEQ: 1
+  SEQ: 1,
+  TUPLE: -1,
 };
 
 module.exports = grammar({
@@ -68,7 +69,6 @@ module.exports = grammar({
     [$.parameter, $._expression],
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $._variable_designation],
-    [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
   ],
 
@@ -615,10 +615,10 @@ module.exports = grammar({
       ')'
     ),
 
-    tuple_element: $ => seq(
+    tuple_element: $ => prec(PREC.TUPLE, seq(
       field('type', $._type),
       field('name', optional($.identifier))
-    ),
+    )),
 
     _statement: $ => choice(
       $.block,
@@ -925,14 +925,15 @@ module.exports = grammar({
 
     anonymous_object_creation_expression: $ => seq(
       'new',
-      choice($._member_declarator_list, $.argument_list),
-    ),
-
-    _member_declarator_list: $ => seq(
       '{',
       commaSep($._anonymous_object_member_declarator),
       optional(','),
       '}'
+    ),
+
+    implicit_object_creation_expression: $ => seq(
+      'new',
+      $.argument_list,
     ),
 
     _anonymous_object_member_declarator: $ => choice(
@@ -1285,6 +1286,7 @@ module.exports = grammar({
       $.element_access_expression,
       $.element_binding_expression,
       $.implicit_array_creation_expression,
+      $.implicit_object_creation_expression,
       $.implicit_stack_alloc_array_creation_expression,
       $.initializer_expression,
       $.interpolated_string_expression,

--- a/grammar.js
+++ b/grammar.js
@@ -68,6 +68,7 @@ module.exports = grammar({
     [$.parameter, $._expression],
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $._variable_designation],
+    [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
   ],
 
@@ -924,6 +925,10 @@ module.exports = grammar({
 
     anonymous_object_creation_expression: $ => seq(
       'new',
+      choice($._member_declarator_list, $.argument_list),
+    ),
+
+    _member_declarator_list: $ => seq(
       '{',
       commaSep($._anonymous_object_member_declarator),
       optional(','),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.16.0"
+    "tree-sitter-cli": "^0.17.1"
   },
   "scripts": {
     "test": "tree-sitter test && node test.js"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3172,33 +3172,37 @@
       ]
     },
     "tuple_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        }
-      ]
+        ]
+      }
     },
     "_statement": {
       "type": "CHOICE",
@@ -4984,24 +4988,6 @@
           "value": "new"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_member_declarator_list"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "argument_list"
-            }
-          ]
-        }
-      ]
-    },
-    "_member_declarator_list": {
-      "type": "SEQ",
-      "members": [
-        {
           "type": "STRING",
           "value": "{"
         },
@@ -5053,6 +5039,19 @@
         {
           "type": "STRING",
           "value": "}"
+        }
+      ]
+    },
+    "implicit_object_creation_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
         }
       ]
     },
@@ -6877,6 +6876,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "implicit_object_creation_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "implicit_stack_alloc_array_creation_expression"
         },
         {
@@ -8249,10 +8252,6 @@
     [
       "parameter",
       "_variable_designation"
-    ],
-    [
-      "tuple_element",
-      "declaration_expression"
     ],
     [
       "tuple_element",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4984,6 +4984,24 @@
           "value": "new"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_member_declarator_list"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            }
+          ]
+        }
+      ]
+    },
+    "_member_declarator_list": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "{"
         },
@@ -8231,6 +8249,10 @@
     [
       "parameter",
       "_variable_designation"
+    ],
+    [
+      "tuple_element",
+      "declaration_expression"
     ],
     [
       "tuple_element",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -547,6 +547,10 @@
           "named": true
         },
         {
+          "type": "argument_list",
+          "named": true
+        },
+        {
           "type": "name_equals",
           "named": true
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -166,6 +166,10 @@
         "named": true
       },
       {
+        "type": "implicit_object_creation_expression",
+        "named": true
+      },
+      {
         "type": "implicit_stack_alloc_array_creation_expression",
         "named": true
       },
@@ -544,10 +548,6 @@
       "types": [
         {
           "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "argument_list",
           "named": true
         },
         {
@@ -2442,6 +2442,21 @@
       "types": [
         {
           "type": "initializer_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "implicit_object_creation_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -35,6 +35,7 @@ typedef uint16_t TSStateId;
 typedef struct {
   bool visible : 1;
   bool named : 1;
+  bool supertype: 1;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;
@@ -119,6 +120,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  uint32_t state_count;
 };
 
 /*


### PR DESCRIPTION
I stuck this in `anonymous_object_creation_expression`, because that's the other rule where we have `new` without a corresponding type; doing this directly in `object_creation_expression` by making its type field optional produced a whole heck of conflicts. Happy to take suggestions as to how to make this better. As it stands, it adds a few tenths of a percent on the passing rate for `dotnet/roslyn`.