### PR TITLE
Improve preprocessing parsing

### DIFF
--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -171,12 +171,12 @@ class Of1879 {
 Pragmas
 ===================================
 
-#pragma warning disable 660,661
+#pragma warning disable 660,661,nullable
 
 ---
 
 (compilation_unit
-  (preprocessor_call (pragma_directive (preproc_warning_number) (preproc_warning_number))))
+  (preprocessor_call (pragma_directive (integer_literal) (integer_literal) (identifier))))
 
 ===================================
 Directives not in strings or comments

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -13,25 +13,60 @@ If, elif and else directives
 ---
 
 (compilation_unit
-  (preprocessor_call (preprocessor_directive) (identifier))
+  (preprocessor_call (if_directive (identifier)))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (preprocessor_directive) (identifier))
+  (preprocessor_call (elif_directive (identifier)))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (preprocessor_directive))
+  (preprocessor_call (else_directive))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (preprocessor_directive)))
+  (preprocessor_call (endif_directive)))
+
+===========================
+Complex if conditions
+===========================
+#if !MACOS
+#if WIN32==true
+#if !MACOS!=false
+#if A && B || C
+#if (A)
+#if (A || B)
+#if (A && B) || C
+
+---
+(compilation_unit
+  (preprocessor_call
+    (if_directive (prefix_unary_expression (identifier))))
+  (preprocessor_call
+    (if_directive      
+      (binary_expression (identifier) (boolean_literal))))
+  (preprocessor_call
+    (if_directive
+      (binary_expression (prefix_unary_expression (identifier)) (boolean_literal))))
+  (preprocessor_call
+    (if_directive
+      (binary_expression (binary_expression (identifier) (identifier)) (identifier))))
+  (preprocessor_call
+    (if_directive (parenthesized_expression (identifier))))
+  (preprocessor_call
+    (if_directive
+      (parenthesized_expression (binary_expression (identifier) (identifier)))))
+  (preprocessor_call
+    (if_directive
+      (binary_expression
+        (parenthesized_expression (binary_expression (identifier) (identifier)))
+        (identifier)))))
 
 ===========================
 Region directives
@@ -47,12 +82,9 @@ Region directives
 
 (compilation_unit
   (preprocessor_call
-    (preprocessor_directive)
-    (identifier)
-    (identifier)
-    (identifier))
+    (region_directive (preproc_message)))
   (comment)
-  (preprocessor_call (preprocessor_directive)))
+  (preprocessor_call (endregion_directive)))
 
 ===================================
 Define and undefine directives
@@ -64,8 +96,8 @@ Define and undefine directives
 ---
 
 (compilation_unit
-  (preprocessor_call (preprocessor_directive) (identifier))
-  (preprocessor_call (preprocessor_directive) (identifier)))
+  (preprocessor_call (define_directive (identifier)))
+  (preprocessor_call (undef_directive (identifier))))
 
 ===================================
 Warning and error directives
@@ -80,8 +112,8 @@ class Of1879 {
 
 (compilation_unit
   (class_declaration (identifier) (declaration_list
-    (preprocessor_call (preprocessor_directive) (identifier) (identifier) (identifier) (identifier))
-    (preprocessor_call (preprocessor_directive) (identifier) (identifier) (identifier)))))
+    (preprocessor_call (warning_directive (preproc_message)))
+    (preprocessor_call (error_directive (preproc_message))))))
 
 ===================================
 Line directives
@@ -89,7 +121,7 @@ Line directives
 
 class Of1879 {
   void AMethod() {
-#line 2001 "A Space"
+#line 2001 "A Space" // Comment
 #line hidden
 #line default
   }
@@ -105,9 +137,9 @@ class Of1879 {
       (identifier)
       (parameter_list)
       (block
-        (preprocessor_call (preprocessor_directive) (integer_literal) (string_literal))
-        (preprocessor_call (preprocessor_directive) (identifier))
-        (preprocessor_call (preprocessor_directive) (identifier))))))) 
+        (preprocessor_call (line_directive (preproc_integer_literal) (preproc_string_literal)) (comment))
+        (preprocessor_call (line_directive))
+        (preprocessor_call (line_directive)))))))
 
 ===================================
 Spaces in directives
@@ -131,9 +163,20 @@ class Of1879 {
       (identifier)
       (parameter_list)
       (block
-        (preprocessor_call (preprocessor_directive) (integer_literal) (string_literal))
-        (preprocessor_call (preprocessor_directive) (identifier))
-        (preprocessor_call (preprocessor_directive) (identifier))))))) 
+        (preprocessor_call (line_directive (preproc_integer_literal) (preproc_string_literal)))
+        (preprocessor_call (line_directive))
+        (preprocessor_call (line_directive)))))))
+
+===================================
+Pragmas
+===================================
+
+#pragma warning disable 660,661
+
+---
+
+(compilation_unit
+  (preprocessor_call (pragma_directive (preproc_warning_number) (preproc_warning_number))))
 
 ===================================
 Directives not in strings or comments

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -13,25 +13,25 @@ If, elif and else directives
 ---
 
 (compilation_unit
-  (preprocessor_call (if_directive (identifier)))
+  (if_directive (identifier))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (elif_directive (identifier)))
+  (elif_directive (identifier))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (else_directive))
+  (else_directive)
   (global_statement
     (local_declaration_statement
       (variable_declaration
         (predefined_type)
         (variable_declarator (identifier) (equals_value_clause (string_literal))))))
-  (preprocessor_call (endif_directive)))
+  (endif_directive))
 
 ===========================
 Complex if conditions
@@ -46,27 +46,20 @@ Complex if conditions
 
 ---
 (compilation_unit
-  (preprocessor_call
-    (if_directive (prefix_unary_expression (identifier))))
-  (preprocessor_call
-    (if_directive      
-      (binary_expression (identifier) (boolean_literal))))
-  (preprocessor_call
-    (if_directive
-      (binary_expression (prefix_unary_expression (identifier)) (boolean_literal))))
-  (preprocessor_call
-    (if_directive
-      (binary_expression (binary_expression (identifier) (identifier)) (identifier))))
-  (preprocessor_call
-    (if_directive (parenthesized_expression (identifier))))
-  (preprocessor_call
-    (if_directive
-      (parenthesized_expression (binary_expression (identifier) (identifier)))))
-  (preprocessor_call
-    (if_directive
-      (binary_expression
-        (parenthesized_expression (binary_expression (identifier) (identifier)))
-        (identifier)))))
+  (if_directive (prefix_unary_expression (identifier)))
+  (if_directive      
+    (binary_expression (identifier) (boolean_literal)))
+  (if_directive
+    (binary_expression (prefix_unary_expression (identifier)) (boolean_literal)))
+  (if_directive
+    (binary_expression (binary_expression (identifier) (identifier)) (identifier)))
+  (if_directive (parenthesized_expression (identifier)))
+  (if_directive
+    (parenthesized_expression (binary_expression (identifier) (identifier))))
+  (if_directive
+    (binary_expression
+      (parenthesized_expression (binary_expression (identifier) (identifier)))
+      (identifier))))
 
 ===========================
 Region directives
@@ -81,10 +74,9 @@ Region directives
 ---
 
 (compilation_unit
-  (preprocessor_call
-    (region_directive (preproc_message)))
+  (region_directive (preproc_message))
   (comment)
-  (preprocessor_call (endregion_directive)))
+  (endregion_directive))
 
 ===================================
 Define and undefine directives
@@ -96,8 +88,8 @@ Define and undefine directives
 ---
 
 (compilation_unit
-  (preprocessor_call (define_directive (identifier)))
-  (preprocessor_call (undef_directive (identifier))))
+  (define_directive (identifier))
+  (undef_directive (identifier)))
 
 ===================================
 Warning and error directives
@@ -112,8 +104,8 @@ class Of1879 {
 
 (compilation_unit
   (class_declaration (identifier) (declaration_list
-    (preprocessor_call (warning_directive (preproc_message)))
-    (preprocessor_call (error_directive (preproc_message))))))
+    (warning_directive (preproc_message))
+    (error_directive (preproc_message)))))
 
 ===================================
 Line directives
@@ -137,9 +129,9 @@ class Of1879 {
       (identifier)
       (parameter_list)
       (block
-        (preprocessor_call (line_directive (preproc_integer_literal) (preproc_string_literal)) (comment))
-        (preprocessor_call (line_directive))
-        (preprocessor_call (line_directive)))))))
+        (line_directive (preproc_integer_literal) (preproc_string_literal)) (comment)
+        (line_directive)
+        (line_directive))))))
 
 ===================================
 Spaces in directives
@@ -163,9 +155,9 @@ class Of1879 {
       (identifier)
       (parameter_list)
       (block
-        (preprocessor_call (line_directive (preproc_integer_literal) (preproc_string_literal)))
-        (preprocessor_call (line_directive))
-        (preprocessor_call (line_directive)))))))
+        (line_directive (preproc_integer_literal) (preproc_string_literal))
+        (line_directive)
+        (line_directive))))))
 
 ===================================
 Pragmas
@@ -176,7 +168,7 @@ Pragmas
 ---
 
 (compilation_unit
-  (preprocessor_call (pragma_directive (integer_literal) (integer_literal) (identifier))))
+  (pragma_directive (integer_literal) (integer_literal) (identifier)))
 
 ===================================
 Directives not in strings or comments

--- a/grammar.js
+++ b/grammar.js
@@ -33,7 +33,7 @@ module.exports = grammar({
   extras: $ => [
     $.comment,
     /[\s\u00A0\uFEFF\u3000]+/,
-    $.preprocessor_call
+    $._preprocessor_call
   ],
 
   supertypes: $ => [
@@ -1639,7 +1639,7 @@ module.exports = grammar({
     return_type: $ => choice($._type, $.void_keyword),
     void_keyword: $ => 'void',
 
-    preprocessor_call: $ => seq(
+    _preprocessor_call: $ => seq(
       $._preproc_directive_start,
       choice(
           $.nullable_directive,

--- a/grammar.js
+++ b/grammar.js
@@ -205,7 +205,7 @@ module.exports = grammar({
     ),
 
     attribute_argument: $ => seq(
-      optional(choice($.name_equals,$.name_colon)),
+      optional(choice($.name_equals, $.name_colon)),
       $._expression
     ),
 
@@ -1642,19 +1642,19 @@ module.exports = grammar({
     _preprocessor_call: $ => seq(
       $._preproc_directive_start,
       choice(
-          $.nullable_directive,
-          $.define_directive,
-          $.undef_directive,
-          $.if_directive,
-          $.else_directive,
-          $.elif_directive,
-          $.endif_directive,
-          $.region_directive,
-          $.endregion_directive,
-          $.error_directive,
-          $.warning_directive,
-          $.line_directive,
-          $.pragma_directive
+        $.nullable_directive,
+        $.define_directive,
+        $.undef_directive,
+        $.if_directive,
+        $.else_directive,
+        $.elif_directive,
+        $.endif_directive,
+        $.region_directive,
+        $.endregion_directive,
+        $.error_directive,
+        $.warning_directive,
+        $.line_directive,
+        $.pragma_directive
       ),
       $._preproc_directive_end
     ),
@@ -1662,9 +1662,9 @@ module.exports = grammar({
     _preproc_directive_start: $ => /#[ \t]*/,
 
     nullable_directive: $ => seq(
-        'nullable',
-        choice('disable', 'enable', 'restore'),
-        optional(choice('annotations', 'warnings'))
+      'nullable',
+      choice('disable', 'enable', 'restore'),
+      optional(choice('annotations', 'warnings'))
     ),
 
     // Preprocessor
@@ -1680,65 +1680,65 @@ module.exports = grammar({
     error_directive: $ => seq('error', $.preproc_message),
     warning_directive: $ => seq('warning', $.preproc_message),
     line_directive: $ => seq('line',
-        choice(
-            'default',
-            'hidden',
-            seq($.preproc_integer_literal, optional($.preproc_string_literal))
-        )
+      choice(
+        'default',
+        'hidden',
+        seq($.preproc_integer_literal, optional($.preproc_string_literal))
+      )
     ),
     pragma_directive: $ => seq('pragma',
-        choice(
-            seq('warning',
-              choice('disable', 'restore'),
-              commaSep(
-                  choice(
-                    $.identifier,
-                    alias($.preproc_integer_literal, $.integer_literal),
+      choice(
+        seq('warning',
+          choice('disable', 'restore'),
+          commaSep(
+            choice(
+              $.identifier,
+              alias($.preproc_integer_literal, $.integer_literal),
             ))),
-            seq('checksum', $.preproc_string_literal, $.preproc_string_literal, $.preproc_string_literal)
-        )
+        seq('checksum', $.preproc_string_literal, $.preproc_string_literal, $.preproc_string_literal)
+      )
     ),
 
-    preproc_message: $ => /[^\n\r]*/,
+    preproc_message: $ => /[^\n\r]+/,
     preproc_integer_literal: $ => /[0-9]+/,
     preproc_string_literal: $ => /"[^"]*"/,
 
     _preproc_expression: $ => choice(
-        $.identifier,
-        $.boolean_literal,
-        alias($.preproc_integer_literal, $.integer_literal),
-        alias($.preproc_string_literal, $.verbatim_string_literal),
-        alias($.preproc_unary_expression, $.prefix_unary_expression),
-        alias($.preproc_binary_expression, $.binary_expression),
-        alias($.preproc_parenthesized_expression, $.parenthesized_expression)
+      $.identifier,
+      $.boolean_literal,
+      alias($.preproc_integer_literal, $.integer_literal),
+      alias($.preproc_string_literal, $.verbatim_string_literal),
+      alias($.preproc_unary_expression, $.prefix_unary_expression),
+      alias($.preproc_binary_expression, $.binary_expression),
+      alias($.preproc_parenthesized_expression, $.parenthesized_expression)
     ),
 
     preproc_parenthesized_expression: $ => seq(
-        '(',
-        $._preproc_expression,
-        ')'
+      '(',
+      $._preproc_expression,
+      ')'
     ),
 
     preproc_unary_expression: $ => prec.left(PREC.UNARY, seq(
-        field('operator', '!'),
-        field('argument', $._preproc_expression)
+      field('operator', '!'),
+      field('argument', $._preproc_expression)
     )),
 
     preproc_binary_expression: $ => {
-        const table = [
-            ['||', PREC.LOGOR],
-            ['&&', PREC.LOGAND],
-            ['==', PREC.EQUAL],
-            ['!=', PREC.EQUAL],
-        ];
+      const table = [
+        ['||', PREC.LOGOR],
+        ['&&', PREC.LOGAND],
+        ['==', PREC.EQUAL],
+        ['!=', PREC.EQUAL],
+      ];
 
-        return choice(...table.map(([operator, precedence]) => {
-            return prec.left(precedence, seq(
-                field('left', $._preproc_expression),
-                field('operator', operator),
-                field('right', $._preproc_expression)
-            ))
-        }));
+      return choice(...table.map(([operator, precedence]) => {
+        return prec.left(precedence, seq(
+          field('left', $._preproc_expression),
+          field('operator', operator),
+          field('right', $._preproc_expression)
+        ))
+      }));
     },
   }
 })

--- a/grammar.js
+++ b/grammar.js
@@ -1688,15 +1688,20 @@ module.exports = grammar({
     ),
     pragma_directive: $ => seq('pragma',
         choice(
-            seq('warning', choice('disable', 'restore'), commaSep($.preproc_warning_number)),
+            seq('warning',
+              choice('disable', 'restore'),
+              commaSep(
+                  choice(
+                    $.identifier,
+                    alias($.preproc_integer_literal, $.integer_literal),
+            ))),
             seq('checksum', $.preproc_string_literal, $.preproc_string_literal, $.preproc_string_literal)
         )
     ),
 
-    preproc_message: $ => /.+/,
+    preproc_message: $ => /[^\n\r]*/,
     preproc_integer_literal: $ => /[0-9]+/,
     preproc_string_literal: $ => /"[^"]*"/,
-    preproc_warning_number: $ => /[A-Za-z]*[0-9]+/,
 
     _preproc_expression: $ => choice(
         $.identifier,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -199,10 +199,6 @@
 ;; Attribute
 (attribute) @type
 
-;; Preprocessor
-(preprocessor_directive) @function.macro
-(preprocessor_call (identifier) @constant)
-
 ;; Parameter
 (parameter
   type: (identifier) @type

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8970,7 +8970,7 @@
       "type": "STRING",
       "value": "void"
     },
-    "preprocessor_call": {
+    "_preprocessor_call": {
       "type": "SEQ",
       "members": [
         {
@@ -9641,7 +9641,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "preprocessor_call"
+      "name": "_preprocessor_call"
     }
   ],
   "conflicts": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9299,8 +9299,22 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "SYMBOL",
-                          "name": "preproc_warning_number"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "identifier"
+                            },
+                            {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "preproc_integer_literal"
+                              },
+                              "named": true,
+                              "value": "integer_literal"
+                            }
+                          ]
                         },
                         {
                           "type": "REPEAT",
@@ -9312,8 +9326,22 @@
                                 "value": ","
                               },
                               {
-                                "type": "SYMBOL",
-                                "name": "preproc_warning_number"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "identifier"
+                                  },
+                                  {
+                                    "type": "ALIAS",
+                                    "content": {
+                                      "type": "SYMBOL",
+                                      "name": "preproc_integer_literal"
+                                    },
+                                    "named": true,
+                                    "value": "integer_literal"
+                                  }
+                                ]
                               }
                             ]
                           }
@@ -9354,7 +9382,7 @@
     },
     "preproc_message": {
       "type": "PATTERN",
-      "value": ".+"
+      "value": "[^\\n\\r]*"
     },
     "preproc_integer_literal": {
       "type": "PATTERN",
@@ -9363,10 +9391,6 @@
     "preproc_string_literal": {
       "type": "PATTERN",
       "value": "\"[^\"]*\""
-    },
-    "preproc_warning_number": {
-      "type": "PATTERN",
-      "value": "[A-Za-z]*[0-9]+"
     },
     "_preproc_expression": {
       "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9382,7 +9382,7 @@
     },
     "preproc_message": {
       "type": "PATTERN",
-      "value": "[^\\n\\r]*"
+      "value": "[^\\n\\r]+"
     },
     "preproc_integer_literal": {
       "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8975,34 +8975,64 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "preprocessor_directive"
+          "name": "_preproc_directive_start"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_literal"
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": -1,
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\\s]+"
-                  }
-                }
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "nullable_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "define_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "undef_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "if_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "else_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "elif_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "endif_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "region_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "endregion_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "error_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "warning_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "line_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "pragma_directive"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -9010,9 +9040,570 @@
         }
       ]
     },
-    "preprocessor_directive": {
+    "_preproc_directive_start": {
       "type": "PATTERN",
-      "value": "#[ \\t]*[a-z]\\w*"
+      "value": "#[ \\t]*"
+    },
+    "nullable_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "nullable"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "disable"
+            },
+            {
+              "type": "STRING",
+              "value": "enable"
+            },
+            {
+              "type": "STRING",
+              "value": "restore"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "annotations"
+                },
+                {
+                  "type": "STRING",
+                  "value": "warnings"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "define_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "define"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "undef_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "undef"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "if_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_preproc_expression"
+        }
+      ]
+    },
+    "else_directive": {
+      "type": "STRING",
+      "value": "else"
+    },
+    "elif_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "elif"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_preproc_expression"
+        }
+      ]
+    },
+    "endif_directive": {
+      "type": "STRING",
+      "value": "endif"
+    },
+    "region_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "region"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "preproc_message"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "endregion_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "endregion"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "preproc_message"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "error_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "error"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preproc_message"
+        }
+      ]
+    },
+    "warning_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "warning"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preproc_message"
+        }
+      ]
+    },
+    "line_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "line"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "default"
+            },
+            {
+              "type": "STRING",
+              "value": "hidden"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "preproc_integer_literal"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "preproc_string_literal"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "pragma_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "pragma"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "warning"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "disable"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "restore"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "preproc_warning_number"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "preproc_warning_number"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "checksum"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "preproc_string_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "preproc_string_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "preproc_string_literal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "preproc_message": {
+      "type": "PATTERN",
+      "value": ".+"
+    },
+    "preproc_integer_literal": {
+      "type": "PATTERN",
+      "value": "[0-9]+"
+    },
+    "preproc_string_literal": {
+      "type": "PATTERN",
+      "value": "\"[^\"]*\""
+    },
+    "preproc_warning_number": {
+      "type": "PATTERN",
+      "value": "[A-Za-z]*[0-9]+"
+    },
+    "_preproc_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "boolean_literal"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_integer_literal"
+          },
+          "named": true,
+          "value": "integer_literal"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_string_literal"
+          },
+          "named": true,
+          "value": "verbatim_string_literal"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_unary_expression"
+          },
+          "named": true,
+          "value": "prefix_unary_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_binary_expression"
+          },
+          "named": true,
+          "value": "binary_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_parenthesized_expression"
+          },
+          "named": true,
+          "value": "parenthesized_expression"
+        }
+      ]
+    },
+    "preproc_parenthesized_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_preproc_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "preproc_unary_expression": {
+      "type": "PREC_LEFT",
+      "value": 17,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "!"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "argument",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_preproc_expression"
+            }
+          }
+        ]
+      }
+    },
+    "preproc_binary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 4,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "||"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "&&"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "=="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "!="
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_preproc_expression"
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1819,6 +1819,21 @@
     "fields": {}
   },
   {
+    "type": "define_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "delegate_declaration",
     "named": true,
     "fields": {
@@ -1985,9 +2000,68 @@
     }
   },
   {
+    "type": "elif_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "verbatim_string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "else_directive",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "empty_statement",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "endregion_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "preproc_message",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "enum_declaration",
@@ -2100,6 +2174,21 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "error_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "preproc_message",
           "named": true
         }
       ]
@@ -2602,6 +2691,45 @@
     "type": "identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "if_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "verbatim_string_literal",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "if_statement",
@@ -3158,6 +3286,25 @@
     }
   },
   {
+    "type": "line_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "preproc_integer_literal",
+          "named": true
+        },
+        {
+          "type": "preproc_string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "local_declaration_statement",
     "named": true,
     "fields": {},
@@ -3583,6 +3730,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "nullable_directive",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "nullable_type",
@@ -4028,12 +4180,76 @@
     }
   },
   {
-    "type": "prefix_unary_expression",
+    "type": "pragma_directive",
     "named": true,
     "fields": {},
     "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "preproc_string_literal",
+          "named": true
+        },
+        {
+          "type": "preproc_warning_number",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "prefix_unary_expression",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_unary_expression",
+            "named": true
+          },
+          {
+            "type": "verbatim_string_literal",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "!",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",
@@ -4047,43 +4263,59 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "boolean_literal",
+          "type": "define_directive",
           "named": true
         },
         {
-          "type": "character_literal",
+          "type": "elif_directive",
           "named": true
         },
         {
-          "type": "identifier",
+          "type": "else_directive",
           "named": true
         },
         {
-          "type": "integer_literal",
+          "type": "endif_directive",
           "named": true
         },
         {
-          "type": "null_literal",
+          "type": "endregion_directive",
           "named": true
         },
         {
-          "type": "preprocessor_directive",
+          "type": "error_directive",
           "named": true
         },
         {
-          "type": "real_literal",
+          "type": "if_directive",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "line_directive",
           "named": true
         },
         {
-          "type": "verbatim_string_literal",
+          "type": "nullable_directive",
+          "named": true
+        },
+        {
+          "type": "pragma_directive",
+          "named": true
+        },
+        {
+          "type": "region_directive",
+          "named": true
+        },
+        {
+          "type": "undef_directive",
+          "named": true
+        },
+        {
+          "type": "warning_directive",
           "named": true
         }
       ]
@@ -4490,6 +4722,21 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "region_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "preproc_message",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -5159,6 +5406,21 @@
     }
   },
   {
+    "type": "undef_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "unsafe_statement",
     "named": true,
     "fields": {},
@@ -5309,6 +5571,21 @@
         },
         {
           "type": "tuple_pattern",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "warning_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "preproc_message",
           "named": true
         }
       ]
@@ -5657,6 +5934,10 @@
     "named": false
   },
   {
+    "type": "annotations",
+    "named": false
+  },
+  {
     "type": "as",
     "named": false
   },
@@ -5701,6 +5982,10 @@
     "named": false
   },
   {
+    "type": "checksum",
+    "named": false
+  },
+  {
     "type": "class",
     "named": false
   },
@@ -5721,11 +6006,19 @@
     "named": false
   },
   {
+    "type": "define",
+    "named": false
+  },
+  {
     "type": "delegate",
     "named": false
   },
   {
     "type": "descending",
+    "named": false
+  },
+  {
+    "type": "disable",
     "named": false
   },
   {
@@ -5741,7 +6034,23 @@
     "named": false
   },
   {
+    "type": "elif",
+    "named": false
+  },
+  {
     "type": "else",
+    "named": false
+  },
+  {
+    "type": "enable",
+    "named": false
+  },
+  {
+    "type": "endif_directive",
+    "named": true
+  },
+  {
+    "type": "endregion",
     "named": false
   },
   {
@@ -5750,6 +6059,10 @@
   },
   {
     "type": "equals",
+    "named": false
+  },
+  {
+    "type": "error",
     "named": false
   },
   {
@@ -5813,6 +6126,10 @@
     "named": false
   },
   {
+    "type": "hidden",
+    "named": false
+  },
+  {
     "type": "if",
     "named": false
   },
@@ -5857,6 +6174,10 @@
     "named": false
   },
   {
+    "type": "line",
+    "named": false
+  },
+  {
     "type": "lock",
     "named": false
   },
@@ -5897,6 +6218,10 @@
     "named": true
   },
   {
+    "type": "nullable",
+    "named": false
+  },
+  {
     "type": "on",
     "named": false
   },
@@ -5933,11 +6258,27 @@
     "named": false
   },
   {
+    "type": "pragma",
+    "named": false
+  },
+  {
     "type": "predefined_type",
     "named": true
   },
   {
-    "type": "preprocessor_directive",
+    "type": "preproc_integer_literal",
+    "named": true
+  },
+  {
+    "type": "preproc_message",
+    "named": true
+  },
+  {
+    "type": "preproc_string_literal",
+    "named": true
+  },
+  {
+    "type": "preproc_warning_number",
     "named": true
   },
   {
@@ -5973,7 +6314,15 @@
     "named": false
   },
   {
+    "type": "region",
+    "named": false
+  },
+  {
     "type": "remove",
+    "named": false
+  },
+  {
+    "type": "restore",
     "named": false
   },
   {
@@ -6041,6 +6390,10 @@
     "named": false
   },
   {
+    "type": "undef",
+    "named": false
+  },
+  {
     "type": "unmanaged",
     "named": false
   },
@@ -6070,6 +6423,14 @@
   },
   {
     "type": "volatile",
+    "named": false
+  },
+  {
+    "type": "warning",
+    "named": false
+  },
+  {
+    "type": "warnings",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4263,69 +4263,6 @@
     }
   },
   {
-    "type": "preprocessor_call",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "define_directive",
-          "named": true
-        },
-        {
-          "type": "elif_directive",
-          "named": true
-        },
-        {
-          "type": "else_directive",
-          "named": true
-        },
-        {
-          "type": "endif_directive",
-          "named": true
-        },
-        {
-          "type": "endregion_directive",
-          "named": true
-        },
-        {
-          "type": "error_directive",
-          "named": true
-        },
-        {
-          "type": "if_directive",
-          "named": true
-        },
-        {
-          "type": "line_directive",
-          "named": true
-        },
-        {
-          "type": "nullable_directive",
-          "named": true
-        },
-        {
-          "type": "pragma_directive",
-          "named": true
-        },
-        {
-          "type": "region_directive",
-          "named": true
-        },
-        {
-          "type": "undef_directive",
-          "named": true
-        },
-        {
-          "type": "warning_directive",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "primary_constructor_base_type",
     "named": true,
     "fields": {},

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4188,11 +4188,15 @@
       "required": false,
       "types": [
         {
-          "type": "preproc_string_literal",
+          "type": "identifier",
           "named": true
         },
         {
-          "type": "preproc_warning_number",
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "preproc_string_literal",
           "named": true
         }
       ]
@@ -6275,10 +6279,6 @@
   },
   {
     "type": "preproc_string_literal",
-    "named": true
-  },
-  {
-    "type": "preproc_warning_number",
     "named": true
   },
   {


### PR DESCRIPTION
Fixes #188 as well as `#IF` containing anything more than a basic token.

It also provides a syntax tree for these statements partly modelled on the C one.

This does not attempt to solve #189 - I'll take a look at that separately (again based on the C one)

Fixes #16 too