### PR TITLE
Fix indexer params parsing

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -487,6 +487,33 @@ class Foo {
                   (bracketed_argument_list (argument (identifier))))
                   (assignment_operator) (identifier)))))))))
 
+
+=====================================
+Class with varargs indexer
+=====================================
+
+class A {
+    public int this[params string[] arguments] {
+        get { return 1; }
+    }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (indexer_declaration
+        (modifier)
+        (predefined_type)
+          (bracketed_parameter_list
+            (array_type (predefined_type) (array_rank_specifier)) (identifier))
+            (accessor_list
+              (accessor_declaration
+                (block
+                  (return_statement (integer_literal)))))))))
+
 =================================
 Method with qualified return type
 =================================

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -153,7 +153,7 @@ class Z {
     (parameter_list)
     (type_parameter_constraints_clause (identifier) (type_parameter_constraint)))
   (delegate_declaration (void_keyword) (identifier)
-    (parameter_list (parameter_array (array_type (predefined_type) (array_rank_specifier)) (identifier))))
+    (parameter_list (array_type (predefined_type) (array_rank_specifier)) (identifier)))
   (class_declaration (identifier) (declaration_list
     (delegate_declaration (void_keyword) (identifier) (parameter_list)))))
 

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -338,12 +338,11 @@ class A {
         (predefined_type)
         (identifier)
         (parameter_list
-          (parameter_array
-            (nullable_type
-              (array_type
-                (predefined_type)
-                (array_rank_specifier)))
-            (identifier)))
+          (nullable_type
+            (array_type
+              (predefined_type)
+              (array_rank_specifier)))
+          (identifier))
         (arrow_expression_clause
           (integer_literal))))))
           

--- a/grammar.js
+++ b/grammar.js
@@ -309,7 +309,7 @@ module.exports = grammar({
 
     _formal_parameter_list: $ => commaSep1(choice(
       $.parameter,
-      $.parameter_array
+      $._parameter_array
     )),
 
     parameter: $ => seq(
@@ -322,7 +322,7 @@ module.exports = grammar({
 
     parameter_modifier: $ => prec.right(choice('ref', 'out', 'this', 'in')),
 
-    parameter_array: $ => seq(
+    _parameter_array: $ => seq(
       repeat($.attribute_list),
       'params',
       choice($.array_type, $.nullable_type),
@@ -477,7 +477,7 @@ module.exports = grammar({
       )
     ),
 
-    bracketed_parameter_list: $ => seq('[', commaSep1($.parameter), ']'),
+    bracketed_parameter_list: $ => seq('[', $._formal_parameter_list, ']'),
 
     property_declaration: $ => seq(
       repeat($.attribute_list),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1146,7 +1146,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "parameter_array"
+              "name": "_parameter_array"
             }
           ]
         },
@@ -1168,7 +1168,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "parameter_array"
+                    "name": "_parameter_array"
                   }
                 ]
               }
@@ -1262,7 +1262,7 @@
         ]
       }
     },
-    "parameter_array": {
+    "_parameter_array": {
       "type": "SEQ",
       "members": [
         {
@@ -2198,29 +2198,8 @@
           "value": "["
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "parameter"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "parameter"
-                  }
-                ]
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_formal_parameter_list"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1162,6 +1162,22 @@
       "required": true,
       "types": [
         {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
           "type": "parameter",
           "named": true
         }
@@ -3995,12 +4011,12 @@
     }
   },
   {
-    "type": "parameter_array",
+    "type": "parameter_list",
     "named": true,
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "array_type",
@@ -4017,24 +4033,9 @@
         {
           "type": "nullable_type",
           "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "parameter_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "parameter",
-          "named": true
         },
         {
-          "type": "parameter_array",
+          "type": "parameter",
           "named": true
         }
       ]


### PR DESCRIPTION
Also makes `parameter_array` hidden so as not to pollute output and to keep parity with Roslyn.

Fixes #201