### PR TITLE
Parse arrays of named tuples correctly

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -888,6 +888,38 @@ void b() {
                       (integer_literal))))))))))))
 
 ============================
+Array of named tuple
+============================
+
+void a() {
+  var z = new (string b, string c)[3];
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement (void_keyword) (identifier) (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (array_creation_expression
+                  (array_type
+                    (tuple_type
+                      (tuple_element
+                        (predefined_type)
+                        (identifier))
+                      (tuple_element
+                        (predefined_type)
+                        (identifier)))
+                  (array_rank_specifier
+                    (integer_literal))))))))))))
+
+============================
 Makeref
 ============================
 

--- a/grammar.js
+++ b/grammar.js
@@ -78,7 +78,9 @@ module.exports = grammar({
     [$.parameter, $.declaration_expression],
     [$.tuple_element],
     [$.tuple_element, $.declaration_expression],
-    [$.tuple_element, $.variable_declarator]
+    [$.tuple_element, $.variable_declarator],
+
+    [$.array_creation_expression, $.element_access_expression]
   ],
 
   inline: $ => [
@@ -1053,11 +1055,11 @@ module.exports = grammar({
       $._expression
     ),
 
-    array_creation_expression: $ => seq(
+    array_creation_expression: $ => prec.dynamic(PREC.UNARY, seq(
       'new',
       $.array_type,
       optional($.initializer_expression)
-    ),
+    )),
 
     initializer_expression: $ => seq(
       '{',


### PR DESCRIPTION
`new (string a, string b)[3]` can be parsed as element access on a implicit
object creation, or as a array creation expression of a named tuple. Give
precedence to the latter.

Closes issue #166.