### PR TITLE
Rename the body of a record _record_base to _record_body

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -585,7 +585,7 @@ module.exports = grammar({
       field('parameters', optional($.parameter_list)),
       field('bases', optional(alias($.record_base, $.base_list))),
       repeat($.type_parameter_constraints_clause),
-      field('body', $._record_base),
+      field('body', $._record_body),
     ),
 
     record_base: $ => choice(
@@ -598,7 +598,7 @@ module.exports = grammar({
       $.argument_list
     ),
 
-    _record_base: $ => choice(
+    _record_body: $ => choice(
       $.declaration_list,
       ';'
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3001,7 +3001,7 @@
           "name": "body",
           "content": {
             "type": "SYMBOL",
-            "name": "_record_base"
+            "name": "_record_body"
           }
         }
       ]
@@ -3113,7 +3113,7 @@
         }
       ]
     },
-    "_record_base": {
+    "_record_body": {
       "type": "CHOICE",
       "members": [
         {


### PR DESCRIPTION
Having `_record_base` and `record_base` is confusing. Since it has an
underscore before it, it is not a public name, so this change shouldn't cause
much problems.