### PR TITLE
Add corpus coverage for conditional refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] Inferred tuple element names
 - [ ] Generic type pattern matching
 
-#### C# 7.2
+#### C# 7.2 (complete)
 
 - [x] `in` parameter modifiers
 - [x] `ref readonly` method returns
@@ -51,7 +51,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] Non-trailing named arguments
 - [x] `_` leading binary and hex literals
 - [x] `private protected` modifier
-- [ ] Conditional `ref` expressions
+- [x] Conditional `ref` expressions
 
 #### C# 7.3 (complete)
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1316,3 +1316,32 @@ async void Sample() {
                     (identifier))
                   (identifier))
                 (identifier))))))))))
+
+=====================================
+Function conditional ref expression
+=====================================
+
+ref T Choice(bool condition, ref T a, ref T b)
+{
+  ref var r = ref (condition ? ref a: ref b);
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (modifier) (identifier) (identifier)
+      (parameter_list
+        (parameter (predefined_type) (identifier))
+        (parameter (parameter_modifier) (identifier) (identifier))
+        (parameter (parameter_modifier) (identifier) (identifier)))
+      (block
+        (local_declaration_statement (modifier)
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause
+                (ref_expression
+                  (parenthesized_expression
+                    (conditional_expression (identifier)
+                      (ref_expression (identifier))
+                      (ref_expression (identifier)))))))))))))


### PR DESCRIPTION
We already actually support this so just adding corpus coverage.

Note that in the corpus example I added the `ref var r` part maps to a `local_declaration_statement` which is fine but the `ref` modifier should actually be inside the `variable_declaration` according to Roslyn but we have it outside. 

Will consider fixing that in the future.