### PR TITLE
Generic type pattern matching is not syntax change

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] `async` main method
 - [x] Default literals (as `default_expression`)
 - [x] Inferred tuple element names
-- [ ] Generic type pattern matching
+- [x] Generic type pattern matching
 
 #### C# 7.2
 


### PR DESCRIPTION
As I can read from the proposal, it is a semantic change that allows variables of generic types to participate in pattern matching:
https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.1/generics-pattern-match.md

There is no new syntax for this feature.