### PR TITLE
Underscore not permitted at start or end of numeric literal segment

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -5,9 +5,11 @@ integer literals
 const int dec = 1_2;
 const long hex = 0xf_1l;
 const long hex2 = 0Xffff;
+const long hex3 = 0x_0_f;
 const UInt64 dec = 1uL;
 const UInt16 bin = 0b0100_100;
 const UInt16 bin2 = 0B01010__10;
+const long bin3 = 0b_0_10;
 ---
 
 (compilation_unit
@@ -33,7 +35,7 @@ const UInt16 bin2 = 0B01010__10;
     (local_declaration_statement
       (modifier)
       (variable_declaration
-        (identifier)
+        (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
   (global_statement
     (local_declaration_statement
@@ -46,6 +48,18 @@ const UInt16 bin2 = 0B01010__10;
       (modifier)
       (variable_declaration
         (identifier)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (identifier)
+        (variable_declarator (identifier) (equals_value_clause (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+        (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (integer_literal)))))))
 
 =======================================

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -118,6 +118,7 @@ const float e = 1e6f;
 const Single en = 0e-1f;
 const Single ep = 1_1e+12f;
 const double d = 0.9_9d;
+const double e = .4_9d;
 const decimal m = 0_1_2.9m;
 const Decimal m2 = 102.349M;
 
@@ -147,6 +148,12 @@ const Decimal m2 = 102.349M;
       (modifier)
       (variable_declaration
       (identifier)
+      (variable_declarator (identifier) (equals_value_clause (real_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (modifier)
+      (variable_declaration
+      (predefined_type)
       (variable_declarator (identifier) (equals_value_clause (real_literal))))))
   (global_statement
     (local_declaration_statement

--- a/grammar.js
+++ b/grammar.js
@@ -1511,8 +1511,8 @@ module.exports = grammar({
     integer_literal: $ => token(seq(
       choice(
         decimalDigitSequence, // Decimal
-        (/0[xX]([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F])/), // Hex
-        (/0[bB]([01][01_]*[01]|[01])/) // Binary
+        (/0[xX][0-9a-fA-F_]+[0-9a-fA-F]*/), // Hex
+        (/0[bB][01_]+[01]*/) // Binary
       ),
       optional(/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/)
     )),

--- a/grammar.js
+++ b/grammar.js
@@ -22,6 +22,8 @@ const PREC = {
   TYPE_PATTERN: -2,
 };
 
+const decimalDigitSequence = /([0-9][0-9_]*[0-9]|[0-9])/;
+
 module.exports = grammar({
   name: 'c_sharp',
 
@@ -1508,9 +1510,9 @@ module.exports = grammar({
 
     integer_literal: $ => token(seq(
       choice(
-        (/[0-9][0-9_]*/), // Decimal
-        (/0[xX][0-9a-fA-F][0-9a-fA-F_]*/), // Hex
-        (/0[bB][01][01_]*/) // Binary
+        decimalDigitSequence, // Decimal
+        (/0[xX]([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F])/), // Hex
+        (/0[bB]([01][01_]*[01]|[01])/) // Binary
       ),
       optional(/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/)
     )),
@@ -1522,25 +1524,25 @@ module.exports = grammar({
       const exponent = /[eE][+-]?[0-9][0-9_]*/;
       return token(choice(
         seq(
-          (/[0-9][0-9_]*/),
+          decimalDigitSequence,
           '.',
-          (/[0-9][0-9_]*/),
+          decimalDigitSequence,
           optional(exponent),
           optional(suffix)
         ),
         seq(
           '.',
-          (/[-0][0-9_]*/),
+          decimalDigitSequence,
           optional(exponent),
           optional(suffix)
         ),
         seq(
-          (/[0-9][0-9_]*/),
+          decimalDigitSequence,
           exponent,
           optional(suffix)
         ),
         seq(
-          (/[0-9][0-9_]*/),
+          decimalDigitSequence,
           suffix
         )
       ))

--- a/grammar.js
+++ b/grammar.js
@@ -1511,8 +1511,8 @@ module.exports = grammar({
     integer_literal: $ => token(seq(
       choice(
         decimalDigitSequence, // Decimal
-        (/0[xX][0-9a-fA-F_]+[0-9a-fA-F]*/), // Hex
-        (/0[bB][01_]+[01]*/) // Binary
+        (/0[xX][0-9a-fA-F_]*[0-9a-fA-F]+/), // Hex
+        (/0[bB][01_]*[01]+/) // Binary
       ),
       optional(/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/)
     )),

--- a/grammar.js
+++ b/grammar.js
@@ -1508,9 +1508,9 @@ module.exports = grammar({
 
     integer_literal: $ => token(seq(
       choice(
-        (/[0-9_]+/), // Decimal
-        (/0[xX][0-9a-fA-F_]+/), // Hex
-        (/0[bB][01_]+/) // Binary
+        (/[0-9][0-9_]*/), // Decimal
+        (/0[xX][0-9a-fA-F][0-9a-fA-F_]*/), // Hex
+        (/0[bB][01][01_]*/) // Binary
       ),
       optional(/u|U|l|L|ul|UL|uL|Ul|lu|LU|Lu|lU/)
     )),
@@ -1519,28 +1519,28 @@ module.exports = grammar({
 
     real_literal: $ => {
       const suffix = /[fFdDmM]/;
-      const exponent = /[eE][+-]?[0-9_]+/;
+      const exponent = /[eE][+-]?[0-9][0-9_]*/;
       return token(choice(
         seq(
-          (/[0-9_]+/),
+          (/[0-9][0-9_]*/),
           '.',
-          (/[0-9_]+/),
+          (/[0-9][0-9_]*/),
           optional(exponent),
           optional(suffix)
         ),
         seq(
           '.',
-          (/[0-9_]+/),
+          (/[-0][0-9_]*/),
           optional(exponent),
           optional(suffix)
         ),
         seq(
-          (/[0-9_]+/),
+          (/[0-9][0-9_]*/),
           exponent,
           optional(suffix)
         ),
         seq(
-          (/[0-9_]+/),
+          (/[0-9][0-9_]*/),
           suffix
         )
       ))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8543,11 +8543,11 @@
               },
               {
                 "type": "PATTERN",
-                "value": "0[xX]([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F])"
+                "value": "0[xX][0-9a-fA-F_]+[0-9a-fA-F]*"
               },
               {
                 "type": "PATTERN",
-                "value": "0[bB]([01][01_]*[01]|[01])"
+                "value": "0[bB][01_]+[01]*"
               }
             ]
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8539,15 +8539,15 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[0-9][0-9_]*"
               },
               {
                 "type": "PATTERN",
-                "value": "0[xX][0-9a-fA-F_]+"
+                "value": "0[xX][0-9a-fA-F][0-9a-fA-F_]*"
               },
               {
                 "type": "PATTERN",
-                "value": "0[bB][01_]+"
+                "value": "0[bB][01][01_]*"
               }
             ]
           },
@@ -8580,7 +8580,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[0-9][0-9_]*"
               },
               {
                 "type": "STRING",
@@ -8588,14 +8588,14 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[0-9][0-9_]*"
               },
               {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][+-]?[0-9_]+"
+                    "value": "[eE][+-]?[0-9][0-9_]*"
                   },
                   {
                     "type": "BLANK"
@@ -8625,14 +8625,14 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[-0][0-9_]*"
               },
               {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][+-]?[0-9_]+"
+                    "value": "[eE][+-]?[0-9][0-9_]*"
                   },
                   {
                     "type": "BLANK"
@@ -8658,11 +8658,11 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[0-9][0-9_]*"
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][+-]?[0-9_]+"
+                "value": "[eE][+-]?[0-9][0-9_]*"
               },
               {
                 "type": "CHOICE",
@@ -8683,7 +8683,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9_]+"
+                "value": "[0-9][0-9_]*"
               },
               {
                 "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8539,15 +8539,15 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "PATTERN",
-                "value": "0[xX][0-9a-fA-F][0-9a-fA-F_]*"
+                "value": "0[xX]([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F])"
               },
               {
                 "type": "PATTERN",
-                "value": "0[bB][01][01_]*"
+                "value": "0[bB]([01][01_]*[01]|[01])"
               }
             ]
           },
@@ -8580,7 +8580,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "STRING",
@@ -8588,7 +8588,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[0-9][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "CHOICE",
@@ -8625,7 +8625,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[-0][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "CHOICE",
@@ -8658,7 +8658,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "PATTERN",
@@ -8683,7 +8683,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[0-9][0-9_]*"
+                "value": "([0-9][0-9_]*[0-9]|[0-9])"
               },
               {
                 "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8543,11 +8543,11 @@
               },
               {
                 "type": "PATTERN",
-                "value": "0[xX][0-9a-fA-F_]+[0-9a-fA-F]*"
+                "value": "0[xX][0-9a-fA-F_]*[0-9a-fA-F]+"
               },
               {
                 "type": "PATTERN",
-                "value": "0[bB][01_]+[01]*"
+                "value": "0[bB][01_]*[01]+"
               }
             ]
           },


### PR DESCRIPTION
When `_` numeric literal support was added it was permitted everywhere in the numeric/hex/boolean literal.

It should not be allowed at the start of end of a segment.

We were also missing a test case for real literals starting with a `.`

Discovered in #131
