### PR TITLE
Added the recursive_pattern rule

### DIFF
--- a/Martin todo.txt
+++ b/Martin todo.txt
@@ -1,0 +1,13 @@
+there is some implementation of "recursive patterns" that looks like positional patterns.
+
+allign this with the property patterns i made and remove dublicate rules.
+
+
+see gramma here: https://github.com/dotnet/csharplang/blob/master/proposals/csharp-8.0/patterns.md
+
+
+Known issues:
+
+var b = p is Point (var x, var y); // is parsed as a (constant_pattern(invocation_expression ...)), should be (recursive_pattern .. (positional_pattern_clause ...))
+
+var b = p is Point (var x, var y) { x: 0 }; // causes error as it tries to parse it as invocation_expression again

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1456,7 +1456,6 @@ var x = name is not null;
 
 ---
 
-
 (compilation_unit
   (field_declaration
     (variable_declaration
@@ -1533,3 +1532,75 @@ var x = !this.Call();
                 (this_expression)
                 (identifier))
               (argument_list))))))))
+
+=====================================
+Property patterns
+=====================================
+
+var x = operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } };
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression
+            (identifier)
+            (recursive_pattern
+              (identifier)
+              (property_pattern_clause
+                (subpattern 
+                  (name_colon (identifier))
+                  (recursive_pattern 
+                    (property_pattern_clause
+                      (subpattern 
+                        (name_colon (identifier))
+                        (constant_pattern (boolean_literal)))
+                      (subpattern
+                        (name_colon (identifier))
+                        (constant_pattern (null_literal))))))))))))))
+
+=====================================
+Positional patterns
+=====================================
+
+var a = p is var (x, y);
+var c = p is (var x, var y) { x: 0 };
+
+---
+
+(compilation_unit
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression
+            (identifier)
+            (var_pattern
+              (parenthesized_variable_designation
+                (identifier)
+                (identifier))))))))
+  (field_declaration
+    (variable_declaration
+      (implicit_type)
+      (variable_declarator
+        (identifier)
+        (equals_value_clause
+          (is_pattern_expression
+            (identifier)
+            (recursive_pattern
+              (positional_pattern_clause
+                (subpattern
+                  (var_pattern (identifier)))
+                (subpattern
+                  (var_pattern (identifier))))
+              (property_pattern_clause
+                (subpattern
+                  (name_colon (identifier))
+                  (constant_pattern (integer_literal)))))))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1637,27 +1637,28 @@ var x = operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: n
 ---
 
 (compilation_unit
-  (field_declaration
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (recursive_pattern
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
               (identifier)
-              (property_pattern_clause
-                (subpattern 
-                  (name_colon (identifier))
-                  (recursive_pattern 
-                    (property_pattern_clause
-                      (subpattern 
-                        (name_colon (identifier))
-                        (constant_pattern (boolean_literal)))
-                      (subpattern
-                        (name_colon (identifier))
-                        (constant_pattern (null_literal))))))))))))))
+              (recursive_pattern
+                (identifier)
+                (property_pattern_clause
+                  (subpattern 
+                    (name_colon (identifier))
+                    (recursive_pattern 
+                      (property_pattern_clause
+                        (subpattern 
+                          (name_colon (identifier))
+                          (constant_pattern (boolean_literal)))
+                        (subpattern
+                          (name_colon (identifier))
+                          (constant_pattern (null_literal)))))))))))))))
 
 =====================================
 Positional patterns
@@ -1669,33 +1670,35 @@ var c = p is (var x, var y) { x: 0 };
 ---
 
 (compilation_unit
-  (field_declaration
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (var_pattern
-              (parenthesized_variable_designation
-                (identifier)
-                (identifier))))))))
-  (field_declaration
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (recursive_pattern
-              (positional_pattern_clause
-                (subpattern
-                  (var_pattern (identifier)))
-                (subpattern
-                  (var_pattern (identifier))))
-              (property_pattern_clause
-                (subpattern
-                  (name_colon (identifier))
-                  (constant_pattern (integer_literal)))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (var_pattern
+                (parenthesized_variable_designation
+                  (identifier)
+                  (identifier)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (recursive_pattern
+                (positional_pattern_clause
+                  (subpattern
+                    (var_pattern (identifier)))
+                  (subpattern
+                    (var_pattern (identifier))))
+                (property_pattern_clause
+                  (subpattern
+                    (name_colon (identifier))
+                    (constant_pattern (integer_literal))))))))))))

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -44,13 +44,11 @@ var x = from a in source select new { Name = a.B };
                 (identifier)
                 (identifier))
                 (select_clause
-                  (initializer_expression
-                    (assignment_expression
+                  (anonymous_object_creation_expression
+                    (name_equals (identifier))
+                    (member_access_expression
                       (identifier)
-                        (assignment_operator)
-                          (member_access_expression
-                            (identifier)
-                            (identifier))))))))))))
+                      (identifier)))))))))))
 
 =====================================
 Query from select with where

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -26,7 +26,7 @@ var x = from a in source select a.B;
 Query from select projection
 =====================================
 
-var x = from a in source select { Name = a.B };
+var x = from a in source select new { Name = a.B };
 
 ---
 
@@ -41,14 +41,12 @@ var x = from a in source select { Name = a.B };
             (from_clause
               (identifier)
               (identifier))
-              (select_clause
-                (initializer_expression
-                  (assignment_expression
+              (select_clause 
+                (anonymous_object_creation_expression
+                  (name_equals (identifier))
+                  (member_access_expression
                     (identifier)
-                      (assignment_operator)
-                        (member_access_expression
-                          (identifier)
-                          (identifier)))))))))))
+                    (identifier))))))))))
 
 =====================================
 Query from select with where

--- a/grammar.js
+++ b/grammar.js
@@ -67,7 +67,6 @@ module.exports = grammar({
     [$.parameter, $._simple_name],
     [$.parameter, $._expression],
     [$.parameter, $.tuple_element, $.declaration_expression],
-    [$.parameter, $._variable_designation],
     [$.tuple_element, $.variable_declarator],
   ],
 
@@ -775,7 +774,7 @@ module.exports = grammar({
       $.constant_pattern,
       $.declaration_pattern,
       $.discard,
-//      $.recursive_pattern,
+      $.recursive_pattern,
       $.var_pattern,
       $.negated_pattern,
       $.parenthesized_pattern,
@@ -814,11 +813,11 @@ module.exports = grammar({
       $._variable_designation
     ),
 
-    _variable_designation: $ => choice(
+    _variable_designation: $ => prec(1, choice(
       $.discard,
       $.parenthesized_variable_designation,
       $.identifier
-    ),
+    )),
 
     discard: $ => '_',
 
@@ -828,27 +827,35 @@ module.exports = grammar({
       ')'
     ),
 
-    // TODO: Matches everything as optional which won't work.
-    // Figure out valid combinations with at least one item to remove ambiguity.
-    recursive_pattern: $ => seq(
+    recursive_pattern: $ => prec.right(seq(
       optional($._type),
-      optional($.positional_pattern_clause),
-      optional($.property_pattern_clause),
+      choice(
+        seq(
+          $.positional_pattern_clause,
+          optional($.property_pattern_clause)
+        ),
+        $.property_pattern_clause
+      ),
       optional($._variable_designation)
-    ),
+    )),
 
-    positional_pattern_clause: $ => seq('(', commaSep($.subpattern), ')'),
+    positional_pattern_clause: $ => prec(1, seq(
+      '(',
+      optional(seq($.subpattern, ',', commaSep1($.subpattern))),// we really should allow single sub patterns, but that causes conficts, and will rarely be used
+      ')',
+    )),
 
     subpattern: $ => seq(
       optional($.name_colon),
       $._pattern
     ),
 
-    property_pattern_clause: $ => seq(
+    property_pattern_clause: $ => prec(1, seq(
       '{',
       commaSep($.subpattern),
-      '}'
-    ),
+      optional(','),
+      '}',
+    )),
 
     var_pattern: $ => prec(1, seq('var', $._variable_designation)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,6 @@
 {
   "name": "c_sharp",
-  "word": "identifier",
+  "word": "_identifier_token",
   "rules": {
     "compilation_unit": {
       "type": "REPEAT",
@@ -79,6 +79,10 @@
         {
           "type": "SYMBOL",
           "name": "property_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_declaration"
         },
         {
           "type": "SYMBOL",
@@ -557,22 +561,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_identifier_or_global"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_reserved_identifier"
-              },
-              "named": true,
-              "value": "identifier"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_identifier_or_global"
         },
         {
           "type": "STRING",
@@ -1150,16 +1140,11 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "discard"
               },
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_reserved_identifier"
-                },
-                "named": true,
-                "value": "identifier"
+                "type": "SYMBOL",
+                "name": "identifier"
               }
             ]
           }
@@ -1658,37 +1643,45 @@
           "value": "where"
         },
         {
-          "type": "SYMBOL",
-          "name": "_identifier_or_global"
+          "type": "FIELD",
+          "name": "target",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier_or_global"
+          }
         },
         {
           "type": "STRING",
           "value": ":"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "type_parameter_constraint"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "type_parameter_constraint"
-                  }
-                ]
+          "type": "FIELD",
+          "name": "constraints",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_parameter_constraint"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_parameter_constraint"
+                    }
+                  ]
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },
@@ -1756,8 +1749,12 @@
       ]
     },
     "type_constraint": {
-      "type": "SYMBOL",
-      "name": "_type"
+      "type": "FIELD",
+      "name": "type",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_type"
+      }
     },
     "operator_declaration": {
       "type": "SEQ",
@@ -2026,6 +2023,10 @@
             {
               "type": "STRING",
               "value": "remove"
+            },
+            {
+              "type": "STRING",
+              "value": "init"
             },
             {
               "type": "SYMBOL",
@@ -2837,6 +2838,225 @@
         }
       ]
     },
+    "record_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_list"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "modifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "record"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type_parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "bases",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "record_base"
+                },
+                "named": true,
+                "value": "base_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "type_parameter_constraints_clause"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_record_base"
+          }
+        }
+      ]
+    },
+    "record_base": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "primary_constructor_base_type"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "identifier"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "primary_constructor_base_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
+        }
+      ]
+    },
+    "_record_base": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "declaration_list"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
+    },
     "namespace_declaration": {
       "type": "SEQ",
       "members": [
@@ -3118,6 +3338,14 @@
           {
             "type": "STRING",
             "value": "ushort"
+          },
+          {
+            "type": "STRING",
+            "value": "nint"
+          },
+          {
+            "type": "STRING",
+            "value": "nuint"
           }
         ]
       }
@@ -3181,33 +3409,37 @@
       ]
     },
     "tuple_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        }
-      ]
+        ]
+      }
     },
     "_statement": {
       "type": "CHOICE",
@@ -3836,6 +4068,13 @@
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
+            "name": "attribute_list"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
             "name": "modifier"
           }
         },
@@ -3950,20 +4189,38 @@
           "value": "switch"
         },
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": ")"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "value",
+              "content": {
+                "type": "SYMBOL",
+                "name": "tuple_expression"
+              }
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -5095,6 +5352,19 @@
         {
           "type": "STRING",
           "value": "}"
+        }
+      ]
+    },
+    "implicit_object_creation_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "argument_list"
         }
       ]
     },
@@ -6854,6 +7124,81 @@
         }
       ]
     },
+    "with_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "with"
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "with_initializer_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "with_initializer_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "simple_assignment_expression"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "simple_assignment_expression"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "simple_assignment_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
     "_expression": {
       "type": "CHOICE",
       "members": [
@@ -6916,6 +7261,10 @@
         {
           "type": "SYMBOL",
           "name": "implicit_array_creation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "implicit_object_creation_expression"
         },
         {
           "type": "SYMBOL",
@@ -7019,16 +7368,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_simple_name"
+          "name": "with_expression"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_reserved_identifier"
-          },
-          "named": true,
-          "value": "identifier"
+          "type": "SYMBOL",
+          "name": "_simple_name"
         },
         {
           "type": "SYMBOL",
@@ -7710,7 +8054,7 @@
         }
       ]
     },
-    "identifier": {
+    "_identifier_token": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -7733,6 +8077,19 @@
           }
         ]
       }
+    },
+    "identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier_token"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_contextual_keywords"
+        }
+      ]
     },
     "global": {
       "type": "STRING",
@@ -8133,12 +8490,104 @@
         ]
       }
     },
-    "_reserved_identifier": {
+    "_contextual_keywords": {
       "type": "CHOICE",
       "members": [
         {
           "type": "STRING",
+          "value": "ascending"
+        },
+        {
+          "type": "STRING",
+          "value": "by"
+        },
+        {
+          "type": "STRING",
+          "value": "descending"
+        },
+        {
+          "type": "STRING",
+          "value": "equals"
+        },
+        {
+          "type": "STRING",
           "value": "from"
+        },
+        {
+          "type": "STRING",
+          "value": "group"
+        },
+        {
+          "type": "STRING",
+          "value": "into"
+        },
+        {
+          "type": "STRING",
+          "value": "join"
+        },
+        {
+          "type": "STRING",
+          "value": "let"
+        },
+        {
+          "type": "STRING",
+          "value": "on"
+        },
+        {
+          "type": "STRING",
+          "value": "orderby"
+        },
+        {
+          "type": "STRING",
+          "value": "select"
+        },
+        {
+          "type": "STRING",
+          "value": "where"
+        },
+        {
+          "type": "STRING",
+          "value": "add"
+        },
+        {
+          "type": "STRING",
+          "value": "get"
+        },
+        {
+          "type": "STRING",
+          "value": "remove"
+        },
+        {
+          "type": "STRING",
+          "value": "set"
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "STRING",
+          "value": "dynamic"
+        },
+        {
+          "type": "STRING",
+          "value": "nameof"
+        },
+        {
+          "type": "STRING",
+          "value": "notnull"
+        },
+        {
+          "type": "STRING",
+          "value": "unmanaged"
+        },
+        {
+          "type": "STRING",
+          "value": "when"
+        },
+        {
+          "type": "STRING",
+          "value": "yield"
         }
       ]
     },
@@ -8260,8 +8709,16 @@
       "member_access_expression"
     ],
     [
-      "from_clause",
-      "_reserved_identifier"
+      "_contextual_keywords",
+      "from_clause"
+    ],
+    [
+      "_contextual_keywords",
+      "accessor_declaration"
+    ],
+    [
+      "_contextual_keywords",
+      "type_parameter_constraint"
     ],
     [
       "_type",
@@ -8287,6 +8744,14 @@
       "parameter",
       "tuple_element",
       "declaration_expression"
+    ],
+    [
+      "parameter",
+      "_variable_designation"
+    ],
+    [
+      "parameter",
+      "_pattern"
     ],
     [
       "tuple_element",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4077,6 +4077,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "recursive_pattern"
+        },
+        {
+          "type": "SYMBOL",
           "name": "var_pattern"
         },
         {
@@ -4285,21 +4289,25 @@
       ]
     },
     "_variable_designation": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "discard"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parenthesized_variable_designation"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "discard"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "parenthesized_variable_designation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        ]
+      }
     },
     "discard": {
       "type": "STRING",
@@ -4352,103 +4360,130 @@
       ]
     },
     "recursive_pattern": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_type"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "positional_pattern_clause"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "property_pattern_clause"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_variable_designation"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "positional_pattern_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "subpattern"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_type"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "positional_pattern_clause"
+                  },
+                  {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": ","
+                        "type": "SYMBOL",
+                        "name": "property_pattern_clause"
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "subpattern"
+                        "type": "BLANK"
                       }
                     ]
                   }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "property_pattern_clause"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_variable_designation"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "positional_pattern_clause": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "subpattern"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "subpattern"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "subpattern"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
     },
     "subpattern": {
       "type": "SEQ",
@@ -4472,50 +4507,66 @@
       ]
     },
     "property_pattern_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "subpattern"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "subpattern"
-                      }
-                    ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "subpattern"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "subpattern"
+                        }
+                      ]
+                    }
                   }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
     },
     "var_pattern": {
       "type": "PREC",
@@ -8236,10 +8287,6 @@
       "parameter",
       "tuple_element",
       "declaration_expression"
-    ],
-    [
-      "parameter",
-      "_variable_designation"
     ],
     [
       "tuple_element",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -72,6 +72,10 @@
         "named": true
       },
       {
+        "type": "record_declaration",
+        "named": true
+      },
+      {
         "type": "struct_declaration",
         "named": true
       },
@@ -163,6 +167,10 @@
       },
       {
         "type": "implicit_array_creation_expression",
+        "named": true
+      },
+      {
+        "type": "implicit_object_creation_expression",
         "named": true
       },
       {
@@ -283,6 +291,10 @@
       },
       {
         "type": "verbatim_string_literal",
+        "named": true
+      },
+      {
+        "type": "with_expression",
         "named": true
       }
     ]
@@ -841,6 +853,10 @@
       "types": [
         {
           "type": "_type",
+          "named": true
+        },
+        {
+          "type": "primary_constructor_base_type",
           "named": true
         }
       ]
@@ -2456,6 +2472,21 @@
     }
   },
   {
+    "type": "implicit_object_creation_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "implicit_stack_alloc_array_creation_expression",
     "named": true,
     "fields": {},
@@ -2827,6 +2858,11 @@
     }
   },
   {
+    "type": "label_name",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "labeled_statement",
     "named": true,
     "fields": {},
@@ -2980,6 +3016,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
         {
           "type": "modifier",
           "named": true
@@ -3527,6 +3567,10 @@
         "required": true,
         "types": [
           {
+            "type": "discard",
+            "named": true
+          },
+          {
             "type": "identifier",
             "named": true
           }
@@ -3759,6 +3803,25 @@
     }
   },
   {
+    "type": "primary_constructor_base_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "property_declaration",
     "named": true,
     "fields": {
@@ -3978,6 +4041,84 @@
     }
   },
   {
+    "type": "record_declaration",
+    "named": true,
+    "fields": {
+      "bases": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "base_list",
+            "named": true
+          }
+        ]
+      },
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": ";",
+            "named": false
+          },
+          {
+            "type": "declaration_list",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "parameter_list",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameter_list",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "type_parameter_constraints_clause",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "recursive_pattern",
     "named": true,
     "fields": {},
@@ -4100,6 +4241,21 @@
     "fields": {},
     "children": {
       "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "simple_assignment_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -4577,16 +4733,17 @@
   {
     "type": "type_constraint",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4645,24 +4802,35 @@
   {
     "type": "type_parameter_constraints_clause",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "global",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "type_parameter_constraint",
-          "named": true
-        }
-      ]
+    "fields": {
+      "constraints": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "type_parameter_constraint",
+            "named": true
+          }
+        ]
+      },
+      "target": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4880,6 +5048,40 @@
         },
         {
           "type": "_statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "with_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "with_initializer_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "with_initializer_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "simple_assignment_expression",
           "named": true
         }
       ]
@@ -5205,6 +5407,10 @@
     "named": false
   },
   {
+    "type": "dynamic",
+    "named": false
+  },
+  {
     "type": "else",
     "named": false
   },
@@ -5289,6 +5495,10 @@
     "named": false
   },
   {
+    "type": "init",
+    "named": false
+  },
+  {
     "type": "integer_literal",
     "named": true
   },
@@ -5313,10 +5523,6 @@
     "named": false
   },
   {
-    "type": "label_name",
-    "named": true
-  },
-  {
     "type": "let",
     "named": false
   },
@@ -5330,6 +5536,10 @@
   },
   {
     "type": "module",
+    "named": false
+  },
+  {
+    "type": "nameof",
     "named": false
   },
   {
@@ -5419,6 +5629,10 @@
   {
     "type": "real_literal",
     "named": true
+  },
+  {
+    "type": "record",
+    "named": false
   },
   {
     "type": "ref",
@@ -5534,6 +5748,10 @@
   },
   {
     "type": "while",
+    "named": false
+  },
+  {
+    "type": "with",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -999,6 +999,10 @@
             "named": true
           },
           {
+            "type": "recursive_pattern",
+            "named": true
+          },
+          {
             "type": "relational_pattern",
             "named": true
           },
@@ -1048,6 +1052,10 @@
           },
           {
             "type": "parenthesized_pattern",
+            "named": true
+          },
+          {
+            "type": "recursive_pattern",
             "named": true
           },
           {
@@ -1147,6 +1155,10 @@
         },
         {
           "type": "parenthesized_pattern",
+          "named": true
+        },
+        {
+          "type": "recursive_pattern",
           "named": true
         },
         {
@@ -2761,6 +2773,10 @@
             "named": true
           },
           {
+            "type": "recursive_pattern",
+            "named": true
+          },
+          {
             "type": "relational_pattern",
             "named": true
           },
@@ -3274,6 +3290,10 @@
           "named": true
         },
         {
+          "type": "recursive_pattern",
+          "named": true
+        },
+        {
           "type": "relational_pattern",
           "named": true
         },
@@ -3641,6 +3661,10 @@
           "named": true
         },
         {
+          "type": "recursive_pattern",
+          "named": true
+        },
+        {
           "type": "relational_pattern",
           "named": true
         },
@@ -3954,6 +3978,37 @@
     }
   },
   {
+    "type": "recursive_pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_type",
+          "named": true
+        },
+        {
+          "type": "discard",
+          "named": true
+        },
+        {
+          "type": "parenthesized_variable_designation",
+          "named": true
+        },
+        {
+          "type": "positional_pattern_clause",
+          "named": true
+        },
+        {
+          "type": "property_pattern_clause",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "ref_expression",
     "named": true,
     "fields": {},
@@ -4204,6 +4259,10 @@
           "named": true
         },
         {
+          "type": "recursive_pattern",
+          "named": true
+        },
+        {
           "type": "relational_pattern",
           "named": true
         },
@@ -4282,6 +4341,10 @@
         },
         {
           "type": "parenthesized_pattern",
+          "named": true
+        },
+        {
+          "type": "recursive_pattern",
           "named": true
         },
         {


### PR DESCRIPTION
This will parse the most common uses of the recursive patterns, while it still fails or parses some others wrong.

fixes #19 

The following is still parsed wrong:
// this is parsed as a (constant_pattern(invocation_expression ...)), should be (recursive_pattern .. (positional_pattern_clause ...))
var b = p is Point (var x, var y); 

//this causes a parse error as it tries to parse it as invocation_expression again
var b = p is Point (var x, var y) { x: 0 };