### PR TITLE
Constrain conditional access to avoid conflicts etc

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1247,45 +1247,6 @@ class Foo {
                         (bracketed_argument_list (argument (range_expression)))))))))))))
 
 =====================================
-conditional access expression
-=====================================
-
-class Foo {
-  void Test() {
-    var a = b?.Something;
-    c.Something();
-  }
-}
-
----
-
-(compilation_unit
-  (class_declaration
-    (identifier)
-    (declaration_list
-      (method_declaration
-        (void_keyword)
-        (identifier)
-        (parameter_list)
-        (block
-          (local_declaration_statement
-            (variable_declaration
-              (implicit_type)
-              (variable_declarator
-                (identifier)
-                (equals_value_clause
-                  (conditional_access_expression
-                    (identifier)
-                    (member_binding_expression
-                    (identifier)))))))
-          (expression_statement
-            (invocation_expression
-              (member_access_expression
-                (identifier)
-                (identifier))
-              (argument_list))))))))
-
-=====================================
 cast expression
 =====================================
 
@@ -1433,27 +1394,6 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
                     (bracketed_argument_list (argument (string_literal))))
                   (assignment_operator)
                   (integer_literal))))))))))
-
-=====================================
-Conditional access to element (should be implicit_element_access)
-=====================================
-
-var x = dict?["a"];
-
----
-
-(compilation_unit
-  (global_statement
-    (local_declaration_statement
-      (variable_declaration
-        (implicit_type)
-        (variable_declarator
-          (identifier)
-          (equals_value_clause
-            (conditional_access_expression
-              (identifier)
-                (element_binding_expression
-                  (bracketed_argument_list (argument (string_literal)))))))))))
 
 =====================================
 Member access expression
@@ -1782,3 +1722,105 @@ var c = o is int; //binary_expression ("IsExpression" in Roslyn)
                 (identifier)
                 (predefined_type))))))) (comment))
                 
+
+=====================================
+Conditional expression with member accesses
+=====================================
+
+var a = b ? c.A + d.A : e.A + f.A;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
+            (conditional_expression (identifier)
+              (binary_expression
+                (member_access_expression (identifier) (identifier))
+                (member_access_expression (identifier) (identifier)))
+              (binary_expression
+                (member_access_expression (identifier) (identifier))
+                (member_access_expression (identifier) (identifier))))))))))
+
+=====================================
+Conditional access expression
+=====================================
+
+var a = b?.Something;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_access_expression
+              (identifier)
+              (member_binding_expression
+              (identifier)))))))))
+
+=====================================
+Conditional access to element (should be implicit_element_access)
+=====================================
+
+var x = dict?["a"];
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_access_expression
+              (identifier)
+                (element_binding_expression
+                  (bracketed_argument_list (argument (string_literal)))))))))))
+
+=====================================
+Conditional access expression with member binding
+=====================================
+
+if (a?.B != 1) { }
+
+---
+
+(compilation_unit
+  (global_statement
+    (if_statement
+      (binary_expression
+        (conditional_access_expression (identifier) (member_binding_expression (identifier)))
+        (integer_literal))
+      (block))))
+
+=====================================
+Conditional access expression with simple member access
+=====================================
+      
+if ((p as Person[])?[0]._Age != 1) { }
+
+---
+
+(compilation_unit
+  (global_statement
+    (if_statement
+      (binary_expression
+          (member_access_expression
+            (conditional_access_expression
+              (parenthesized_expression
+                (binary_expression (identifier) (array_type (identifier) (array_rank_specifier))))
+              (element_binding_expression
+                (bracketed_argument_list (argument (integer_literal)))))
+            (identifier))
+          (integer_literal))
+      (block))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1485,3 +1485,38 @@ var a = global => global.Single();
               (invocation_expression
                 (member_access_expression (identifier) (identifier))
                 (argument_list)))))))))
+
+
+=====================================
+Null-coalescing assignment
+=====================================
+
+numbers ??= new List<int>();
+
+---
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression (identifier) (assignment_operator)
+        (object_creation_expression
+          (generic_name (identifier)
+            (type_argument_list (predefined_type)))
+          (argument_list))))))
+
+=====================================
+Null literal arguments
+=====================================
+
+person = new Person(null!, null!);
+
+---
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression (identifier) (assignment_operator)
+        (object_creation_expression (identifier)
+          (argument_list
+            (argument (postfix_unary_expression (null_literal)))
+            (argument (postfix_unary_expression (null_literal)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1086,10 +1086,10 @@ module.exports = grammar({
       seq('unchecked', '(', $._expression, ')')
     ),
 
-    conditional_access_expression: $ => prec.right(seq(
+    conditional_access_expression: $ => prec.right(PREC.COND, seq(
       field('condition', $._expression),
       '?',
-      field('value', $._expression)
+      choice($.member_binding_expression, $.element_binding_expression)
     )),
 
     conditional_expression: $ => prec.right(PREC.COND, seq(
@@ -1206,7 +1206,7 @@ module.exports = grammar({
 
     member_binding_expression: $ => seq(
       '.',
-      $._simple_name,
+      field('name', $._simple_name),
     ),
 
     object_creation_expression: $ => prec.right(seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5980,7 +5980,7 @@
     },
     "conditional_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 3,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5997,12 +5997,17 @@
             "value": "?"
           },
           {
-            "type": "FIELD",
-            "name": "value",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "member_binding_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "element_binding_expression"
+              }
+            ]
           }
         ]
       }
@@ -6526,8 +6531,12 @@
           "value": "."
         },
         {
-          "type": "SYMBOL",
-          "name": "_simple_name"
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_simple_name"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1489,17 +1489,21 @@
             "named": true
           }
         ]
-      },
-      "value": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          }
-        ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "element_binding_expression",
+          "named": true
+        },
+        {
+          "type": "member_binding_expression",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -3265,24 +3269,25 @@
   {
     "type": "member_binding_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "generic_name",
-          "named": true
-        },
-        {
-          "type": "global",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        }
-      ]
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {


### PR DESCRIPTION
Changes the allowed type of conditional access from the open-ended `expression` in the Roslyn grammar to simply allow `?.` and `?[x]` which is more inline with the C# 6 specification grammar.

Does not introduce any new regressions in our examples parsing and drops the Roslyn grammar parsing failures from 27 files to 25 (most of which are caused by statement splitting in preprocessor blocks)

Fixes #131 and #138.