### PR TITLE
Change precedence of select in LINQ queries

### DIFF
--- a/corpus/query-syntax.txt
+++ b/corpus/query-syntax.txt
@@ -24,6 +24,110 @@ var x = from a in source select a.B;
                     (identifier))))))))))
 
 =====================================
+Query from select with operator
+=====================================
+
+var x = from a in source select a * 2;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (select_clause
+                (binary_expression
+                  (identifier)
+                  (integer_literal))))))))))
+
+=====================================
+Query from select with method call
+=====================================
+
+var x = from a in source select a.B();
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (select_clause
+                (invocation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (argument_list))))))))))
+
+=====================================
+Query from select with conditional operator
+=====================================
+
+var x = from a in source select a ? 0 : 1;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (select_clause
+                (conditional_expression
+                  (identifier)
+                  (integer_literal)
+                  (integer_literal))))))))))
+
+=====================================
+Query from select with assignment
+=====================================
+
+var x = from a in source select somevar = a;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (query_expression
+              (from_clause
+                (identifier)
+                (identifier))
+              (select_clause
+                (assignment_expression
+                  (identifier)
+                  (assignment_operator)
+                  (identifier))))))))))
+
+=====================================
 Query from select projection
 =====================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -1,6 +1,5 @@
 const PREC = {
   DOT: 17,
-  SELECT: 16,
   INVOCATION: 16,
   POSTFIX: 16,
   PREFIX: 15,
@@ -19,6 +18,7 @@ const PREC = {
   COND: 3,
   ASSIGN: 2,
   SEQ: 1,
+  SELECT: 0,
   TYPE_PATTERN: -2,
 };
 
@@ -1300,14 +1300,14 @@ module.exports = grammar({
       $.select_clause
     ),
 
-    group_clause: $ => prec.left(PREC.SELECT, seq(
+    group_clause: $ => prec.right(PREC.SELECT, seq(
       'group',
       $._expression,
       'by',
       $._expression
     )),
 
-    select_clause: $ => prec.left(PREC.SELECT, seq('select', $._expression)),
+    select_clause: $ => prec.right(PREC.SELECT, seq('select', $._expression)),
 
     query_continuation: $ => seq('into', $.identifier, $._query_body),
 


### PR DESCRIPTION
In a LINQ query, e.g. `from w in words select w`, anything after the `select`
should be included in the query. So `select w * 2` should be parsed as `select
(w * 2)`.

I noted this problem with multiplication and function calls. I also added tests
for conditional comparison and assignment, because these normally have the
highest precendence.

I wrote the tests, and then changed things in grammar.js till it worked. So
this change comes from result-based effort, not a good understanding of
operator precedence.

Tested with `tree-sitter generate && tree-sitter test`.

Fixes #144