### PR TITLE
Allow tagging of types in local variable declarations.

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -8,8 +8,11 @@
 
 (interface_declaration
  name: (identifier) @name
- bases: (base_list (_) @name)
  ) @definition.interface
+
+(interface_declaration
+ bases: (base_list (_) @name)
+ ) @reference.interface
 
 (method_declaration
  name: (identifier) @name

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,7 +1,10 @@
 (class_declaration
  name: (identifier) @name
- bases: (base_list (_) @name)
  ) @definition.class
+
+(class_declaration
+   bases: (base_list (_) @name)
+ ) @reference.class
 
 (interface_declaration
  name: (identifier) @name
@@ -21,6 +24,10 @@
  ) @reference.class
 
 (type_constraint
+ type: (identifier) @name
+ ) @reference.class
+
+(variable_declaration
  type: (identifier) @name
  ) @reference.class
 


### PR DESCRIPTION
Also fix tagging of classes with no superclasses, and ensure that
bases of classes are tagged as references, not definitions.