### PR TITLE
Fix member_access_expression matching to element access

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -957,7 +957,8 @@ typeof
 ============================
 
 void b() {
-  var z = typeof(int);
+  var y = typeof(int);
+  var z = typeof(List<string>.Enumerator);
 }
 
 ---
@@ -967,13 +968,18 @@ void b() {
     (local_function_statement (void_keyword) (identifier) (parameter_list)
       (block
         (local_declaration_statement
-          (variable_declaration
-            (implicit_type)
-            (variable_declarator
-              (identifier)
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
               (equals_value_clause
-                (type_of_expression
-                  (predefined_type))))))))))
+                (type_of_expression (predefined_type))))))
+          (local_declaration_statement
+            (variable_declaration (implicit_type)
+              (variable_declarator (identifier)
+                (equals_value_clause
+                  (type_of_expression
+                    (qualified_name
+                      (generic_name (identifier) (type_argument_list (predefined_type)))
+                      (identifier)))))))))))
 
 ============================
 switch expression
@@ -1396,29 +1402,27 @@ var x = new Dictionary<string,int> { ["a"] = 65 };
                   (integer_literal))))))))))
 
 =====================================
-Member access expression
+Member access expression (methods)
 =====================================
 
-void Test(){
-  a.IsInfinity(value);
+void Test(int value) {
+  value.ToString();
   double.IsInfinity(value);
-  string.Empty;
 }
 
 ---
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (void_keyword) (identifier)
+      (parameter_list (parameter (predefined_type) (identifier)))
       (block
         (expression_statement
           (invocation_expression
             (member_access_expression
               (identifier)
               (identifier))
-            (argument_list
-              (argument
-                (identifier)))))
+            (argument_list)))
         (expression_statement
           (invocation_expression
             (member_access_expression
@@ -1426,11 +1430,36 @@ void Test(){
               (identifier))
             (argument_list
               (argument
-                (identifier)))))
-        (expression_statement
-          (member_access_expression
-            (predefined_type)
-            (identifier)))))))
+                (identifier)))))))))
+
+=====================================
+Member access expression (properties)
+=====================================
+
+void Test(int value) {
+  var x = string.Empty;
+  var z = B<int>.Something;
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (void_keyword) (identifier)
+      (parameter_list (parameter (predefined_type) (identifier)))
+      (block
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause
+                (member_access_expression (predefined_type) (identifier))))))
+        (local_declaration_statement
+          (variable_declaration (implicit_type)
+            (variable_declarator (identifier)
+              (equals_value_clause
+                (member_access_expression
+                  (generic_name (identifier) (type_argument_list (predefined_type)))
+                  (identifier))))))))))
 
 =====================================
 is expression

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -975,6 +975,25 @@ class A {
                     (bracketed_argument_list
                       (argument (identifier))))))))))))))
 
+====================================
+Member access of an array element
+=====================================
+
+var g = args[0].Length;
+
+---
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
+            (member_access_expression
+              (element_access_expression
+                (identifier)
+                (bracketed_argument_list (argument (integer_literal))))
+            (identifier))))))))
+
 =====================================
 Using statement with implicit local variable
 =====================================

--- a/grammar.js
+++ b/grammar.js
@@ -1199,7 +1199,7 @@ module.exports = grammar({
     ),
 
     member_access_expression: $ => prec(PREC.DOT, seq(
-      field('expression', choice($._expression, $._type, $._name)),
+      field('expression', choice($._expression, $.predefined_type, $._name)),
       choice('.', '->'),
       field('name', $._simple_name)
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6490,7 +6490,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "_type"
+                  "name": "predefined_type"
                 },
                 {
                   "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3237,7 +3237,15 @@
             "named": true
           },
           {
-            "type": "_type",
+            "type": "alias_qualified_name",
+            "named": true
+          },
+          {
+            "type": "predefined_type",
+            "named": true
+          },
+          {
+            "type": "qualified_name",
             "named": true
           }
         ]


### PR DESCRIPTION
Fixes #141 by not allowing a full set of types to be matched in a member_access.

No regressions on corpus and no new file failures on examples or Roslyn code base.

Added some test coverage, cleaned up existing.