### PR TITLE
Extract _string_literal_fragment and _interpolated_string_text_fragment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1164,9 +1164,11 @@ module.exports = grammar({
 
     interpolated_string_text: $ => choice(
       '{{',
-      token.immediate(prec(1, /[^{"\\\n]+/)),
+      $._interpolated_string_text_fragment,
       $.escape_sequence
     ),
+
+    _interpolated_string_text_fragment: $ => token.immediate(prec(1, /[^{"\\\n]+/)),
 
     interpolated_verbatim_string_text: $ => choice(
       '{{',
@@ -1569,11 +1571,13 @@ module.exports = grammar({
     string_literal: $ => seq(
       '"',
       repeat(choice(
-        token.immediate(prec(1, /[^"\\\n]+/)),
+        $._string_literal_fragment,
         $.escape_sequence
       )),
       '"'
     ),
+
+    _string_literal_fragment: $ => token.immediate(prec(1, /[^"\\\n]+/)),
 
     verbatim_string_literal: $ => token(seq(
       '@"',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6300,21 +6300,25 @@
           "value": "{{"
         },
         {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 1,
-            "content": {
-              "type": "PATTERN",
-              "value": "[^{\"\\\\\\n]+"
-            }
-          }
+          "type": "SYMBOL",
+          "name": "_interpolated_string_text_fragment"
         },
         {
           "type": "SYMBOL",
           "name": "escape_sequence"
         }
       ]
+    },
+    "_interpolated_string_text_fragment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^{\"\\\\\\n]+"
+        }
+      }
     },
     "interpolated_verbatim_string_text": {
       "type": "CHOICE",
@@ -8755,15 +8759,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": 1,
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\"\\\\\\n]+"
-                  }
-                }
+                "type": "SYMBOL",
+                "name": "_string_literal_fragment"
               },
               {
                 "type": "SYMBOL",
@@ -8777,6 +8774,17 @@
           "value": "\""
         }
       ]
+    },
+    "_string_literal_fragment": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^\"\\\\\\n]+"
+        }
+      }
     },
     "verbatim_string_literal": {
       "type": "TOKEN",


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep/issues/3289

This results in a better name for string fragments (Str_lit_frag instead of
Imm_tok_pat_5a6fa79), and solves a problem where the node is not created in the
CST.