### PR TITLE
Support trailing attribute comma and contextual global keyword

### DIFF
--- a/corpus/attributes.txt
+++ b/corpus/attributes.txt
@@ -270,3 +270,20 @@ class Zzz {
             (attribute_list (attribute (identifier)) (attribute (identifier) (attribute_argument_list)))
             (attribute_list (attribute (identifier)))
             (block)))))))
+
+=======================================
+Attributes with trailing comma
+=======================================
+[Theory,]
+void A() { }
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement
+      (attribute_list (attribute (identifier)))
+      (void_keyword)
+      (identifier)
+      (parameter_list)
+      (block))))

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -17,7 +17,7 @@ using static J.K;
     (qualified_name (identifier) (identifier)))
   (using_directive
     (qualified_name
-      (alias_qualified_name (global) (identifier))
+      (alias_qualified_name (identifier) (identifier))
       (identifier)))
   (using_directive
     (name_equals (identifier))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1466,3 +1466,22 @@ List<int> a = new(1)
             (implicit_object_creation_expression
               (argument_list (argument (integer_literal)))
               (initializer_expression))))))))
+
+=====================================
+Lambda parameter named global
+=====================================
+
+var a = global => global.Single();
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
+            (lambda_expression (identifier)
+              (invocation_expression
+                (member_access_expression (identifier) (identifier))
+                (argument_list)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -59,6 +59,7 @@ module.exports = grammar({
     [$.qualified_name, $.member_access_expression],
 
     [$._contextual_keywords, $.from_clause],
+    [$._contextual_keywords, $.global],
     [$._contextual_keywords, $.accessor_declaration],
     [$._contextual_keywords, $.type_parameter_constraint],
 
@@ -171,7 +172,13 @@ module.exports = grammar({
 
     qualified_name: $ => prec(PREC.DOT, seq($._name, '.', $._simple_name)),
 
-    attribute_list: $ => seq('[', optional($.attribute_target_specifier), commaSep1($.attribute), ']'),
+    attribute_list: $ => seq(
+      '[',
+      optional($.attribute_target_specifier),
+      commaSep1($.attribute),
+      optional(','),
+      ']'
+    ),
 
     attribute_target_specifier: $ => seq(
       choice('field', 'event', 'method', 'param', 'property', 'return', 'type'),
@@ -1601,6 +1608,7 @@ module.exports = grammar({
       // 'await',
 
       // Misc
+      'global',
       'alias',
       'dynamic',
       'nameof',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -417,6 +417,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "]"
         }
@@ -8873,6 +8885,10 @@
         },
         {
           "type": "STRING",
+          "value": "global"
+        },
+        {
+          "type": "STRING",
           "value": "alias"
         },
         {
@@ -9022,6 +9038,10 @@
     [
       "_contextual_keywords",
       "from_clause"
+    ],
+    [
+      "_contextual_keywords",
+      "global"
     ],
     [
       "_contextual_keywords",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2498,6 +2498,11 @@
     }
   },
   {
+    "type": "global",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "global_attribute_list",
     "named": true,
     "fields": {},
@@ -5669,7 +5674,7 @@
   },
   {
     "type": "global",
-    "named": true
+    "named": false
   },
   {
     "type": "goto",


### PR DESCRIPTION
As discovered parsing the Roslyn repo.

Brings total unparseable down by another 2 files to 27.