### PR TITLE
Make null-coalescing operator ?? right associative

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1958,3 +1958,76 @@ if ((p as Person[])?[0]._Age != 1) { }
             (identifier))
           (integer_literal))
       (block))))
+
+=====================================
+Null-coalescing operator is right-associative
+=====================================
+
+var a = b ?? c ?? d;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (binary_expression
+              (identifier)
+              (binary_expression
+                (identifier)
+                (identifier)))))))))
+
+=====================================
+Precedence between null-coalescing operator and conditional OR
+=====================================
+
+var a = b ?? c || d ?? e;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (binary_expression
+              (identifier)
+              (binary_expression
+                (binary_expression
+                  (identifier)
+                  (identifier))
+                (identifier)))))))))
+
+=====================================
+Precedence between null-coalescing operator and conditional operator
+=====================================
+
+var a = b ?? c ? d ?? e : f ?? g;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_expression
+              (binary_expression
+                (identifier)
+                (identifier))
+              (binary_expression
+                (identifier)
+                (identifier))
+              (binary_expression
+                (identifier)
+                (identifier)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -15,10 +15,9 @@ const PREC = {
   OR: 6,
   LOGAND: 5,
   LOGOR: 4,
-  COND: 3,
-  ASSIGN: 2,
-  SEQ: 1,
-  TERNARY: 1,  
+  COALESCING: 3,
+  COND: 2,
+  ASSIGN: 1,
   SELECT: 0,
   TYPE_PATTERN: -2,
 };
@@ -1457,15 +1456,19 @@ module.exports = grammar({
         ['==', PREC.EQUAL], // equals_expression
         ['!=', PREC.EQUAL], // not_equals_expression
         ['>=', PREC.REL], // greater_than_or_equal_expression
-        ['>', PREC.REL], //  greater_than_expression
-        ['??', PREC.TERNARY], // coalesce_expression
+        ['>', PREC.REL] //  greater_than_expression
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._expression),
           field('operator', operator),
           field('right', $._expression)
         ))
-      )
+      ),
+      prec.right(PREC.COALESCING, seq(
+        field('left', $._expression),
+        field('operator', '??'), // coalesce_expression
+        field('right', $._expression)
+      ))
     ),
 
     as_expression: $ => prec.left(PREC.EQUAL, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3313,7 +3313,7 @@
         },
         {
           "type": "PREC",
-          "value": 2,
+          "value": 1,
           "content": {
             "type": "SEQ",
             "members": [
@@ -5690,7 +5690,7 @@
       "members": [
         {
           "type": "PREC_DYNAMIC",
-          "value": 2,
+          "value": 1,
           "content": {
             "type": "SEQ",
             "members": [
@@ -5979,7 +5979,7 @@
     },
     "conditional_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 3,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6013,7 +6013,7 @@
     },
     "conditional_expression": {
       "type": "PREC_RIGHT",
-      "value": 3,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -8320,8 +8320,8 @@
           }
         },
         {
-          "type": "PREC_LEFT",
-          "value": 1,
+          "type": "PREC_RIGHT",
+          "value": 3,
           "content": {
             "type": "SEQ",
             "members": [


### PR DESCRIPTION
Unlike the other operators, `??` is right-associative. And give it the correct
precedence.

Fixes #169. Similar to PR #171, but that was reverted because it didn't include
the generated files.

Docs: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/#operator-associativity