### PR TITLE
fixed precedence of recursive pattern

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -315,6 +315,37 @@ class A {
               (default_switch_label)
               (return_statement (integer_literal))))))))))
 
+
+=====================================
+switch on positional pattern with when clause
+=====================================
+
+switch (A, B)
+{
+    case (_, _) when !c:
+      break;
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (switch_statement
+      (tuple_expression
+        (argument (identifier))
+        (argument (identifier)))
+      (switch_body
+        (switch_section
+          (case_pattern_switch_label
+            (recursive_pattern
+              (positional_pattern_clause
+                (subpattern (discard))
+                (subpattern (discard))))
+            (when_clause
+              (prefix_unary_expression (identifier))))
+          (break_statement))))))
+
+
 =====================================
 Try finally statement
 =====================================

--- a/grammar.js
+++ b/grammar.js
@@ -916,7 +916,7 @@ module.exports = grammar({
       ')'
     ),
 
-    recursive_pattern: $ => prec.right(seq(
+    recursive_pattern: $ => prec.left(seq(
       optional($._type),
       choice(
         seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4899,7 +4899,7 @@
       ]
     },
     "recursive_pattern": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",


### PR DESCRIPTION
It failed to parse a switch on a positional pattern followed by a when-clause.

Found the issue parsing roslyn here: https://github.com/dotnet/roslyn/blob/057b9e2b3d782fb3ea98d92fb94bf1c924cfdf81/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs#L712