### PR TITLE
Support contextual keywords as identifiers everywhere

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -462,6 +462,22 @@ void a() {
             (invocation_expression
               (member_access_expression (identifier) (identifier))
               (argument_list (argument (identifier)))))))))))
+         
+============================
+Async Lambda
+============================
+void a()
+{
+    Do(async () => {});
+}
+
+---
+(compilation_unit
+  (method_declaration (void_keyword) (identifier) (parameter_list)
+  (block
+    (expression_statement (invocation_expression (identifier)
+    (argument_list
+      (argument (lambda_expression (parameter_list) (initializer_expression)))))))))
 
 ============================
 Lambda expression with qualifiers

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1175,3 +1175,57 @@ class A {
             (variable_declarator
               (tuple_pattern (identifier) (tuple_pattern (identifier) (discard)))
               (equals_value_clause (identifier))))))))))
+
+=====================================
+Function with contextually reserved identifiers
+=====================================
+
+void Sample() {
+  var var = "";
+  int partial = from;
+  A into = select;
+  R await = get;
+  T set = let + yield + group + add + alias + ascending + descending + equals;
+}
+
+---
+
+(compilation_unit
+  (method_declaration
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause (string_literal)))))
+        (local_declaration_statement
+          (variable_declaration (predefined_type)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+       (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause
+                (binary_expression
+                  (binary_expression
+                    (binary_expression
+                      (binary_expression
+                        (binary_expression
+                          (binary_expression
+                            (binary_expression (identifier) (identifier))
+                          (identifier))
+                        (identifier))
+                      (identifier))
+                    (identifier))
+                  (identifier))
+                (identifier)))))))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1177,6 +1177,24 @@ class A {
               (equals_value_clause (identifier))))))))))
 
 =====================================
+Function with dynamic local variable
+=====================================
+
+void A() {
+  dynamic dyn = "";
+}
+
+---
+
+ (compilation_unit
+  (method_declaration (void_keyword) (identifier) (parameter_list)
+    (block
+      (local_declaration_statement
+        (variable_declaration (identifier)
+          (variable_declarator (identifier)
+            (equals_value_clause (string_literal))))))))
+
+=====================================
 Function with contextually reserved identifiers
 =====================================
 
@@ -1185,7 +1203,7 @@ async void Sample() {
   int partial = from;
   A into = select;
   R await = get;
-  T set = let + yield + group + add + alias + ascending + async + descending + equals;
+  T set = let + yield + group + add + alias + ascending + notnull + descending + equals;
 }
 
 ---

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1180,18 +1180,19 @@ class A {
 Function with contextually reserved identifiers
 =====================================
 
-void Sample() {
+async void Sample() {
   var var = "";
   int partial = from;
   A into = select;
   R await = get;
-  T set = let + yield + group + add + alias + ascending + descending + equals;
+  T set = let + yield + group + add + alias + ascending + async + descending + equals;
 }
 
 ---
 
 (compilation_unit
   (method_declaration
+      (modifier)
       (void_keyword)
       (identifier)
       (parameter_list)
@@ -1222,7 +1223,9 @@ void Sample() {
                       (binary_expression
                         (binary_expression
                           (binary_expression
-                            (binary_expression (identifier) (identifier))
+                            (binary_expression
+                              (binary_expression (identifier) (identifier))
+                            (identifier))
                           (identifier))
                         (identifier))
                       (identifier))

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -197,11 +197,11 @@ class A {
         (block)))))
 
 =======================================
-Class method with contextually-reserved keyword named parameter
+Class method with contextually-reserved keyword named parameters
 =======================================
 
 class A {
-  void HasAnOut(int from) {
+  void HasAnOut(int from, string partial) {
   }
 }
 
@@ -215,6 +215,7 @@ class A {
         (void_keyword)
         (identifier)
         (parameter_list
+          (parameter (predefined_type) (identifier))
           (parameter (predefined_type) (identifier)))
         (block)))))        
 

--- a/grammar.js
+++ b/grammar.js
@@ -196,7 +196,7 @@ module.exports = grammar({
 
     modifier: $ => prec.right(choice(
       'abstract',
-      'async',
+      prec(1, 'async'),
       'const',
       'extern',
       'fixed',
@@ -1496,7 +1496,7 @@ module.exports = grammar({
       'set',
 
       // Async
-      // 'async', // conflicts, need a way to enable for fewer scenarios
+      'async',
       'await',
 
       // Misc

--- a/grammar.js
+++ b/grammar.js
@@ -1471,8 +1471,42 @@ module.exports = grammar({
     )),
 
     // Custom non-Roslyn additions beyond this point that will not sync up with grammar.txt
+
+    // Contextual keywords - keywords that can also be identifiers...
     _reserved_identifier: $ => choice(
-      'from'
+      // LINQ comprehension syntax
+      'ascending',
+      'by',
+      'descending',
+      'equals',
+      'from',
+      'group',
+      'into',
+      'join',
+      'let',
+      'on',
+      'orderby',
+      'select',
+      'where',
+
+      // Property/event handlers
+      'add',
+      'get',
+      'remove',
+      'set',
+
+      // Async
+      // 'async', // conflicts, need a way to enable for fewer scenarios
+      'await',
+
+      // Misc
+      'alias',
+      'dynamic',
+      'nameof',
+      'notnull',
+      'unmanaged',
+      'when',
+      'yield'
     ),
 
     // We use this instead of type so 'void' is only treated as type in the right contexts

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -626,8 +626,12 @@
             "value": "abstract"
           },
           {
-            "type": "STRING",
-            "value": "async"
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "async"
+            }
           },
           {
             "type": "STRING",
@@ -8203,6 +8207,10 @@
         {
           "type": "STRING",
           "value": "set"
+        },
+        {
+          "type": "STRING",
+          "value": "async"
         },
         {
           "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,6 @@
 {
   "name": "c_sharp",
-  "word": "identifier",
+  "word": "_identifier_token",
   "rules": {
     "compilation_unit": {
       "type": "REPEAT",
@@ -557,22 +557,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_identifier_or_global"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_reserved_identifier"
-              },
-              "named": true,
-              "value": "identifier"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_identifier_or_global"
         },
         {
           "type": "STRING",
@@ -626,12 +612,8 @@
             "value": "abstract"
           },
           {
-            "type": "PREC",
-            "value": 1,
-            "content": {
-              "type": "STRING",
-              "value": "async"
-            }
+            "type": "STRING",
+            "value": "async"
           },
           {
             "type": "STRING",
@@ -1150,22 +1132,8 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_reserved_identifier"
-                },
-                "named": true,
-                "value": "identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "identifier"
           }
         },
         {
@@ -7026,15 +6994,6 @@
           "name": "_simple_name"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_reserved_identifier"
-          },
-          "named": true,
-          "value": "identifier"
-        },
-        {
           "type": "SYMBOL",
           "name": "_literal"
         }
@@ -7714,7 +7673,7 @@
         }
       ]
     },
-    "identifier": {
+    "_identifier_token": {
       "type": "TOKEN",
       "content": {
         "type": "SEQ",
@@ -7737,6 +7696,19 @@
           }
         ]
       }
+    },
+    "identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier_token"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_contextual_keywords"
+        }
+      ]
     },
     "global": {
       "type": "STRING",
@@ -8137,7 +8109,7 @@
         ]
       }
     },
-    "_reserved_identifier": {
+    "_contextual_keywords": {
       "type": "CHOICE",
       "members": [
         {
@@ -8207,14 +8179,6 @@
         {
           "type": "STRING",
           "value": "set"
-        },
-        {
-          "type": "STRING",
-          "value": "async"
-        },
-        {
-          "type": "STRING",
-          "value": "await"
         },
         {
           "type": "STRING",
@@ -8364,8 +8328,16 @@
       "member_access_expression"
     ],
     [
-      "from_clause",
-      "_reserved_identifier"
+      "_contextual_keywords",
+      "from_clause"
+    ],
+    [
+      "_contextual_keywords",
+      "accessor_declaration"
+    ],
+    [
+      "_contextual_keywords",
+      "type_parameter_constraint"
     ],
     [
       "_type",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8138,7 +8138,103 @@
       "members": [
         {
           "type": "STRING",
+          "value": "ascending"
+        },
+        {
+          "type": "STRING",
+          "value": "by"
+        },
+        {
+          "type": "STRING",
+          "value": "descending"
+        },
+        {
+          "type": "STRING",
+          "value": "equals"
+        },
+        {
+          "type": "STRING",
           "value": "from"
+        },
+        {
+          "type": "STRING",
+          "value": "group"
+        },
+        {
+          "type": "STRING",
+          "value": "into"
+        },
+        {
+          "type": "STRING",
+          "value": "join"
+        },
+        {
+          "type": "STRING",
+          "value": "let"
+        },
+        {
+          "type": "STRING",
+          "value": "on"
+        },
+        {
+          "type": "STRING",
+          "value": "orderby"
+        },
+        {
+          "type": "STRING",
+          "value": "select"
+        },
+        {
+          "type": "STRING",
+          "value": "where"
+        },
+        {
+          "type": "STRING",
+          "value": "add"
+        },
+        {
+          "type": "STRING",
+          "value": "get"
+        },
+        {
+          "type": "STRING",
+          "value": "remove"
+        },
+        {
+          "type": "STRING",
+          "value": "set"
+        },
+        {
+          "type": "STRING",
+          "value": "await"
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "STRING",
+          "value": "dynamic"
+        },
+        {
+          "type": "STRING",
+          "value": "nameof"
+        },
+        {
+          "type": "STRING",
+          "value": "notnull"
+        },
+        {
+          "type": "STRING",
+          "value": "unmanaged"
+        },
+        {
+          "type": "STRING",
+          "value": "when"
+        },
+        {
+          "type": "STRING",
+          "value": "yield"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2830,6 +2830,11 @@
     }
   },
   {
+    "type": "label_name",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "labeled_statement",
     "named": true,
     "fields": {},
@@ -5283,10 +5288,6 @@
   {
     "type": "join",
     "named": false
-  },
-  {
-    "type": "label_name",
-    "named": true
   },
   {
     "type": "let",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5173,6 +5173,10 @@
     "named": false
   },
   {
+    "type": "dynamic",
+    "named": false
+  },
+  {
     "type": "else",
     "named": false
   },
@@ -5298,6 +5302,10 @@
   },
   {
     "type": "module",
+    "named": false
+  },
+  {
+    "type": "nameof",
     "named": false
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -35,6 +35,7 @@ typedef uint16_t TSStateId;
 typedef struct {
   bool visible : 1;
   bool named : 1;
+  bool supertype: 1;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;
@@ -119,6 +120,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  uint32_t state_count;
 };
 
 /*


### PR DESCRIPTION
Fixes #47 with the exception of `async` and `await` which causes all sorts of issues.

Will revisit those in a future PR/issue so we can get further along with parsing c# repos.

