### PR TITLE
Treat top-level as global statements as per Roslyn

### DIFF
--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -7,12 +7,13 @@ var a = Assert.Range(from, to);
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (invocation_expression
-            (member_access_expression (identifier) (identifier))
-            (argument_list (argument (identifier)) (argument (identifier))))))))) 
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (invocation_expression
+              (member_access_expression (identifier) (identifier))
+              (argument_list (argument (identifier)) (argument (identifier)))))))))) 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -136,17 +136,18 @@ void Test() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement (assignment_expression
-        (identifier)
-        (assignment_operator)
-        (binary_expression
-          (cast_expression (identifier) (identifier))
-          (cast_expression (identifier) (identifier))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement (assignment_expression
+          (identifier)
+          (assignment_operator)
+          (binary_expression
+            (cast_expression (identifier) (identifier))
+            (cast_expression (identifier) (identifier)))))))))
 
 ============================
 Anonymous object creation with empty body
@@ -160,18 +161,19 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-          (identifier)
-            (equals_value_clause
-              (anonymous_object_creation_expression))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+            (identifier)
+              (equals_value_clause
+                (anonymous_object_creation_expression)))))))))
 
 ============================
 Target-type object creation
@@ -184,19 +186,20 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (identifier)
-          (variable_declarator
-          (identifier)
-            (equals_value_clause
-              (implicit_object_creation_expression
-                (argument_list (argument (string_literal)))))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (identifier)
+            (variable_declarator
+            (identifier)
+              (equals_value_clause
+                (implicit_object_creation_expression
+                  (argument_list (argument (string_literal))))))))))))
 
 ============================
 Anonymous object creation with single unnamed
@@ -211,18 +214,19 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-          (identifier)
-            (equals_value_clause
-              (anonymous_object_creation_expression (identifier)))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+            (identifier)
+              (equals_value_clause
+                (anonymous_object_creation_expression (identifier))))))))))
 
 ============================
 Anonymous object creation with single named
@@ -237,21 +241,22 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-          (identifier)
-            (equals_value_clause
-              (anonymous_object_creation_expression
-                (name_equals
-                  (identifier))
-                (string_literal)))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+            (identifier)
+              (equals_value_clause
+                (anonymous_object_creation_expression
+                  (name_equals
+                    (identifier))
+                  (string_literal))))))))))
 
 ============================
 Checked expressions
@@ -264,21 +269,22 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (checked_expression
-                (binary_expression
-                  (integer_literal)
-                  (integer_literal))))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (checked_expression
+                  (binary_expression
+                    (integer_literal)
+                    (integer_literal)))))))))))
 
 ============================
 Object creation expressions
@@ -299,41 +305,42 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (object_creation_expression
-          (qualified_name (identifier) (identifier))
-          (argument_list
-            (argument (integer_literal))
-            (argument (string_literal)))))
-      (expression_statement
-        (assignment_expression
-          (identifier)
-          (assignment_operator)
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement
           (object_creation_expression
+            (qualified_name (identifier) (identifier))
+            (argument_list
+              (argument (integer_literal))
+              (argument (string_literal)))))
+        (expression_statement
+          (assignment_expression
             (identifier)
-            (initializer_expression
-              (assignment_expression
-                (identifier) (assignment_operator) (identifier))))))
-      (expression_statement
-        (assignment_expression
-          (identifier)
-          (assignment_operator)
-          (object_creation_expression
+            (assignment_operator)
+            (object_creation_expression
+              (identifier)
+              (initializer_expression
+                (assignment_expression
+                  (identifier) (assignment_operator) (identifier))))))
+        (expression_statement
+          (assignment_expression
             (identifier)
-            (argument_list (argument (integer_literal))))))
-      (expression_statement
-        (assignment_expression
-          (identifier)
-          (assignment_operator)
-          (object_creation_expression
+            (assignment_operator)
+            (object_creation_expression
+              (identifier)
+              (argument_list (argument (integer_literal))))))
+        (expression_statement
+          (assignment_expression
             (identifier)
-            (argument_list (argument (integer_literal)))
-            (initializer_expression)))))))
+            (assignment_operator)
+            (object_creation_expression
+              (identifier)
+              (argument_list (argument (integer_literal)))
+              (initializer_expression))))))))
 
 ============================
 Named parameters in constructors
@@ -346,20 +353,20 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration (implicit_type)
-          (variable_declarator (identifier)
-            (equals_value_clause
-              (object_creation_expression (identifier)
-                (argument_list
-                  (argument (name_colon (identifier)) (integer_literal))
-                  (argument (name_colon (identifier)) (string_literal)))))))))))
-
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause
+                (object_creation_expression (identifier)
+                  (argument_list
+                    (argument (name_colon (identifier)) (integer_literal))
+                    (argument (name_colon (identifier)) (string_literal))))))))))))
 
 ============================
 Named parameters in method calls
@@ -372,18 +379,19 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (assignment_expression (identifier) (assignment_operator)
-          (invocation_expression
-            (member_access_expression (identifier) (identifier))
-            (argument_list
-              (argument (name_colon (identifier)) (integer_literal))
-              (argument (name_colon (identifier)) (string_literal)))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement
+          (assignment_expression (identifier) (assignment_operator)
+            (invocation_expression
+              (member_access_expression (identifier) (identifier))
+              (argument_list
+                (argument (name_colon (identifier)) (integer_literal))
+                (argument (name_colon (identifier)) (string_literal))))))))))
 
 ============================
 Named parameters using contextually reserved words
@@ -396,17 +404,18 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (assignment_expression (identifier) (assignment_operator)
-          (invocation_expression (identifier)
-            (argument_list
-              (argument (name_colon (identifier)) (integer_literal))
-              (argument (name_colon (identifier)) (string_literal)))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement
+          (assignment_expression (identifier) (assignment_operator)
+            (invocation_expression (identifier)
+              (argument_list
+                (argument (name_colon (identifier)) (integer_literal))
+                (argument (name_colon (identifier)) (string_literal))))))))))
 
 ============================
 Anonymous method expressions
@@ -421,16 +430,16 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (anonymous_method_expression
-          (parameter_list (parameter (predefined_type) (identifier)))
-          (block
-            (return_statement (identifier))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement
+          (anonymous_method_expression
+            (parameter_list (parameter (predefined_type) (identifier)))
+            (block (return_statement (identifier)))))))))
 
 ============================
 Anonymous method expression with discard parameters
@@ -445,18 +454,18 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (anonymous_method_expression
-          (parameter_list
-            (parameter (predefined_type) (discard))
-            (parameter (predefined_type) (discard)))
-          (block
-            (return_statement (identifier))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (expression_statement
+          (anonymous_method_expression
+            (parameter_list
+              (parameter (predefined_type) (discard))
+              (parameter (predefined_type) (discard)))
+            (block (return_statement (identifier)))))))))
 
 ============================
 Lambda expressions
@@ -470,24 +479,22 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (lambda_expression
-          (identifier)
-          (binary_expression (identifier) (integer_literal))))
-      (expression_statement
-        (lambda_expression
-          (parameter_list
-            (parameter (identifier) (identifier))
-            (parameter (identifier) (identifier)))
-          (block (return_statement
-            (invocation_expression
-              (member_access_expression (identifier) (identifier))
-              (argument_list (argument (identifier)))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement
+          (lambda_expression
+            (identifier)
+            (binary_expression (identifier) (integer_literal))))
+        (expression_statement
+          (lambda_expression
+            (parameter_list
+              (parameter (identifier) (identifier))
+              (parameter (identifier) (identifier)))
+            (block (return_statement
+              (invocation_expression
+                (member_access_expression (identifier) (identifier))
+                (argument_list (argument (identifier))))))))))))
          
 ============================
 Async Lambda
@@ -501,11 +508,12 @@ void a()
 ---
 
 (compilation_unit
-  (local_function_statement (void_keyword) (identifier) (parameter_list)
-    (block
-      (expression_statement (invocation_expression (identifier)
-      (argument_list
-        (argument (lambda_expression (parameter_list) (initializer_expression)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement (invocation_expression (identifier)
+        (argument_list
+          (argument (lambda_expression (parameter_list) (initializer_expression))))))))))
 
 ============================
 Lambda expression with qualifiers
@@ -519,33 +527,31 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (lambda_expression
-                (identifier)
-                (binary_expression
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
                   (identifier)
-                  (integer_literal)))))))
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (lambda_expression
-                (identifier)
-                (binary_expression
+                  (binary_expression
+                    (identifier)
+                    (integer_literal)))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
                   (identifier)
-                  (integer_literal))))))))))
+                  (binary_expression
+                    (identifier)
+                    (integer_literal)))))))))))
 
 ============================
 Lambda expression with discard parameters
@@ -559,33 +565,31 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (lambda_expression
-                (parameter_list
-                  (parameter (discard))
-                  (parameter (discard)))
-                (integer_literal))))))
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (lambda_expression
-                (parameter_list
-                  (parameter (predefined_type) (discard))
-                  (parameter (predefined_type) (discard)))
-                (integer_literal)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (parameter_list
+                    (parameter (discard))
+                    (parameter (discard)))
+                  (integer_literal))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (parameter_list
+                    (parameter (predefined_type) (discard))
+                    (parameter (predefined_type) (discard)))
+                  (integer_literal))))))))))
 
 ============================
 Invocation expressions
@@ -598,20 +602,18 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (invocation_expression
-          (identifier)
-          (argument_list
-            (argument (identifier))
-            (argument (identifier))
-            (argument (identifier))
-            (argument (identifier))
-            (argument (declaration_expression (implicit_type) (identifier)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement
+          (invocation_expression
+            (identifier)
+            (argument_list
+              (argument (identifier))
+              (argument (identifier))
+              (argument (identifier))
+              (argument (identifier))
+              (argument (declaration_expression (implicit_type) (identifier))))))))))
 
 ============================
 Tuple expressions
@@ -624,19 +626,17 @@ void a() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement (assignment_expression
-        (identifier)
-        (assignment_operator)
-        (tuple_expression
-          (argument (identifier))
-          (argument
-            (name_colon (identifier))
-            (string_literal))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement (assignment_expression
+          (identifier)
+          (assignment_operator)
+          (tuple_expression
+            (argument (identifier))
+            (argument
+              (name_colon (identifier))
+              (string_literal)))))))))
 
 ============================
 Implicit array creation
@@ -649,22 +649,20 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (implicit_array_creation_expression
-                (initializer_expression
-                  (integer_literal)
-                  (integer_literal)
-                  (integer_literal))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (implicit_array_creation_expression
+                  (initializer_expression
+                    (integer_literal)
+                    (integer_literal)
+                    (integer_literal)))))))))))
 
 ============================
 Implicit multi array creation
@@ -677,28 +675,26 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (implicit_array_creation_expression
-                (initializer_expression
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (implicit_array_creation_expression
                   (initializer_expression
-                    (integer_literal)
-                    (integer_literal))
-                  (initializer_expression
-                    (integer_literal)
-                    (integer_literal))
-                  (initializer_expression
-                    (integer_literal)
-                    (integer_literal)))))))))))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))))))))))))
 
 ============================
 Stackalloc implicit array
@@ -711,22 +707,20 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (implicit_stack_alloc_array_creation_expression
-                (initializer_expression
-                  (integer_literal)
-                  (integer_literal)
-                  (integer_literal))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (implicit_stack_alloc_array_creation_expression
+                  (initializer_expression
+                    (integer_literal)
+                    (integer_literal)
+                    (integer_literal)))))))))))
 
 ============================
 Stackalloc explicit array
@@ -739,23 +733,21 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (stack_alloc_array_creation_expression
-                (array_type (predefined_type) (array_rank_specifier))
-                (initializer_expression
-                  (integer_literal)
-                  (integer_literal)
-                  (integer_literal))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (stack_alloc_array_creation_expression
+                  (array_type (predefined_type) (array_rank_specifier))
+                  (initializer_expression
+                    (integer_literal)
+                    (integer_literal)
+                    (integer_literal)))))))))))
 
 ============================
 Explicit array creation
@@ -769,25 +761,9 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (array_creation_expression
-                (array_type
-                  (predefined_type)
-                  (array_rank_specifier (integer_literal)))
-                (initializer_expression
-                  (integer_literal)
-                  (integer_literal)
-                  (integer_literal)))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
         (local_declaration_statement
           (variable_declaration
             (implicit_type)
@@ -797,14 +773,28 @@ void b() {
                 (array_creation_expression
                   (array_type
                     (predefined_type)
-                    (array_rank_specifier))
+                    (array_rank_specifier (integer_literal)))
                   (initializer_expression
+                    (integer_literal)
+                    (integer_literal)
+                    (integer_literal)))))))
+          (local_declaration_statement
+            (variable_declaration
+              (implicit_type)
+              (variable_declarator
+                (identifier)
+                (equals_value_clause
+                  (array_creation_expression
+                    (array_type
+                      (predefined_type)
+                      (array_rank_specifier))
                     (initializer_expression
-                      (integer_literal)
-                      (integer_literal))
-                    (initializer_expression
-                      (integer_literal)
-                      (integer_literal)))))))))))
+                      (initializer_expression
+                        (integer_literal)
+                        (integer_literal))
+                      (initializer_expression
+                        (integer_literal)
+                        (integer_literal))))))))))))
 
 ============================
 Explicit multi array creation
@@ -817,33 +807,31 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (array_creation_expression
-                (array_type
-                  (predefined_type)
-                  (array_rank_specifier
-                    (integer_literal)
-                    (integer_literal)))
-                (initializer_expression
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (array_creation_expression
+                  (array_type
+                    (predefined_type)
+                    (array_rank_specifier
+                      (integer_literal)
+                      (integer_literal)))
                   (initializer_expression
-                    (integer_literal)
-                    (integer_literal))
-                  (initializer_expression
-                    (integer_literal)
-                    (integer_literal))
-                  (initializer_expression
-                    (integer_literal)
-                    (integer_literal)))))))))))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))
+                    (initializer_expression
+                      (integer_literal)
+                      (integer_literal))))))))))))
 
 ============================
 Makeref
@@ -856,19 +844,17 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (make_ref_expression
-                (identifier)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (make_ref_expression
+                  (identifier))))))))))
 
 ============================
 Postfix unary
@@ -883,21 +869,19 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement (postfix_unary_expression (identifier)))
-      (expression_statement (postfix_unary_expression (identifier)))
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (postfix_unary_expression
-                (identifier)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement (postfix_unary_expression (identifier)))
+        (expression_statement (postfix_unary_expression (identifier)))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (postfix_unary_expression
+                  (identifier))))))))))
 
 ============================
 __reftype
@@ -910,19 +894,17 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (ref_type_expression
-                (identifier)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ref_type_expression
+                  (identifier))))))))))
 
 ============================
 __refvalue
@@ -935,20 +917,18 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (ref_value_expression
-                (identifier)
-                (predefined_type)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ref_value_expression
+                  (identifier)
+                  (predefined_type))))))))))
 
 ============================
 sizeof
@@ -961,19 +941,17 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (size_of_expression
-                (predefined_type)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (size_of_expression
+                  (predefined_type))))))))))
 
 ============================
 typeof
@@ -986,19 +964,17 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (type_of_expression
-                (predefined_type)))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (type_of_expression
+                  (predefined_type))))))))))
 
 ============================
 switch expression
@@ -1015,28 +991,26 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (switch_expression
-                (identifier)
-                (switch_expression_arm
-                  (constant_pattern (integer_literal))
-                  (string_literal))
-                (switch_expression_arm
-                  (constant_pattern (integer_literal))
-                  (string_literal))
-                (switch_expression_arm
-                  (discard)
-                  (string_literal))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (switch_expression
+                  (identifier)
+                  (switch_expression_arm
+                    (constant_pattern (integer_literal))
+                    (string_literal))
+                  (switch_expression_arm
+                    (constant_pattern (integer_literal))
+                    (string_literal))
+                  (switch_expression_arm
+                    (discard)
+                    (string_literal)))))))))))
 
 ============================
 switch expression with trailing comma
@@ -1053,28 +1027,26 @@ void b() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (switch_expression
-                (identifier)
-                (switch_expression_arm
-                  (constant_pattern (integer_literal))
-                  (string_literal))
-                (switch_expression_arm
-                  (constant_pattern (integer_literal))
-                  (string_literal))
-                (switch_expression_arm
-                  (discard)
-                  (string_literal))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (switch_expression
+                  (identifier)
+                  (switch_expression_arm
+                    (constant_pattern (integer_literal))
+                    (string_literal))
+                  (switch_expression_arm
+                    (constant_pattern (integer_literal))
+                    (string_literal))
+                  (switch_expression_arm
+                    (discard)
+                    (string_literal)))))))))))
 
 =====================================
 await Expression
@@ -1304,26 +1276,28 @@ var t = typeof(Tuple<,,,>);
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (type_of_expression
-            (generic_name
-              (identifier)
-              (type_argument_list)))))))
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (type_of_expression
-            (generic_name
-              (identifier)
-              (type_argument_list))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (type_of_expression
+              (generic_name
+                (identifier)
+                (type_argument_list))))))))
+    (global_statement
+      (local_declaration_statement
+        (variable_declaration
+          (implicit_type)
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (type_of_expression
+                (generic_name
+                  (identifier)
+                  (type_argument_list)))))))))
 
 =====================================
 default expression
@@ -1334,21 +1308,23 @@ int b = default;
 
 ---
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (default_expression
-            (predefined_type))))))
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (default_expression))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (default_expression
+              (predefined_type)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (default_expression)))))))
 
 =====================================
 Generic type name no type args
@@ -1360,28 +1336,30 @@ ref var elementRef = ref arr[0];
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (identifier)
-      (variable_declarator
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
         (identifier)
-        (equals_value_clause
-          (ref_expression
-            (identifier))))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (ref_expression
-            (element_access_expression
-              (identifier)
-              (bracketed_argument_list
-                (argument
-                  (integer_literal))))))))))
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (ref_expression
+              (identifier)))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (ref_expression
+              (element_access_expression
+                (identifier)
+                (bracketed_argument_list
+                  (argument
+                    (integer_literal)))))))))))
 
 =====================================
 Element binding expression
@@ -1392,22 +1370,23 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (object_creation_expression
-            (generic_name
-              (identifier)
-              (type_argument_list (predefined_type) (predefined_type)))
-            (initializer_expression
-              (assignment_expression
-                (element_binding_expression
-                  (bracketed_argument_list (argument (string_literal))))
-                (assignment_operator)
-                (integer_literal)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (object_creation_expression
+              (generic_name
+                (identifier)
+                (type_argument_list (predefined_type) (predefined_type)))
+              (initializer_expression
+                (assignment_expression
+                  (element_binding_expression
+                    (bracketed_argument_list (argument (string_literal))))
+                  (assignment_operator)
+                  (integer_literal))))))))))
 
 =====================================
 Conditional access to element (should be implicit_element_access)
@@ -1418,16 +1397,17 @@ var x = dict?["a"];
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (conditional_access_expression
-            (identifier)
-              (element_binding_expression
-                (bracketed_argument_list (argument (string_literal))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_access_expression
+              (identifier)
+                (element_binding_expression
+                  (bracketed_argument_list (argument (string_literal)))))))))))
 
 =====================================
 Member access expression
@@ -1442,31 +1422,29 @@ void Test(){
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (expression_statement
-        (invocation_expression
-          (member_access_expression
-            (identifier)
-            (identifier))
-          (argument_list
-            (argument
-              (identifier)))))
-      (expression_statement
-        (invocation_expression
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (expression_statement
+          (invocation_expression
+            (member_access_expression
+              (identifier)
+              (identifier))
+            (argument_list
+              (argument
+                (identifier)))))
+        (expression_statement
+          (invocation_expression
+            (member_access_expression
+              (predefined_type)
+              (identifier))
+            (argument_list
+              (argument
+                (identifier)))))
+        (expression_statement
           (member_access_expression
             (predefined_type)
-            (identifier))
-          (argument_list
-            (argument
-              (identifier)))))
-      (expression_statement
-        (member_access_expression
-          (predefined_type)
-          (identifier))))))
+            (identifier)))))))
 
 =====================================
 is expression
@@ -1477,15 +1455,16 @@ var b = s is string;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (binary_expression
-            (identifier)
-            (predefined_type)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (binary_expression
+              (identifier)
+              (predefined_type))))))))
 
 =====================================
 is pattern
@@ -1497,27 +1476,29 @@ var c = s is "test";
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (declaration_pattern
-              (predefined_type)
-              (identifier)))))))
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-              (constant_pattern
-                (string_literal))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (declaration_pattern
+                (predefined_type)
+                (identifier))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+                (constant_pattern
+                  (string_literal)))))))))
 
 =====================================
 Discard pattern
@@ -1530,15 +1511,16 @@ void Do() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-      (block
-        (expression_statement
-          (invocation_expression
-            (member_access_expression (identifier) (identifier))
-            (argument_list (argument (identifier)) (argument (identifier))))))))
+  (global_statement
+    (local_function_statement
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+        (block
+          (expression_statement
+            (invocation_expression
+              (member_access_expression (identifier) (identifier))
+              (argument_list (argument (identifier)) (argument (identifier)))))))))
 
 =====================================
 Null-forgiving operator
@@ -1549,14 +1531,15 @@ var x = name!.Length;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (member_access_expression (postfix_unary_expression (identifier))
-          (identifier)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (member_access_expression (postfix_unary_expression (identifier))
+            (identifier))))))))
 
 =====================================
 Negated pattern
@@ -1568,16 +1551,17 @@ var x = name is not null;
 
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (negated_pattern
-              (constant_pattern (null_literal)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (negated_pattern
+                (constant_pattern (null_literal))))))))))
 
 =====================================
 Parenthesized pattern
@@ -1588,16 +1572,17 @@ var x = name is (var a);
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (parenthesized_pattern
-              (var_pattern (identifier)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (parenthesized_pattern
+                (var_pattern (identifier))))))))))
 
 =====================================
 Pattern Combinators and relational pattern
@@ -1608,19 +1593,20 @@ var x = c is < '0' or >= 'A' and <= 'Z';
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (is_pattern_expression
-            (identifier)
-            (binary_pattern
-              (relational_pattern (character_literal))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
               (binary_pattern
                 (relational_pattern (character_literal))
-                (relational_pattern (character_literal))))))))))
+                (binary_pattern
+                  (relational_pattern (character_literal))
+                  (relational_pattern (character_literal)))))))))))
 
 =====================================
 Precedence of prefix_unary_expression and invocation_expression
@@ -1631,15 +1617,14 @@ var x = !this.Call();
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (prefix_unary_expression
-            (invocation_expression
-              (member_access_expression
-                (this_expression)
-                (identifier))
-              (argument_list))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (prefix_unary_expression
+              (invocation_expression
+                (member_access_expression (this_expression) (identifier))
+                (argument_list)))))))))

--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -7,10 +7,11 @@ int x = y;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (identifier))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (identifier)))))))
 
 =======================================
 indentifiers with keyword names
@@ -21,10 +22,11 @@ int @var = @const;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (identifier))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (identifier)))))))
 
 =======================================
 indentifiers with contextual keyword names
@@ -36,11 +38,13 @@ int nuint = 0;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal)))))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -11,36 +11,42 @@ const UInt16 bin2 = 0B01010__10;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (identifier)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (identifier)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (identifier)
-      (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (identifier)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (identifier)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (identifier)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal)))))))
 
 =======================================
 boolean literals
@@ -51,12 +57,13 @@ const bool t = true, u = false;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (boolean_literal)))
-      (variable_declarator (identifier) (equals_value_clause (boolean_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (boolean_literal)))
+        (variable_declarator (identifier) (equals_value_clause (boolean_literal)))))))
 
 =======================================
 char literals
@@ -71,31 +78,36 @@ const char uni32 = '\UA0BFf9ca';
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (character_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
       (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (character_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence)))))))
+        (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence)))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence)))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence)))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (character_literal (escape_sequence))))))))
 
 =======================================
 real literals
@@ -112,41 +124,48 @@ const Decimal m2 = 102.349M;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (identifier)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (identifier)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (predefined_type)
-    (variable_declarator (identifier) (equals_value_clause (real_literal)))))
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-    (identifier)
-    (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (identifier)
+      (variable_declarator (identifier) (equals_value_clause (real_literal)))))))
 
 =======================================
 null literals
@@ -157,11 +176,12 @@ const string x = null;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (modifier)
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (null_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (null_literal)))))))
 
 =======================================
 string literals
@@ -244,13 +264,14 @@ multi-line";
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (verbatim_string_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (verbatim_string_literal)))))))
 
 ==================================================
 string literals containing the line comment token
@@ -506,13 +527,14 @@ line";
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (interpolated_string_expression (interpolated_verbatim_string_text)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression (interpolated_verbatim_string_text))))))))
 
 ==================================================
 interpolated verbatim string literals bracket escapes
@@ -531,19 +553,20 @@ class A
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (interpolated_string_expression
-            (interpolated_verbatim_string_text)
-            (interpolated_verbatim_string_text)
-            (interpolated_verbatim_string_text)
-            (interpolated_verbatim_string_text)
-            (interpolated_verbatim_string_text)
-            (interpolation (identifier))
-            (interpolated_verbatim_string_text)
-            (interpolation (identifier))
-            (interpolated_verbatim_string_text)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_verbatim_string_text)
+              (interpolated_verbatim_string_text)
+              (interpolated_verbatim_string_text)
+              (interpolated_verbatim_string_text)
+              (interpolated_verbatim_string_text)
+              (interpolation (identifier))
+              (interpolated_verbatim_string_text)
+              (interpolation (identifier))
+              (interpolated_verbatim_string_text))))))))

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -14,20 +14,23 @@ If, elif and else directives
 
 (compilation_unit
   (preprocessor_call (preprocessor_directive) (identifier))
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (string_literal)))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (string_literal))))))
   (preprocessor_call (preprocessor_directive) (identifier))
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (string_literal)))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (string_literal))))))
   (preprocessor_call (preprocessor_directive))
-  (local_declaration_statement
-    (variable_declaration
-      (predefined_type)
-      (variable_declarator (identifier) (equals_value_clause (string_literal)))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator (identifier) (equals_value_clause (string_literal))))))
   (preprocessor_call (preprocessor_directive)))
 
 ===========================

--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -7,20 +7,21 @@ var x = from a in source select a.B;
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-              (select_clause
-                (member_access_expression
-                  (identifier)
-                  (identifier)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+                (select_clause
+                  (member_access_expression
+                    (identifier)
+                    (identifier))))))))))
 
 =====================================
 Query from select projection
@@ -31,24 +32,25 @@ var x = from a in source select { Name = a.B };
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-              (select_clause
-                (initializer_expression
-                  (assignment_expression
-                    (identifier)
-                      (assignment_operator)
-                        (member_access_expression
-                          (identifier)
-                          (identifier)))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+                (select_clause
+                  (initializer_expression
+                    (assignment_expression
+                      (identifier)
+                        (assignment_operator)
+                          (member_access_expression
+                            (identifier)
+                            (identifier))))))))))))
 
 =====================================
 Query from select with where
@@ -61,24 +63,25 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (where_clause
-              (binary_expression
-                (member_access_expression
-                  (identifier)
-                  (identifier))
-                (string_literal)))
-            (select_clause
-              (identifier))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (where_clause
+                (binary_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (string_literal)))
+              (select_clause
+                (identifier)))))))))
 
 =====================================
 Query from select with where and projection
@@ -91,34 +94,35 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (where_clause
-              (binary_expression
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (where_clause
                 (binary_expression
-                  (member_access_expression
-                    (identifier)
-                    (identifier))
-                  (string_literal))
-                (binary_expression
-                  (member_access_expression
-                    (identifier)
-                    (identifier))
-                  (string_literal))))
-              (select_clause
-                (anonymous_object_creation_expression
-                  (name_equals (identifier))
-                  (member_access_expression
-                    (identifier)
-                    (identifier))))))))))
+                  (binary_expression
+                    (member_access_expression
+                      (identifier)
+                      (identifier))
+                    (string_literal))
+                  (binary_expression
+                    (member_access_expression
+                      (identifier)
+                      (identifier))
+                    (string_literal))))
+                (select_clause
+                  (anonymous_object_creation_expression
+                    (name_equals (identifier))
+                    (member_access_expression
+                      (identifier)
+                      (identifier)))))))))))
 
 =====================================
 Query from select with orderby
@@ -133,28 +137,29 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (order_by_clause
-              (member_access_expression
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
                 (identifier)
-                (identifier)))
-            (order_by_clause
-              (member_access_expression
-                (identifier)
-                (identifier)))
-            (order_by_clause
-              (integer_literal))
-            (select_clause
-              (identifier))))))))
+                (identifier))
+              (order_by_clause
+                (member_access_expression
+                  (identifier)
+                  (identifier)))
+              (order_by_clause
+                (member_access_expression
+                  (identifier)
+                  (identifier)))
+              (order_by_clause
+                (integer_literal))
+              (select_clause
+                (identifier)))))))))
 
 =====================================
 Query from select with let
@@ -167,27 +172,28 @@ var x = from a in source
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (let_clause
-              (identifier)
-              (anonymous_object_creation_expression
-                (member_access_expression
-                  (identifier)
-                  (identifier))
-                (member_access_expression
-                  (identifier)
-                  (identifier))))
-            (select_clause
-              (identifier))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (let_clause
+                (identifier)
+                (anonymous_object_creation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (member_access_expression
+                    (identifier)
+                    (identifier))))
+              (select_clause
+                (identifier)))))))))
 
 =====================================
 Query from select with join
@@ -200,33 +206,34 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (join_clause
-              (identifier)
-              (identifier)
-              (member_access_expression
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
                 (identifier)
                 (identifier))
-              (member_access_expression
+              (join_clause
                 (identifier)
-                (identifier)))
-            (select_clause
-              (anonymous_object_creation_expression
+                (identifier)
                 (member_access_expression
                   (identifier)
                   (identifier))
                 (member_access_expression
                   (identifier)
-                  (identifier))))))))))
+                  (identifier)))
+              (select_clause
+                (anonymous_object_creation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (member_access_expression
+                    (identifier)
+                    (identifier)))))))))))
 
 =====================================
 Query from select with multiple from
@@ -240,35 +247,36 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (from_clause
-              (identifier)
-              (identifier))
-            (where_clause
-              (binary_expression
-                (member_access_expression
-                  (identifier)
-                  (identifier))
-                (member_access_expression
-                  (identifier)
-                  (identifier))))
-            (select_clause
-              (anonymous_object_creation_expression
-                (member_access_expression
-                  (identifier)
-                  (identifier))
-                (member_access_expression
-                  (identifier)
-                  (identifier))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (from_clause
+                (identifier)
+                (identifier))
+              (where_clause
+                (binary_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (member_access_expression
+                    (identifier)
+                    (identifier))))
+              (select_clause
+                (anonymous_object_creation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (member_access_expression
+                    (identifier)
+                    (identifier)))))))))))
 
 =====================================
 Query from select with group by & continuation
@@ -281,38 +289,39 @@ var x = from a in sourceA
 ---
 
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration
-      (implicit_type)
-      (variable_declarator
-        (identifier)
-        (equals_value_clause
-          (query_expression
-            (from_clause
-              (identifier)
-              (identifier))
-            (group_clause
-              (identifier)
-              (member_access_expression
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
                 (identifier)
-                (identifier)))
-            (query_continuation
-              (identifier)
-              (select_clause
-                (anonymous_object_creation_expression
-                  (name_equals (identifier))
-                  (member_access_expression
-                    (identifier)
-                    (identifier))
-                  (name_equals (identifier))
-                  (invocation_expression
+                (identifier))
+              (group_clause
+                (identifier)
+                (member_access_expression
+                  (identifier)
+                  (identifier)))
+              (query_continuation
+                (identifier)
+                (select_clause
+                  (anonymous_object_creation_expression
+                    (name_equals (identifier))
                     (member_access_expression
                       (identifier)
                       (identifier))
-                    (argument_list
-                      (argument
-                        (lambda_expression
-                          (identifier)
-                          (member_access_expression
+                    (name_equals (identifier))
+                    (invocation_expression
+                      (member_access_expression
+                        (identifier)
+                        (identifier))
+                      (argument_list
+                        (argument
+                          (lambda_expression
                             (identifier)
-                            (identifier)))))))))))))))
+                            (member_access_expression
+                              (identifier)
+                              (identifier))))))))))))))))

--- a/corpus/records.txt
+++ b/corpus/records.txt
@@ -182,20 +182,21 @@ void A() {
 ---
 
 (compilation_unit
-  (local_function_statement (void_keyword) (identifier) (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
-            (identifier)
-            (equals_value_clause
-              (with_expression
-                (identifier)
-                (with_initializer_expression
-                  (simple_assignment_expression
-                    (identifier)
-                    (string_literal)))))))))))
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (with_expression
+                  (identifier)
+                  (with_initializer_expression
+                    (simple_assignment_expression
+                      (identifier)
+                      (string_literal))))))))))))
 
 =====================================
 With expression using expressions
@@ -211,12 +212,13 @@ void A() {
 ---
 
 (compilation_unit
-  (local_function_statement (void_keyword) (identifier) (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration
-          (implicit_type)
-          (variable_declarator
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
               (identifier)
               (equals_value_clause
                 (with_expression
@@ -227,4 +229,4 @@ void A() {
                       (invocation_expression (identifier) (argument_list)))
                     (simple_assignment_expression
                       (identifier)
-                      (invocation_expression (identifier) (argument_list))))))))))))
+                      (invocation_expression (identifier) (argument_list)))))))))))))

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -155,7 +155,8 @@ var a = 1;
 
 ---
 (compilation_unit
-  (local_declaration_statement
-    (variable_declaration (implicit_type)
-      (variable_declarator (identifier)
-        (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause (integer_literal)))))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1189,13 +1189,14 @@ void A() {
 
 ---
 
- (compilation_unit
-  (local_function_statement (void_keyword) (identifier) (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration (identifier)
-          (variable_declarator (identifier)
-            (equals_value_clause (string_literal))))))))
+(compilation_unit
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause (string_literal)))))))))
 
 =====================================
 Function with contextually reserved identifiers
@@ -1212,44 +1213,45 @@ async void Sample() {
 ---
 
 (compilation_unit
-  (local_function_statement
-    (modifier)
-    (void_keyword)
-    (identifier)
-    (parameter_list)
-    (block
-      (local_declaration_statement
-        (variable_declaration (implicit_type)
-          (variable_declarator (identifier)
-            (equals_value_clause (string_literal)))))
-      (local_declaration_statement
-        (variable_declaration (predefined_type)
-          (variable_declarator (identifier)
-            (equals_value_clause (identifier)))))
-      (local_declaration_statement
-        (variable_declaration (identifier)
-          (variable_declarator (identifier)
-            (equals_value_clause (identifier)))))
-      (local_declaration_statement
-        (variable_declaration (identifier)
-          (variable_declarator (identifier)
-            (equals_value_clause (identifier)))))
-      (local_declaration_statement
-        (variable_declaration (identifier)
-          (variable_declarator (identifier)
-            (equals_value_clause
-              (binary_expression
+  (global_statement
+    (local_function_statement
+      (modifier)
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause (string_literal)))))
+        (local_declaration_statement
+          (variable_declaration (predefined_type)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause (identifier)))))
+        (local_declaration_statement
+          (variable_declaration (identifier)
+            (variable_declarator (identifier)
+              (equals_value_clause
                 (binary_expression
                   (binary_expression
                     (binary_expression
                       (binary_expression
                         (binary_expression
                           (binary_expression
-                            (binary_expression (identifier) (identifier))
+                            (binary_expression
+                              (binary_expression (identifier) (identifier))
+                            (identifier))
                           (identifier))
                         (identifier))
                       (identifier))
                     (identifier))
                   (identifier))
-                (identifier))
-              (identifier)))))))))
+                (identifier))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -80,14 +80,15 @@ module.exports = grammar({
   word: $ => $._identifier_token,
 
   rules: {
-    // Intentionally deviates from spec so that we can syntax highlight fragments of code
     compilation_unit: $ => seq(
       repeat($.extern_alias_directive),
       repeat($.using_directive),
       repeat($.global_attribute_list),
-      repeat($._statement),
+      repeat($.global_statement),
       repeat($._namespace_member_declaration)
     ),
+
+    global_statement: $ => $._statement,
 
     _declaration: $ => choice(
       $.class_declaration,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -30,7 +30,7 @@
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "_statement"
+            "name": "global_statement"
           }
         },
         {
@@ -41,6 +41,10 @@
           }
         }
       ]
+    },
+    "global_statement": {
+      "type": "SYMBOL",
+      "name": "_statement"
     },
     "_declaration": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1406,10 +1406,6 @@
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
           "type": "class_declaration",
           "named": true
         },
@@ -1427,6 +1423,10 @@
         },
         {
           "type": "global_attribute_list",
+          "named": true
+        },
+        {
+          "type": "global_statement",
           "named": true
         },
         {
@@ -2483,6 +2483,21 @@
       "types": [
         {
           "type": "attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "global_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
           "named": true
         }
       ]


### PR DESCRIPTION
Treats newly added top-level statements as global statements.

Should tie in with #12 and see what syntax is still left to support there.

This is about as far as we can go with global statements without seeing the grammar for how Roslyn has repurposed them etc.