### PR TITLE
Null conditional operations

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1949,12 +1949,17 @@ if ((p as Person[])?[0]._Age != 1) { }
   (global_statement
     (if_statement
       (binary_expression
-          (member_access_expression
-            (conditional_access_expression
-              (parenthesized_expression
-                (as_expression (identifier) (array_type (identifier) (array_rank_specifier))))
-              (null_conditional_element_access
-                (argument (integer_literal))))
-            (identifier))
-          (integer_literal))
+        (conditional_access_expression
+          (parenthesized_expression
+            (as_expression
+              (identifier)
+              (array_type
+                (identifier)
+                (array_rank_specifier))))
+          (null_conditional_element_access
+            (argument
+              (integer_literal)))
+          (member_binding_expression
+            (identifier)))
+        (integer_literal))
       (block))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1963,3 +1963,89 @@ if ((p as Person[])?[0]._Age != 1) { }
             (identifier)))
         (integer_literal))
       (block))))
+
+=====================================
+Conditional access expression with multiple conditionals
+=====================================
+
+var a = b?.Something?.Something;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_access_expression
+              (identifier)
+              (null_conditional_member_access
+                (identifier))
+              (null_conditional_member_access
+                (identifier)))))))))
+
+=====================================
+Conditional access expression statement
+=====================================
+
+b?.Something();
+
+---
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (conditional_access_expression
+        (identifier)
+        (null_conditional_member_access
+          (identifier))
+        (conditional_invocation_expression (argument_list))))))
+
+=====================================
+Conditional access expression in anonymous object creation expression
+=====================================
+
+class H
+{
+    private int b = 3;
+    
+    public void Main()
+    {
+        var a = new {this?.b};
+    }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (field_declaration
+        (modifier)
+        (variable_declaration
+          (predefined_type)
+          (variable_declarator
+            (identifier)
+            (equals_value_clause
+              (integer_literal)))))
+      (method_declaration
+        (modifier)
+        (void_keyword)
+        (identifier)
+        (parameter_list)
+        (block
+          (local_declaration_statement
+            (variable_declaration
+              (implicit_type)
+              (variable_declarator
+                (identifier)
+                (equals_value_clause
+                  (anonymous_object_creation_expression
+                    (conditional_access_expression
+                      (this_expression)
+                      (null_conditional_member_access
+                        (identifier)))))))))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1919,7 +1919,9 @@ var x = dict?["a"];
             (conditional_access_expression
               (identifier)
               (null_conditional_element_access
-                (argument (string_literal))))))))))
+                (element_binding_expression
+                  (bracketed_argument_list
+                    (argument (string_literal))))))))))))
 
 =====================================
 Conditional access expression with member binding
@@ -1957,8 +1959,10 @@ if ((p as Person[])?[0]._Age != 1) { }
                 (identifier)
                 (array_rank_specifier))))
           (null_conditional_element_access
-            (argument
-              (integer_literal)))
+            (element_binding_expression
+              (bracketed_argument_list
+                (argument
+                  (integer_literal)))))
           (member_binding_expression
             (identifier)))
         (integer_literal))
@@ -1988,7 +1992,7 @@ var a = b?.Something?.Something;
                 (identifier)))))))))
 
 =====================================
-Conditional access expression statement
+Conditional access expression invocation statement
 =====================================
 
 b?.Something();

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1897,8 +1897,8 @@ var a = b?.Something;
           (equals_value_clause
             (conditional_access_expression
               (identifier)
-              (member_binding_expression
-              (identifier)))))))))
+              (null_conditional_member_access
+                (identifier)))))))))
 
 =====================================
 Conditional access to element (should be implicit_element_access)
@@ -1918,8 +1918,8 @@ var x = dict?["a"];
           (equals_value_clause
             (conditional_access_expression
               (identifier)
-                (element_binding_expression
-                  (bracketed_argument_list (argument (string_literal)))))))))))
+              (null_conditional_element_access
+                (argument (string_literal))))))))))
 
 =====================================
 Conditional access expression with member binding
@@ -1933,7 +1933,7 @@ if (a?.B != 1) { }
   (global_statement
     (if_statement
       (binary_expression
-        (conditional_access_expression (identifier) (member_binding_expression (identifier)))
+        (conditional_access_expression (identifier) (null_conditional_member_access (identifier)))
         (integer_literal))
       (block))))
 
@@ -1953,8 +1953,8 @@ if ((p as Person[])?[0]._Age != 1) { }
             (conditional_access_expression
               (parenthesized_expression
                 (as_expression (identifier) (array_type (identifier) (array_rank_specifier))))
-              (element_binding_expression
-                (bracketed_argument_list (argument (integer_literal)))))
+              (null_conditional_element_access
+                (argument (integer_literal))))
             (identifier))
           (integer_literal))
       (block))))

--- a/grammar.js
+++ b/grammar.js
@@ -1090,11 +1090,31 @@ module.exports = grammar({
       seq('unchecked', '(', $._expression, ')')
     ),
 
-    conditional_access_expression: $ => prec.right(PREC.COND, seq(
-      field('condition', $._expression),
-      '?',
-      choice($.member_binding_expression, $.element_binding_expression)
+    conditional_access_expression: $ => prec.right(seq(
+      $._expression,
+      $._null_conditional_operations
     )),
+
+    _null_conditional_operations: $ => prec.right(choice(
+      seq(optional($._null_conditional_operations), $.null_conditional_member_access),
+      seq(optional($._null_conditional_operations), $.null_conditional_element_access),
+      seq($._null_conditional_operations, $.member_binding_expression),
+      seq($._null_conditional_operations, $.element_binding_expression),
+      seq($._null_conditional_operations, $.conditional_invocation_expression),
+    )),
+
+    null_conditional_member_access: $ => seq(
+      '?.',
+      field('name', $._simple_name),
+    ),
+
+    null_conditional_element_access: $ => seq(
+      '?[',
+      commaSep($.argument),
+      ']'
+    ),
+
+    conditional_invocation_expression: $ => field('arguments', $.argument_list),
 
     conditional_expression: $ => prec.right(PREC.COND, seq(
       field('condition', $._expression),

--- a/grammar.js
+++ b/grammar.js
@@ -80,7 +80,13 @@ module.exports = grammar({
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
 
-    [$.array_creation_expression, $.element_access_expression]
+    [$.array_creation_expression, $.element_access_expression],
+
+    [$.conditional_expression, $.conditional_access_expression, $.prefix_unary_expression],
+    [$.conditional_expression, $.conditional_access_expression, $.await_expression],
+    [$.conditional_expression, $.conditional_access_expression, $.binary_expression],
+    [$.conditional_expression, $.conditional_access_expression, $.cast_expression],
+    [$.null_conditional_element_access, $._expression],
   ],
 
   inline: $ => [
@@ -1104,15 +1110,11 @@ module.exports = grammar({
     )),
 
     null_conditional_member_access: $ => seq(
-      '?.',
+      seq('?', '.'),
       field('name', $._simple_name),
     ),
 
-    null_conditional_element_access: $ => seq(
-      '?[',
-      commaSep($.argument),
-      ']'
-    ),
+    null_conditional_element_access: $ => seq('?', $.element_binding_expression),
 
     conditional_invocation_expression: $ => field('arguments', $.argument_list),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6106,11 +6106,44 @@
       "members": [
         {
           "type": "STRING",
-          "value": "?"
+          "value": "?["
         },
         {
-          "type": "SYMBOL",
-          "name": "bracketed_argument_list"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "argument"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "argument"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6088,8 +6088,17 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "?."
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "?"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -6106,44 +6115,11 @@
       "members": [
         {
           "type": "STRING",
-          "value": "?["
+          "value": "?"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "argument"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "argument"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "element_binding_expression"
         }
       ]
     },
@@ -9291,6 +9267,30 @@
     [
       "array_creation_expression",
       "element_access_expression"
+    ],
+    [
+      "conditional_expression",
+      "conditional_access_expression",
+      "prefix_unary_expression"
+    ],
+    [
+      "conditional_expression",
+      "conditional_access_expression",
+      "await_expression"
+    ],
+    [
+      "conditional_expression",
+      "conditional_access_expression",
+      "binary_expression"
+    ],
+    [
+      "conditional_expression",
+      "conditional_access_expression",
+      "cast_expression"
+    ],
+    [
+      "null_conditional_element_access",
+      "_expression"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5979,36 +5979,147 @@
     },
     "conditional_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 3,
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "FIELD",
-            "name": "condition",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
+            "type": "SYMBOL",
+            "name": "_expression"
           },
           {
-            "type": "STRING",
-            "value": "?"
+            "type": "SYMBOL",
+            "name": "_null_conditional_operations"
+          }
+        ]
+      }
+    },
+    "_null_conditional_operations": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_null_conditional_operations"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "null_conditional_member_access"
+              }
+            ]
           },
           {
-            "type": "CHOICE",
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_null_conditional_operations"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "null_conditional_element_access"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
             "members": [
               {
                 "type": "SYMBOL",
+                "name": "_null_conditional_operations"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "member_binding_expression"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_null_conditional_operations"
               },
               {
                 "type": "SYMBOL",
                 "name": "element_binding_expression"
               }
             ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_null_conditional_operations"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "conditional_invocation_expression"
+              }
+            ]
           }
         ]
+      }
+    },
+    "null_conditional_member_access": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "?."
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_simple_name"
+          }
+        }
+      ]
+    },
+    "null_conditional_element_access": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "?"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bracketed_argument_list"
+        }
+      ]
+    },
+    "conditional_invocation_expression": {
+      "type": "FIELD",
+      "name": "arguments",
+      "content": {
+        "type": "SYMBOL",
+        "name": "argument_list"
       }
     },
     "conditional_expression": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1507,28 +1507,29 @@
   {
     "type": "conditional_access_expression",
     "named": true,
-    "fields": {
-      "condition": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_expression",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
-          "type": "element_binding_expression",
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_invocation_expression",
           "named": true
         },
         {
           "type": "member_binding_expression",
+          "named": true
+        },
+        {
+          "type": "null_conditional_element_access",
+          "named": true
+        },
+        {
+          "type": "null_conditional_member_access",
           "named": true
         }
       ]
@@ -1564,6 +1565,22 @@
         "types": [
           {
             "type": "_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "conditional_invocation_expression",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argument_list",
             "named": true
           }
         ]
@@ -3585,6 +3602,45 @@
     }
   },
   {
+    "type": "null_conditional_element_access",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "argument",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "null_conditional_member_access",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "nullable_type",
     "named": true,
     "fields": {},
@@ -5585,11 +5641,19 @@
     "named": false
   },
   {
+    "type": "?.",
+    "named": false
+  },
+  {
     "type": "??",
     "named": false
   },
   {
     "type": "??=",
+    "named": false
+  },
+  {
+    "type": "?[",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3606,11 +3606,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "argument",
+          "type": "element_binding_expression",
           "named": true
         }
       ]
@@ -5641,19 +5641,11 @@
     "named": false
   },
   {
-    "type": "?.",
-    "named": false
-  },
-  {
     "type": "??",
     "named": false
   },
   {
     "type": "??=",
-    "named": false
-  },
-  {
-    "type": "?[",
     "named": false
   },
   {


### PR DESCRIPTION
Implement conditional access expressions according to [the C# lang specification](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#null-conditional-operator).

I am not totally convinced this is better than [the way Roslyn does it](https://github.com/tree-sitter/tree-sitter-c-sharp/issues/138#issuecomment-806473913), but this gives something working to compare against.