### PR TITLE
Add support for file_scoped_namespace_declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-tree-sitter-c-sharp
-===========================
+# tree-sitter-c-sharp
 
 [![Build Status](https://github.com/tree-sitter/tree-sitter-c-sharp/workflows/build/badge.svg)](https://github.com/tree-sitter/tree-sitter-c-sharp/actions?query=workflow%3Abuild)
 
@@ -92,7 +91,7 @@ Comprehensive support for C# exists with the following exceptions:
 #### C# 10.0
 
 - [x] global using directives
-- [ ] File-scoped namespace declaration
+- [x] File-scoped namespace declaration
 - [ ] Extended property patterns
 - [x] Allow const interpolated strings
 - [x] Record types can seal ToString()
@@ -102,6 +101,6 @@ Comprehensive support for C# exists with the following exceptions:
 
 ### References
 
-* [Official C# 6 Language Spec](https://github.com/dotnet/csharplang/blob/master/spec/) provides chapters that formally define the language grammar.
-* [Roslyn C# language grammar export](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4)
-* [SharpLab](https://sharplab.io) (web-based syntax tree playground based on Roslyn)
+- [Official C# 6 Language Spec](https://github.com/dotnet/csharplang/blob/master/spec/) provides chapters that formally define the language grammar.
+- [Roslyn C# language grammar export](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4)
+- [SharpLab](https://sharplab.io) (web-based syntax tree playground based on Roslyn)

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -111,6 +111,24 @@ namespace A {
         (declaration_list)))))
 
 =====================================
+File scoped namespaces
+=====================================
+
+namespace A;
+
+class B {
+}
+
+---
+
+(compilation_unit
+  (file_scoped_namespace_declaration
+    (identifier)
+  (class_declaration
+    (identifier)
+      (declaration_list))))
+
+=====================================
 Interfaces
 =====================================
 

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -124,8 +124,8 @@ class B {
 (compilation_unit
   (file_scoped_namespace_declaration
     (identifier)
-  (class_declaration
-    (identifier)
+    (class_declaration
+      (identifier)
       (declaration_list))))
 
 =====================================

--- a/grammar.js
+++ b/grammar.js
@@ -100,8 +100,10 @@ module.exports = grammar({
       repeat($.extern_alias_directive),
       repeat($.using_directive),
       repeat($.global_attribute_list),
-      repeat($.global_statement),
-      repeat($._namespace_member_declaration)
+      choice(
+        seq(repeat($.global_statement), repeat($._namespace_member_declaration)),
+        $.file_scoped_namespace_declaration
+      )
     ),
 
     global_statement: $ => $._statement,
@@ -627,6 +629,15 @@ module.exports = grammar({
       field('name', $._name),
       field('body', $.declaration_list),
       optional(';')
+    ),
+
+    file_scoped_namespace_declaration: $ => seq(
+      'namespace',
+      field('name', $._name),
+      ';',
+      repeat($.extern_alias_directive),
+      repeat($.using_directive),
+      repeat($._type_declaration)
     ),
 
     _type: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -27,18 +27,32 @@
           }
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "global_statement"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_namespace_member_declaration"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "global_statement"
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_namespace_member_declaration"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "file_scoped_namespace_declaration"
+            }
+          ]
         }
       ]
     },
@@ -3262,6 +3276,48 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "file_scoped_namespace_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "namespace"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "extern_alias_directive"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "using_directive"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_type_declaration"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1494,6 +1494,10 @@
           "named": true
         },
         {
+          "type": "file_scoped_namespace_declaration",
+          "named": true
+        },
+        {
           "type": "global_attribute_list",
           "named": true
         },
@@ -2374,6 +2378,80 @@
         },
         {
           "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "file_scoped_namespace_declaration",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "alias_qualified_name",
+            "named": true
+          },
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "qualified_name",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "class_declaration",
+          "named": true
+        },
+        {
+          "type": "delegate_declaration",
+          "named": true
+        },
+        {
+          "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "extern_alias_directive",
+          "named": true
+        },
+        {
+          "type": "interface_declaration",
+          "named": true
+        },
+        {
+          "type": "record_declaration",
+          "named": true
+        },
+        {
+          "type": "record_struct_declaration",
+          "named": true
+        },
+        {
+          "type": "struct_declaration",
+          "named": true
+        },
+        {
+          "type": "using_directive",
           "named": true
         }
       ]


### PR DESCRIPTION
As per the C# 10 draft at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces

Sticking with Roslyn naming and grammar.

Should probably also remove `global_statement` and replace it with just `statement` for consistency (in a subsequent PR if no objections)