### PR TITLE
Corpus coverage for inferred tuple element names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Comprehensive support for C# exists with the following exceptions:
 
 - [x] `async` main method
 - [x] Default literals (as `default_expression`)
-- [ ] Inferred tuple element names
+- [x] Inferred tuple element names
 - [ ] Generic type pattern matching
 
 #### C# 7.2

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -278,6 +278,36 @@ class A {
                 (return_statement (integer_literal)))))))))))
 
 =====================================
+Inferred tuples
+=====================================
+
+var result = list.Select(c => (c.f1, c.f2)).Where(t => t.f2 == 1);
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
+            (invocation_expression
+              (member_access_expression
+                (invocation_expression
+                  (member_access_expression (identifier) (identifier))
+                  (argument_list
+                    (argument
+                      (lambda_expression (identifier)
+                        (tuple_expression
+                          (argument (member_access_expression (identifier) (identifier)))
+                          (argument (member_access_expression (identifier) (identifier))))))))
+              (identifier))
+            (argument_list
+              (argument
+                (lambda_expression (identifier)
+                  (binary_expression (member_access_expression (identifier) (identifier)) (integer_literal))))))))))))
+
+=====================================
 Switch statement with tuple
 =====================================
 


### PR DESCRIPTION
Turns out we already support this C# 7.1 feature so mark it off the README and add coverage.