### PR TITLE
Fix tuple type declarations

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -316,6 +316,34 @@ M(out (int a, int b) c);
             (identifier))))))))
 
 =====================================
+Returning tuples
+=====================================
+
+void M() {
+  (bool a, bool b) M2() {
+    return (true, false);
+  }
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_function_statement
+          (tuple_type
+            (tuple_element (predefined_type) (identifier))
+            (tuple_element (predefined_type) (identifier)))
+          (identifier)
+          (parameter_list)
+          (block
+            (return_statement
+              (tuple_expression
+                (argument (boolean_literal))
+                (argument (boolean_literal))))))))))
+
+=====================================
 Inferred tuples
 =====================================
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -278,6 +278,25 @@ class A {
                 (return_statement (integer_literal)))))))))))
 
 =====================================
+Declared tuple type with default
+=====================================
+
+(string a, bool b) c = default;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (tuple_type
+          (tuple_element (predefined_type) (identifier))
+          (tuple_element (predefined_type) (identifier)))
+        (variable_declarator (identifier)
+          (equals_value_clause
+            (default_expression)))))))
+
+=====================================
 Inferred tuples
 =====================================
 
@@ -1378,3 +1397,4 @@ ref T Choice(bool condition, ref T a, ref T b)
                     (conditional_expression (identifier)
                       (ref_expression (identifier))
                       (ref_expression (identifier)))))))))))))
+                      

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -297,6 +297,25 @@ Declared tuple type with default
             (default_expression)))))))
 
 =====================================
+Invocation with inline tuple_type declaration
+=====================================
+
+M(out (int a, int b) c);
+
+---
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (invocation_expression (identifier)
+        (argument_list
+          (argument (declaration_expression
+            (tuple_type
+              (tuple_element (predefined_type) (identifier))
+              (tuple_element (predefined_type) (identifier)))
+            (identifier))))))))
+
+=====================================
 Inferred tuples
 =====================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -19,7 +19,6 @@ const PREC = {
   COND: 3,
   ASSIGN: 2,
   SEQ: 1,
-  TUPLE: -1,
   TYPE_PATTERN: -2,
 };
 
@@ -68,8 +67,13 @@ module.exports = grammar({
 
     [$.parameter_modifier, $.this_expression],
     [$.parameter, $._simple_name],
+    [$.parameter, $.tuple_element],
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $._pattern],
+    [$.parameter, $.declaration_expression],
+    [$.tuple_element],
+    [$.tuple_element, $.declaration_expression],
+    [$.tuple_element, $.variable_declarator]
   ],
 
   inline: $ => [
@@ -599,7 +603,7 @@ module.exports = grammar({
       $.pointer_type,
       $.function_pointer_type,
       $.predefined_type,
-      $.tuple_type,  // TODO: Conflicts with everything
+      $.tuple_type,
     ),
 
     implicit_type: $ => 'var',
@@ -689,14 +693,12 @@ module.exports = grammar({
     tuple_type: $ => seq(
       '(',
       $.tuple_element,
-      repeat1(seq(
-        ',',
-        $.tuple_element,
-      )),
+      ',',
+      commaSep1($.tuple_element),
       ')'
     ),
 
-    tuple_element: $ => prec(PREC.TUPLE, seq(
+    tuple_element: $ => prec.left(seq(
       field('type', $._type),
       field('name', optional($.identifier))
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3660,20 +3660,33 @@
           "name": "tuple_element"
         },
         {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "tuple_element"
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "tuple_element"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "tuple_element"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -3682,8 +3695,8 @@
       ]
     },
     "tuple_element": {
-      "type": "PREC",
-      "value": -1,
+      "type": "PREC_LEFT",
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
@@ -9024,12 +9037,31 @@
     ],
     [
       "parameter",
+      "tuple_element"
+    ],
+    [
+      "parameter",
       "tuple_element",
       "declaration_expression"
     ],
     [
       "parameter",
       "_pattern"
+    ],
+    [
+      "parameter",
+      "declaration_expression"
+    ],
+    [
+      "tuple_element"
+    ],
+    [
+      "tuple_element",
+      "declaration_expression"
+    ],
+    [
+      "tuple_element",
+      "variable_declarator"
     ]
   ],
   "externals": [


### PR DESCRIPTION
Changes the priority and conflicts around tuple types so the shown example (based on a fragment from Roslyn source that didn't parse) now works.

Fixes #117 and #119

This change reduces the number of unparseable files in Roslyn down from 57 to 37.