### PR TITLE
Fix `??` priority and give it a name

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1152,7 +1152,7 @@ class Foo {
             (assignment_expression
               (identifier)
               (assignment_operator)
-              (coalesce_expression
+              (binary_expression
                 (identifier)
                 (throw_expression (identifier))))))))))
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1152,7 +1152,7 @@ class Foo {
             (assignment_expression
               (identifier)
               (assignment_operator)
-              (binary_expression
+              (coalesce_expression
                 (identifier)
                 (throw_expression (identifier))))))))))
 
@@ -1855,3 +1855,4 @@ if ((p as Person[])?[0]._Age != 1) { }
             (identifier))
           (integer_literal))
       (block))))
+      

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1535,7 +1535,8 @@ b = obj ?? a == 0;
   (global_statement
     (expression_statement
       (assignment_expression (identifier) (assignment_operator)
-        (coalesce_expression (identifier)
+        (binary_expression
+          (identifier)
           (binary_expression (identifier) (integer_literal)))))))
 
 =====================================

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1524,6 +1524,21 @@ numbers ??= new List<int>();
           (argument_list))))))
 
 =====================================
+Null-coalescing
+=====================================
+
+b = obj ?? a == 0;
+
+---
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression (identifier) (assignment_operator)
+        (coalesce_expression (identifier)
+          (binary_expression (identifier) (integer_literal)))))))
+
+=====================================
 Null literal arguments
 =====================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -1397,7 +1397,6 @@ module.exports = grammar({
       $.binary_expression,
       $.cast_expression,
       $.checked_expression,
-      $.coalesce_expression,
       $.conditional_access_expression,
       $.conditional_expression,
       $.default_expression,
@@ -1457,6 +1456,7 @@ module.exports = grammar({
         ['!=', PREC.EQUAL],
         ['>=', PREC.REL],
         ['>', PREC.REL],
+        ['??', PREC.TERNARY],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._expression),
@@ -1465,12 +1465,6 @@ module.exports = grammar({
         ))
       )
     ),
-
-    coalesce_expression: $ => prec.left(PREC.TERNARY, seq(
-      field('left', $._expression),
-      field('operator', '??'),
-      field('right', $._expression)
-    )),
 
     as_expression: $ => prec.left(PREC.EQUAL, seq(
       field('left', $._expression),

--- a/grammar.js
+++ b/grammar.js
@@ -18,6 +18,7 @@ const PREC = {
   COND: 3,
   ASSIGN: 2,
   SEQ: 1,
+  TERNARY: 1,  
   SELECT: 0,
   TYPE_PATTERN: -2,
 };
@@ -1396,6 +1397,7 @@ module.exports = grammar({
       $.binary_expression,
       $.cast_expression,
       $.checked_expression,
+      $.coalesce_expression,
       $.conditional_access_expression,
       $.conditional_expression,
       $.default_expression,
@@ -1455,7 +1457,6 @@ module.exports = grammar({
         ['!=', PREC.EQUAL],
         ['>=', PREC.REL],
         ['>', PREC.REL],
-        ['??', PREC.EQUAL],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._expression),
@@ -1464,6 +1465,12 @@ module.exports = grammar({
         ))
       )
     ),
+
+    coalesce_expression: $ => prec.left(PREC.TERNARY, seq(
+      field('left', $._expression),
+      field('operator', '??'),
+      field('right', $._expression)
+    )),
 
     as_expression: $ => prec.left(PREC.EQUAL, seq(
       field('left', $._expression),

--- a/grammar.js
+++ b/grammar.js
@@ -1438,25 +1438,25 @@ module.exports = grammar({
 
     binary_expression: $ => choice(
       ...[
-        ['&&', PREC.LOGAND],
-        ['||', PREC.LOGOR],
-        ['>>', PREC.SHIFT],
-        ['<<', PREC.SHIFT],
-        ['&', PREC.AND],
-        ['^', PREC.OR],
-        ['|', PREC.OR],
-        ['+', PREC.ADD],
-        ['-', PREC.ADD],
-        ['*', PREC.MULT],
-        ['/', PREC.MULT],
-        ['%', PREC.MULT],
-        ['<', PREC.REL],
-        ['<=', PREC.REL],
-        ['==', PREC.EQUAL],
-        ['!=', PREC.EQUAL],
-        ['>=', PREC.REL],
-        ['>', PREC.REL],
-        ['??', PREC.TERNARY],
+        ['&&', PREC.LOGAND], // logical_and_expression
+        ['||', PREC.LOGOR], // logical_or_expression
+        ['>>', PREC.SHIFT], // right_shift_expression
+        ['<<', PREC.SHIFT], // left_shift_expression
+        ['&', PREC.AND],  // bitwise_and_expression
+        ['^', PREC.OR], // exclusive_or_expression
+        ['|', PREC.OR], // bitwise_or_expression
+        ['+', PREC.ADD], // add_expression
+        ['-', PREC.ADD], // subtract_expression
+        ['*', PREC.MULT], // multiply_expression
+        ['/', PREC.MULT], // divide_expression
+        ['%', PREC.MULT], // modulo_expression
+        ['<', PREC.REL], // less_than_expression
+        ['<=', PREC.REL], // less_than_or_equal_expression
+        ['==', PREC.EQUAL], // equals_expression
+        ['!=', PREC.EQUAL], // not_equals_expression
+        ['>=', PREC.REL], // greater_than_or_equal_expression
+        ['>', PREC.REL], //  greater_than_expression
+        ['??', PREC.TERNARY], // coalesce_expression
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._expression),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7575,6 +7575,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "coalesce_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "conditional_access_expression"
         },
         {
@@ -8311,41 +8315,41 @@
               }
             ]
           }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 9,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "??"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
         }
       ]
+    },
+    "coalesce_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "??"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
     },
     "as_expression": {
       "type": "PREC_LEFT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7575,10 +7575,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "coalesce_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "conditional_access_expression"
         },
         {
@@ -8315,41 +8311,41 @@
               }
             ]
           }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "??"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
         }
       ]
-    },
-    "coalesce_expression": {
-      "type": "PREC_LEFT",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "left",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "operator",
-            "content": {
-              "type": "STRING",
-              "value": "??"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "right",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          }
-        ]
-      }
     },
     "as_expression": {
       "type": "PREC_LEFT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -130,6 +130,10 @@
         "named": true
       },
       {
+        "type": "coalesce_expression",
+        "named": true
+      },
+      {
         "type": "conditional_access_expression",
         "named": true
       },
@@ -977,10 +981,6 @@
             "named": false
           },
           {
-            "type": "??",
-            "named": false
-          },
-          {
             "type": "^",
             "named": false
           },
@@ -1447,6 +1447,42 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "coalesce_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "??",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -130,10 +130,6 @@
         "named": true
       },
       {
-        "type": "coalesce_expression",
-        "named": true
-      },
-      {
         "type": "conditional_access_expression",
         "named": true
       },
@@ -981,6 +977,10 @@
             "named": false
           },
           {
+            "type": "??",
+            "named": false
+          },
+          {
             "type": "^",
             "named": false
           },
@@ -1447,42 +1447,6 @@
           "named": true
         }
       ]
-    }
-  },
-  {
-    "type": "coalesce_expression",
-    "named": true,
-    "fields": {
-      "left": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "??",
-            "named": false
-          }
-        ]
-      },
-      "right": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          }
-        ]
-      }
     }
   },
   {


### PR DESCRIPTION
`??` produced confused expression trees in #149

The priority was incorrect.

Also took the opportunity to introduce `coalesce_expression` as per Roslyn.

```csharp
b = obj ?? a == 0;
```

Results in

```
assignment_expression
  identifier
  assignment_operator
  coalesce_expression
    identifier
    binary_expression
      identifier
      integer_literal
```

Introduces no regressions in the corpus tests or the example suite.