### PR TITLE
Discarded parameters are identifiers in Roslyn.

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -463,8 +463,8 @@ void a() {
         (expression_statement
           (anonymous_method_expression
             (parameter_list
-              (parameter (predefined_type) (discard))
-              (parameter (predefined_type) (discard)))
+              (parameter (predefined_type) (identifier))
+              (parameter (predefined_type) (identifier)))
             (block (return_statement (identifier)))))))))
 
 ============================
@@ -576,8 +576,8 @@ void a() {
               (equals_value_clause
                 (lambda_expression
                   (parameter_list
-                    (parameter (discard))
-                    (parameter (discard)))
+                    (parameter (identifier))
+                    (parameter (identifier)))
                   (integer_literal))))))
         (local_declaration_statement
           (variable_declaration
@@ -587,8 +587,8 @@ void a() {
               (equals_value_clause
                 (lambda_expression
                   (parameter_list
-                    (parameter (predefined_type) (discard))
-                    (parameter (predefined_type) (discard)))
+                    (parameter (predefined_type) (identifier))
+                    (parameter (predefined_type) (identifier)))
                   (integer_literal))))))))))
 
 ============================
@@ -629,9 +629,8 @@ void a() {
   (global_statement
     (local_function_statement (void_keyword) (identifier) (parameter_list)
       (block
-        (expression_statement (assignment_expression
-          (identifier)
-          (assignment_operator)
+        (expression_statement
+          (assignment_expression (identifier) (assignment_operator)
           (tuple_expression
             (argument (identifier))
             (argument

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1222,7 +1222,8 @@ class A {
   void Sample() {
     (var a, var b) = c;
     var (a, b) = c;
-    (a, b) = c;
+    (a, b, _) = c;
+    (_, b) = c;
     var (a, _) = c;
     var (a, (b, _)) = c;
   }
@@ -1253,6 +1254,11 @@ class A {
               (equals_value_clause (identifier)))))
           (expression_statement
             (assignment_expression
+              (tuple_expression (argument (identifier)) (argument (identifier)) (argument (identifier)))
+              (assignment_operator)
+              (identifier)))
+          (expression_statement
+            (assignment_expression
               (tuple_expression (argument (identifier)) (argument (identifier)))
               (assignment_operator)
               (identifier)))
@@ -1266,7 +1272,7 @@ class A {
             (variable_declarator
               (tuple_pattern (identifier) (tuple_pattern (identifier) (discard)))
               (equals_value_clause (identifier))))))))))
-
+              
 =====================================
 Function with dynamic local variable
 =====================================

--- a/grammar.js
+++ b/grammar.js
@@ -297,7 +297,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       optional($.parameter_modifier),
       optional(field('type', $._type)),
-      field('name', choice($.discard, $.identifier)),
+      field('name', $.identifier),
       optional($.equals_value_clause)
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1207,17 +1207,8 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "discard"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "identifier"
           }
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3721,10 +3721,6 @@
         "required": true,
         "types": [
           {
-            "type": "discard",
-            "named": true
-          },
-          {
             "type": "identifier",
             "named": true
           }


### PR DESCRIPTION
While this might sound not important this was causing issues with parsing any Tuple rule where the first argument was a discard `_`.

Corpus coverage added for that scenario.

This fixes parsing of another 4 files in the Roslyn repo bringing the remaining number down to 57.