### PR TITLE
Add simple pattern corpus coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] nullable reference types
 - [x] null-forgiving operator
 
-#### C# 9.0 (TBC)
+#### C# 9.0 (complete)
 
 - [x] Covariant returns
 - [x] Extending partial methods
@@ -77,8 +77,8 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] Local function attributes
 - [x] Module initializers
 - [x] Native integers
-- [ ] Patterns
-  - [ ] Simple type patterns
+- [x] Patterns
+  - [x] Simple type patterns
   - [x] Relational patterns
   - [x] Logical patterns
 - [x] Records

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1048,6 +1048,47 @@ void b() {
                     (discard)
                     (string_literal)))))))))))
 
+============================
+switch expression return
+============================
+
+string b(Object operation) =>
+  operation switch {
+      1 => "one",
+      _ => "more",
+  };
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (predefined_type) (identifier) (parameter_list (parameter (identifier) (identifier)))
+      (arrow_expression_clause
+        (switch_expression (identifier)
+          (switch_expression_arm (constant_pattern (integer_literal)) (string_literal))
+          (switch_expression_arm (discard) (string_literal)))))))
+
+============================
+switch expression declaration and constant patterns
+============================
+
+string b(Object operation) =>
+  operation switch {
+      Declaration d => "declaration",
+      Simple => "simple (constant)",
+      null => "constant",
+  };
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (predefined_type) (identifier) (parameter_list (parameter (identifier) (identifier)))
+      (arrow_expression_clause (switch_expression (identifier)
+        (switch_expression_arm (declaration_pattern (identifier) (identifier)) (string_literal))
+        (switch_expression_arm (constant_pattern (identifier)) (string_literal))
+        (switch_expression_arm (constant_pattern (null_literal)) (string_literal)))))))
+
 =====================================
 await Expression
 =====================================


### PR DESCRIPTION
We already support this and it maps to `constant_pattern` just like Roslyn.