### PR TITLE
Support Unicode identifiers

### DIFF
--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -59,7 +59,7 @@ var varæble = 0;
 var Переменная = 0;
 var first‿letter = 0;
 var ග්‍රහලෝකය = 0;
-var كوكب = 0;
+var _كوكبxxx = 0;
 
 ---
 

--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -29,7 +29,7 @@ int @var = @const;
         (variable_declarator (identifier) (equals_value_clause (identifier)))))))
 
 =======================================
-indentifiers with contextual keyword names
+identifiers with contextual keyword names
 =======================================
 
 int nint = 0;
@@ -48,3 +48,75 @@ int nuint = 0;
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (integer_literal)))))))
+
+=======================================
+unicode identifiers 
+=======================================
+
+var under_score = 0;
+var with1number = 0;
+var varæble = 0;
+var Переменная = 0;
+var first‿letter = 0;
+var ග්‍රහලෝකය = 0;
+var كوكب = 0;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal))))))                        
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (integer_literal)))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1487,8 +1487,8 @@ module.exports = grammar({
       field('right', $._type)
     )),
 
-    // Unicode categories: L = Letter, Nd = Decimal_Number, Pc = Connector_Punctuation, Cf = Format, Mn = Nonspacing_Mark, Mc = Spacing_Mark, Me = Enclosing_Mark
-    _identifier_token: $ => token(seq(optional('@'), /[\p{L}_][\p{L}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}\p{Me}]*/)),
+    // Unicode categories: L = Letter, Nl Letter_Number, = Nd = Decimal_Number, Pc = Connector_Punctuation, Cf = Format, Mn = Nonspacing_Mark, Mc = Spacing_Mark
+    _identifier_token: $ => token(seq(optional('@'), /[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*/)),
     identifier: $ => choice($._identifier_token, $._contextual_keywords),
 
     global: $ => 'global',

--- a/grammar.js
+++ b/grammar.js
@@ -1487,7 +1487,8 @@ module.exports = grammar({
       field('right', $._type)
     )),
 
-    _identifier_token: $ => token(seq(optional('@'), /[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ_0-9]*/)), // identifier_token in Roslyn
+    // Unicode categories: L = Letter, Nd = Decimal_Number, Pc = Connector_Punctuation, Cf = Format, Mn = Nonspacing_Mark, Mc = Spacing_Mark, Me = Enclosing_Mark
+    _identifier_token: $ => token(seq(optional('@'), /[\p{L}_][\p{L}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}\p{Me}]*/)),
     identifier: $ => choice($._identifier_token, $._contextual_keywords),
 
     global: $ => 'global',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8443,7 +8443,7 @@
           },
           {
             "type": "PATTERN",
-            "value": "[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ_0-9]*"
+            "value": "[\\p{L}_][\\p{L}\\p{Nd}\\p{Pc}\\p{Cf}\\p{Mn}\\p{Mc}\\p{Me}]*"
           }
         ]
       }


### PR DESCRIPTION
According to documentation (https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names):

> Identifiers may contain Unicode letter characters, decimal digit characters, Unicode connecting characters, Unicode combining characters, or Unicode formatting characters.