### PR TITLE
Add `as_expression` and `in_expression`

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -57,40 +57,42 @@ class Foo {
               right: (integer_literal))))))))
 
 =====================================
-Ternary expressions vs nullable types
+Ternary expressions is type
 =====================================
 
-class Foo {
-  void Test() {
-    x is int?;
-    x is int
-      ? a
-      : b;
-    x is int?
-      ? a
-      : b;
-  }
-}
+var t = x is int
+  ? a
+  : b;
 
 ---
 
 (compilation_unit
-  (class_declaration
-    (identifier)
-    (declaration_list
-      (method_declaration
-        (void_keyword)
-        (identifier)
-        (parameter_list)
-        (block
-          (expression_statement
-            (binary_expression (identifier) (nullable_type (predefined_type))))
-          (expression_statement
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
             (conditional_expression
               (binary_expression (identifier) (predefined_type))
               (identifier)
-              (identifier)))
-          (expression_statement
+              (identifier))))))))
+
+=====================================
+Ternary expressions is nullable type
+=====================================
+
+var u = x is int?
+  ? a
+  : b;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration (implicit_type)
+        (variable_declarator (identifier)
+          (equals_value_clause
             (conditional_expression
               (binary_expression (identifier) (nullable_type (predefined_type)))
               (identifier)
@@ -495,7 +497,7 @@ void a() {
               (invocation_expression
                 (member_access_expression (identifier) (identifier))
                 (argument_list (argument (identifier))))))))))))
-         
+
 ============================
 Async Lambda
 ============================
@@ -1664,11 +1666,11 @@ var x = operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: n
               (recursive_pattern
                 (identifier)
                 (property_pattern_clause
-                  (subpattern 
+                  (subpattern
                     (name_colon (identifier))
-                    (recursive_pattern 
+                    (recursive_pattern
                       (property_pattern_clause
-                        (subpattern 
+                        (subpattern
                           (name_colon (identifier))
                           (constant_pattern (boolean_literal)))
                         (subpattern
@@ -1750,7 +1752,7 @@ var c = o is int; //binary_expression ("IsExpression" in Roslyn)
               (binary_expression
                 (identifier)
                 (predefined_type))))))) (comment))
-                
+
 
 =====================================
 Conditional expression with member accesses
@@ -1835,7 +1837,7 @@ if (a?.B != 1) { }
 =====================================
 Conditional access expression with simple member access
 =====================================
-      
+
 if ((p as Person[])?[0]._Age != 1) { }
 
 ---

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -73,7 +73,7 @@ var t = x is int
         (variable_declarator (identifier)
           (equals_value_clause
             (conditional_expression
-              (binary_expression (identifier) (predefined_type))
+              (is_expression (identifier) (predefined_type))
               (identifier)
               (identifier))))))))
 
@@ -94,7 +94,7 @@ var u = x is int?
         (variable_declarator (identifier)
           (equals_value_clause
             (conditional_expression
-              (binary_expression (identifier) (nullable_type (predefined_type)))
+              (is_expression (identifier) (nullable_type (predefined_type)))
               (identifier)
               (identifier))))))))
 
@@ -1479,7 +1479,7 @@ var b = s is string;
         (variable_declarator
           (identifier)
           (equals_value_clause
-            (binary_expression
+            (is_expression
               (identifier)
               (predefined_type))))))))
 
@@ -1725,7 +1725,7 @@ Type patterns
 =====================================
 
 var b = o is int or string; //is_pattern_expression with type_pattern
-var c = o is int; //binary_expression ("IsExpression" in Roslyn)
+var c = o is int; //is_expression with type
 
 ---
 
@@ -1749,7 +1749,7 @@ var c = o is int; //binary_expression ("IsExpression" in Roslyn)
           (variable_declarator
             (identifier)
             (equals_value_clause
-              (binary_expression
+              (is_expression
                 (identifier)
                 (predefined_type))))))) (comment))
 
@@ -1849,7 +1849,7 @@ if ((p as Person[])?[0]._Age != 1) { }
           (member_access_expression
             (conditional_access_expression
               (parenthesized_expression
-                (binary_expression (identifier) (array_type (identifier) (array_rank_specifier))))
+                (as_expression (identifier) (array_type (identifier) (array_rank_specifier))))
               (element_binding_expression
                 (bracketed_argument_list (argument (integer_literal)))))
             (identifier))

--- a/grammar.js
+++ b/grammar.js
@@ -49,8 +49,9 @@ module.exports = grammar({
 
     [$.event_declaration, $.variable_declarator],
 
-    [$.nullable_type, $.binary_expression],
-    [$.nullable_type, $.binary_expression, $.type_pattern],
+    [$.nullable_type, $.as_expression],
+    [$.nullable_type, $.is_expression, $.type_pattern],
+    [$.nullable_type, $.as_expression, $.type_pattern],
 
     [$._name, $._expression],
     [$._simple_name, $.type_parameter],
@@ -1388,6 +1389,7 @@ module.exports = grammar({
       $.anonymous_method_expression,
       $.anonymous_object_creation_expression,
       $.array_creation_expression,
+      $.as_expression,
       $.assignment_expression,
       $.await_expression,
       $.base_expression,
@@ -1405,6 +1407,7 @@ module.exports = grammar({
       $.initializer_expression,
       $.interpolated_string_expression,
       $.invocation_expression,
+      $.is_expression,
       $.is_pattern_expression,
       $.lambda_expression,
       $.make_ref_expression,
@@ -1459,14 +1462,20 @@ module.exports = grammar({
           field('operator', operator),
           field('right', $._expression)
         ))
-      ).concat(
-        prec.left(PREC.EQUAL, seq(
-          field('left', $._expression),
-          field('operator', choice('is', 'as')),
-          field('right', $._type)
-        ))
       )
     ),
+
+    as_expression: $ => prec.left(PREC.EQUAL, seq(
+      field('left', $._expression),
+      field('operator', 'as'),
+      field('right', $._type)
+    )),
+
+    is_expression: $ => prec.left(PREC.EQUAL, seq(
+      field('left', $._expression),
+      field('operator', 'is'),
+      field('right', $._type)
+    )),
 
     _identifier_token: $ => token(seq(optional('@'), /[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ_0-9]*/)), // identifier_token in Roslyn
     identifier: $ => choice($._identifier_token, $._contextual_keywords),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7547,6 +7547,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "as_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "assignment_expression"
         },
         {
@@ -7612,6 +7616,10 @@
         {
           "type": "SYMBOL",
           "name": "invocation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "is_expression"
         },
         {
           "type": "SYMBOL",
@@ -8336,50 +8344,74 @@
               }
             ]
           }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 9,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "is"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "as"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_type"
-                }
-              }
-            ]
-          }
         }
       ]
+    },
+    "as_expression": {
+      "type": "PREC_LEFT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "as"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type"
+            }
+          }
+        ]
+      }
+    },
+    "is_expression": {
+      "type": "PREC_LEFT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "is"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_type"
+            }
+          }
+        ]
+      }
     },
     "_identifier_token": {
       "type": "TOKEN",
@@ -9009,11 +9041,16 @@
     ],
     [
       "nullable_type",
-      "binary_expression"
+      "as_expression"
     ],
     [
       "nullable_type",
-      "binary_expression",
+      "is_expression",
+      "type_pattern"
+    ],
+    [
+      "nullable_type",
+      "as_expression",
       "type_pattern"
     ],
     [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -94,6 +94,10 @@
         "named": true
       },
       {
+        "type": "as_expression",
+        "named": true
+      },
+      {
         "type": "assignment_expression",
         "named": true
       },
@@ -183,6 +187,10 @@
       },
       {
         "type": "invocation_expression",
+        "named": true
+      },
+      {
+        "type": "is_expression",
         "named": true
       },
       {
@@ -671,6 +679,42 @@
     }
   },
   {
+    "type": "as_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "as",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "assignment_expression",
     "named": true,
     "fields": {
@@ -941,14 +985,6 @@
             "named": false
           },
           {
-            "type": "as",
-            "named": false
-          },
-          {
-            "type": "is",
-            "named": false
-          },
-          {
             "type": "|",
             "named": false
           },
@@ -964,10 +1000,6 @@
         "types": [
           {
             "type": "_expression",
-            "named": true
-          },
-          {
-            "type": "_type",
             "named": true
           }
         ]
@@ -2910,6 +2942,42 @@
         "types": [
           {
             "type": "_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "is_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "is",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_type",
             "named": true
           }
         ]


### PR DESCRIPTION
Fixes #154 and also fixes a corpus test that had invalid syntax breaking it into two smaller correct tests.