### PR TITLE
Make null-coalescing operator ?? right associative

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1958,3 +1958,25 @@ if ((p as Person[])?[0]._Age != 1) { }
             (identifier))
           (integer_literal))
       (block))))
+
+=====================================
+Null-coalescing operator is right-associative
+=====================================
+
+var a = b ?? c ?? d;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (binary_expression
+              (identifier)
+              (binary_expression
+                (identifier)
+                (identifier)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -15,10 +15,10 @@ const PREC = {
   OR: 6,
   LOGAND: 5,
   LOGOR: 4,
+  COALESCING: 3,
   COND: 3,
   ASSIGN: 2,
   SEQ: 1,
-  TERNARY: 1,  
   SELECT: 0,
   TYPE_PATTERN: -2,
 };
@@ -1457,15 +1457,19 @@ module.exports = grammar({
         ['==', PREC.EQUAL], // equals_expression
         ['!=', PREC.EQUAL], // not_equals_expression
         ['>=', PREC.REL], // greater_than_or_equal_expression
-        ['>', PREC.REL], //  greater_than_expression
-        ['??', PREC.TERNARY], // coalesce_expression
+        ['>', PREC.REL] //  greater_than_expression
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._expression),
           field('operator', operator),
           field('right', $._expression)
         ))
-      )
+      ),
+      prec.right(PREC.COALESCING, seq(
+        field('left', $._expression),
+        field('operator', '??'), // coalesce_expression
+        field('right', $._expression)
+      ))
     ),
 
     as_expression: $ => prec.left(PREC.EQUAL, seq(


### PR DESCRIPTION
Unlike the other operators, `??` is right-associative.

Fixes #169.

Docs: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-associativity