### PR TITLE
Added support for lambda discard parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [ ] Extension GetEnumerator
 - [ ] Function pointers
 - [x] Init properties
-- [ ] Lambda discard parameters
+- [x] Lambda discard parameters
 - [ ] Local function attributes
 - [ ] Module initializers
 - [x] Native integers

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -433,6 +433,32 @@ void a() {
             (return_statement (identifier))))))))
 
 ============================
+Anonymous method expression with discard parameters
+============================
+
+void a() {
+  delegate(int _, int _) {
+    return a;
+  };
+}
+
+---
+
+(compilation_unit
+  (method_declaration
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (expression_statement
+        (anonymous_method_expression
+          (parameter_list
+            (parameter (predefined_type) (discard))
+            (parameter (predefined_type) (discard)))
+          (block
+            (return_statement (identifier))))))))
+
+============================
 Lambda expressions
 ============================
 
@@ -518,6 +544,46 @@ void a() {
                 (binary_expression
                   (identifier)
                   (integer_literal))))))))))
+
+============================
+Lambda expression with discard parameters
+============================
+
+void a() {
+  var lam = (_, _) => 0;
+  var bda = (int _, int _) => 0;
+}
+
+---
+
+(compilation_unit
+  (method_declaration
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (local_declaration_statement
+        (variable_declaration
+          (implicit_type)
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (lambda_expression
+                (parameter_list
+                  (parameter (discard))
+                  (parameter (discard)))
+                (integer_literal))))))
+      (local_declaration_statement
+        (variable_declaration
+          (implicit_type)
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (lambda_expression
+                (parameter_list
+                  (parameter (predefined_type) (discard))
+                  (parameter (predefined_type) (discard)))
+                (integer_literal)))))))))
 
 ============================
 Invocation expressions

--- a/grammar.js
+++ b/grammar.js
@@ -71,6 +71,7 @@ module.exports = grammar({
     [$.parameter, $._expression],
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $._variable_designation],
+    [$.parameter, $._pattern],
     [$.tuple_element, $.variable_declarator],
   ],
 
@@ -279,7 +280,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       optional($.parameter_modifier),
       optional(field('type', $._type)),
-      field('name', $.identifier),
+      field('name', choice($.discard, $.identifier)),
       optional($.equals_value_clause)
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1132,8 +1132,17 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "discard"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
           }
         },
         {
@@ -8379,6 +8388,10 @@
     [
       "parameter",
       "_variable_designation"
+    ],
+    [
+      "parameter",
+      "_pattern"
     ],
     [
       "tuple_element",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3531,6 +3531,10 @@
         "required": true,
         "types": [
           {
+            "type": "discard",
+            "named": true
+          },
+          {
             "type": "identifier",
             "named": true
           }


### PR DESCRIPTION
I don't know if the discard should be part of the field called 'name' or not, as it is really not a name of an identifier.