### PR TITLE
Add cs file extension so tree-sitter can match files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,20 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.12.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.17.1"
   },
   "scripts": {
     "test": "tree-sitter test && node test.js"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.cs",
+      "file-types": [
+        "cs"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This lets `tree-sitter parse` from tree-sitter-cli correctly identify local copy of `tree-sitter-c-sharp` as being responsible for parsing `.cs` files.

Also bumped nan to align with tree-sitter-javascript