### PR TITLE
Support top level statements from C# 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] Static anonymous functions
 - [ ] Target-typed conditional expression
 - [x] Target-typed new
-- [ ] Top-level statements
+- [x] Top-level statements
 
 ### References
 

--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -7,7 +7,7 @@ var a = Assert.Range(from, to);
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -136,7 +136,7 @@ void Test() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -160,7 +160,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -184,7 +184,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -211,7 +211,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -237,7 +237,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -264,7 +264,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -299,7 +299,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -346,7 +346,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -372,7 +372,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -396,7 +396,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -421,7 +421,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -445,7 +445,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -470,7 +470,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -492,18 +492,20 @@ void a() {
 ============================
 Async Lambda
 ============================
+
 void a()
 {
     Do(async () => {});
 }
 
 ---
+
 (compilation_unit
-  (method_declaration (void_keyword) (identifier) (parameter_list)
-  (block
-    (expression_statement (invocation_expression (identifier)
-    (argument_list
-      (argument (lambda_expression (parameter_list) (initializer_expression)))))))))
+  (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (block
+      (expression_statement (invocation_expression (identifier)
+      (argument_list
+        (argument (lambda_expression (parameter_list) (initializer_expression)))))))))
 
 ============================
 Lambda expression with qualifiers
@@ -517,7 +519,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -557,7 +559,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -595,20 +597,21 @@ void a() {
 
 ---
 
-(compilation_unit (method_declaration
-  (void_keyword)
-  (identifier)
-  (parameter_list)
-  (block
-    (expression_statement
-      (invocation_expression
-        (identifier)
-        (argument_list
-          (argument (identifier))
-          (argument (identifier))
-          (argument (identifier))
-          (argument (identifier))
-          (argument (declaration_expression (implicit_type) (identifier)))))))))
+(compilation_unit
+  (local_function_statement
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (expression_statement
+        (invocation_expression
+          (identifier)
+          (argument_list
+            (argument (identifier))
+            (argument (identifier))
+            (argument (identifier))
+            (argument (identifier))
+            (argument (declaration_expression (implicit_type) (identifier)))))))))
 
 ============================
 Tuple expressions
@@ -621,7 +624,7 @@ void a() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -646,7 +649,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -674,7 +677,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -708,7 +711,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -736,7 +739,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -766,7 +769,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -814,7 +817,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -853,7 +856,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -880,7 +883,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -907,7 +910,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -932,7 +935,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -958,7 +961,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -983,7 +986,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -1012,7 +1015,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -1050,7 +1053,7 @@ void b() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -1301,7 +1304,7 @@ var t = typeof(Tuple<,,,>);
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1311,7 +1314,7 @@ var t = typeof(Tuple<,,,>);
             (generic_name
               (identifier)
               (type_argument_list)))))))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1331,7 +1334,7 @@ int b = default;
 
 ---
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1339,7 +1342,7 @@ int b = default;
         (equals_value_clause
           (default_expression
             (predefined_type))))))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator
@@ -1357,7 +1360,7 @@ ref var elementRef = ref arr[0];
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (identifier)
@@ -1366,7 +1369,7 @@ ref var elementRef = ref arr[0];
         (equals_value_clause
           (ref_expression
             (identifier))))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (implicit_type)
@@ -1389,7 +1392,7 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1415,7 +1418,7 @@ var x = dict?["a"];
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1439,7 +1442,7 @@ void Test(){
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -1474,7 +1477,7 @@ var b = s is string;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1494,7 +1497,7 @@ var c = s is "test";
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1505,7 +1508,7 @@ var c = s is "test";
             (declaration_pattern
               (predefined_type)
               (identifier)))))))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1527,7 +1530,7 @@ void Do() {
 ---
 
 (compilation_unit
-  (method_declaration
+  (local_function_statement
     (void_keyword)
     (identifier)
     (parameter_list)
@@ -1546,7 +1549,7 @@ var x = name!.Length;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1565,7 +1568,7 @@ var x = name is not null;
 
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1585,7 +1588,7 @@ var x = name is (var a);
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1605,7 +1608,7 @@ var x = c is < '0' or >= 'A' and <= 'Z';
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -1628,7 +1631,7 @@ var x = !this.Call();
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator

--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -7,7 +7,7 @@ int x = y;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (identifier))))))
@@ -21,7 +21,7 @@ int @var = @const;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (identifier))))))
@@ -36,11 +36,11 @@ int nuint = 0;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (integer_literal))))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -11,32 +11,32 @@ const UInt16 bin2 = 0B01010__10;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (identifier)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (identifier)
       (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (identifier)
@@ -51,7 +51,7 @@ const bool t = true, u = false;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
@@ -71,27 +71,27 @@ const char uni32 = '\UA0BFf9ca';
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (character_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
@@ -112,37 +112,37 @@ const Decimal m2 = 102.349M;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (identifier)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (identifier)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (predefined_type)
     (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
     (identifier)
@@ -157,7 +157,7 @@ const string x = null;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (modifier)
     (variable_declaration
       (predefined_type)
@@ -476,7 +476,7 @@ class A {
               (interpolated_verbatim_string_text)))))))))
 
 ==================================================
-interpolated verbatim string literals bracket escapes
+interpolated verbatim string literals bracket escapes (WRONG!)
 ==================================================
 
 string s = $@"
@@ -492,7 +492,7 @@ class A
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -14,17 +14,17 @@ If, elif and else directives
 
 (compilation_unit
   (preprocessor_call (preprocessor_directive) (identifier))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (string_literal)))))
   (preprocessor_call (preprocessor_directive) (identifier))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (string_literal)))))
   (preprocessor_call (preprocessor_directive))
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (string_literal)))))

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -7,7 +7,7 @@ var x = from a in source select a.B;
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -31,7 +31,7 @@ var x = from a in source select { Name = a.B };
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -61,7 +61,7 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -91,7 +91,7 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -133,7 +133,7 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -167,7 +167,7 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -200,7 +200,7 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -240,7 +240,7 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator
@@ -281,7 +281,7 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration
       (implicit_type)
       (variable_declarator

--- a/corpus/records.txt
+++ b/corpus/records.txt
@@ -182,7 +182,7 @@ void A() {
 ---
 
 (compilation_unit
-  (method_declaration (void_keyword) (identifier) (parameter_list)
+  (local_function_statement (void_keyword) (identifier) (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration
@@ -211,7 +211,7 @@ void A() {
 ---
 
 (compilation_unit
-  (method_declaration (void_keyword) (identifier) (parameter_list)
+  (local_function_statement (void_keyword) (identifier) (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -155,7 +155,7 @@ var a = 1;
 
 ---
 (compilation_unit
-  (field_declaration
+  (local_declaration_statement
     (variable_declaration (implicit_type)
       (variable_declarator (identifier)
         (equals_value_clause (integer_literal))))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1190,7 +1190,7 @@ void A() {
 ---
 
  (compilation_unit
-  (method_declaration (void_keyword) (identifier) (parameter_list)
+  (local_function_statement (void_keyword) (identifier) (parameter_list)
     (block
       (local_declaration_statement
         (variable_declaration (identifier)
@@ -1212,44 +1212,44 @@ async void Sample() {
 ---
 
 (compilation_unit
-  (method_declaration
-      (modifier)
-      (void_keyword)
-      (identifier)
-      (parameter_list)
-      (block
-        (local_declaration_statement
-          (variable_declaration (implicit_type)
-            (variable_declarator (identifier)
-              (equals_value_clause (string_literal)))))
-        (local_declaration_statement
-          (variable_declaration (predefined_type)
-            (variable_declarator (identifier)
-              (equals_value_clause (identifier)))))
-        (local_declaration_statement
-          (variable_declaration (identifier)
-            (variable_declarator (identifier)
-              (equals_value_clause (identifier)))))
-        (local_declaration_statement
-          (variable_declaration (identifier)
-            (variable_declarator (identifier)
-              (equals_value_clause (identifier)))))
-       (local_declaration_statement
-          (variable_declaration (identifier)
-            (variable_declarator (identifier)
-              (equals_value_clause
+  (local_function_statement
+    (modifier)
+    (void_keyword)
+    (identifier)
+    (parameter_list)
+    (block
+      (local_declaration_statement
+        (variable_declaration (implicit_type)
+          (variable_declarator (identifier)
+            (equals_value_clause (string_literal)))))
+      (local_declaration_statement
+        (variable_declaration (predefined_type)
+          (variable_declarator (identifier)
+            (equals_value_clause (identifier)))))
+      (local_declaration_statement
+        (variable_declaration (identifier)
+          (variable_declarator (identifier)
+            (equals_value_clause (identifier)))))
+      (local_declaration_statement
+        (variable_declaration (identifier)
+          (variable_declarator (identifier)
+            (equals_value_clause (identifier)))))
+      (local_declaration_statement
+        (variable_declaration (identifier)
+          (variable_declarator (identifier)
+            (equals_value_clause
+              (binary_expression
                 (binary_expression
                   (binary_expression
                     (binary_expression
                       (binary_expression
                         (binary_expression
                           (binary_expression
-                            (binary_expression
-                              (binary_expression (identifier) (identifier))
-                            (identifier))
+                            (binary_expression (identifier) (identifier))
                           (identifier))
                         (identifier))
                       (identifier))
                     (identifier))
                   (identifier))
-                (identifier)))))))))
+                (identifier))
+              (identifier)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -84,10 +84,15 @@ module.exports = grammar({
 
   rules: {
     // Intentionally deviates from spec so that we can syntax highlight fragments of code
-    compilation_unit: $ => repeat($._declaration),
+    compilation_unit: $ => seq(
+      repeat($.extern_alias_directive),
+      repeat($.using_directive),
+      repeat($.global_attribute_list),
+      repeat($._statement),
+      repeat($._namespace_member_declaration)
+    ),
 
     _declaration: $ => choice(
-      $.global_attribute_list,
       $.class_declaration,
       $.constructor_declaration,
       $.conversion_operator_declaration,
@@ -95,7 +100,6 @@ module.exports = grammar({
       $.destructor_declaration,
       $.enum_declaration,
       $.event_declaration,
-      $.extern_alias_directive,
       $.event_field_declaration,
       $.field_declaration,
       $.indexer_declaration,
@@ -107,6 +111,20 @@ module.exports = grammar({
       $.record_declaration,
       $.struct_declaration,
       $.using_directive,
+    ),
+
+    _namespace_member_declaration: $ => choice(
+      $.namespace_declaration,
+      $._type_declaration
+    ),
+
+    _type_declaration: $ => choice(
+      $.class_declaration,
+      $.struct_declaration,
+      $.interface_declaration,
+      $.enum_declaration,
+      $.delegate_declaration,
+      $.record_declaration
     ),
 
     extern_alias_directive: $ => seq('extern', 'alias', $.identifier, ';'),

--- a/grammar.js
+++ b/grammar.js
@@ -45,8 +45,6 @@ module.exports = grammar({
   conflicts: $ => [
     [$.block, $.initializer_expression],
 
-    [$.element_access_expression, $.enum_member_declaration],
-
     [$.event_declaration, $.variable_declarator],
 
     [$.nullable_type, $.binary_expression],
@@ -59,7 +57,7 @@ module.exports = grammar({
     [$.qualified_name, $.explicit_interface_specifier],
     [$.qualified_name, $.member_access_expression],
 
-    [$._contextual_keywords, $.from_clause, ],
+    [$._contextual_keywords, $.from_clause],
     [$._contextual_keywords, $.accessor_declaration],
     [$._contextual_keywords, $.type_parameter_constraint],
 
@@ -72,7 +70,6 @@ module.exports = grammar({
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $._variable_designation],
     [$.parameter, $._pattern],
-    [$.tuple_element, $.variable_declarator],
   ],
 
   inline: $ => [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8900,10 +8900,6 @@
       "initializer_expression"
     ],
     [
-      "element_access_expression",
-      "enum_member_declaration"
-    ],
-    [
       "event_declaration",
       "variable_declarator"
     ],
@@ -8979,10 +8975,6 @@
     [
       "parameter",
       "_pattern"
-    ],
-    [
-      "tuple_element",
-      "variable_declarator"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3,19 +3,48 @@
   "word": "_identifier_token",
   "rules": {
     "compilation_unit": {
-      "type": "REPEAT",
-      "content": {
-        "type": "SYMBOL",
-        "name": "_declaration"
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "extern_alias_directive"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "using_directive"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "global_attribute_list"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_namespace_member_declaration"
+          }
+        }
+      ]
     },
     "_declaration": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "global_attribute_list"
-        },
         {
           "type": "SYMBOL",
           "name": "class_declaration"
@@ -43,10 +72,6 @@
         {
           "type": "SYMBOL",
           "name": "event_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "extern_alias_directive"
         },
         {
           "type": "SYMBOL",
@@ -91,6 +116,48 @@
         {
           "type": "SYMBOL",
           "name": "using_directive"
+        }
+      ]
+    },
+    "_namespace_member_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "namespace_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_type_declaration"
+        }
+      ]
+    },
+    "_type_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "class_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interface_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "delegate_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_declaration"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,15 +36,7 @@
         "named": true
       },
       {
-        "type": "extern_alias_directive",
-        "named": true
-      },
-      {
         "type": "field_declaration",
-        "named": true
-      },
-      {
-        "type": "global_attribute_list",
         "named": true
       },
       {
@@ -1410,7 +1402,47 @@
       "required": false,
       "types": [
         {
-          "type": "_declaration",
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "delegate_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "extern_alias_directive",
+          "named": true
+        },
+        {
+          "type": "global_attribute_list",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "namespace_declaration",
+          "named": true
+        },
+        {
+          "type": "record_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "using_directive",
           "named": true
         }
       ]


### PR DESCRIPTION
Now that C# 9.0 supports top-level statements we can remove our workarounds we were using for fragment markup.

This means code we previously hacked as `field_declaration` is now `local_declaration_statement` and `method_declaration` is `local_function_statement` (basically we now treat functions and variables as if they were defined inside an invisible function like C# 9.0 specifies - previously we treated them as if they were on an invisible class).

Fixes #113