### PR TITLE
Added support for record structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Comprehensive support for C# exists with the following exceptions:
 - [x] Record types can seal ToString()
 - [x] Allow both assignment and declaration in the same deconstruction
 - [x] Allow AsyncMethodBuilder attribute on methods
+- [x] Record structs
 
 ### References
 

--- a/corpus/records.txt
+++ b/corpus/records.txt
@@ -18,6 +18,25 @@ record F {
         (accessor_list (accessor_declaration) (accessor_declaration))))))
 
 =====================================
+Basic record struct declaration
+=====================================
+
+record struct F {
+  int Age { get; init; }
+}
+
+---
+
+(compilation_unit
+  (record_struct_declaration
+    (identifier)
+    (declaration_list
+      (property_declaration
+        (predefined_type)
+        (identifier)
+        (accessor_list (accessor_declaration) (accessor_declaration))))))
+
+=====================================
 Record with a type parameter struct constraint
 =====================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -123,6 +123,7 @@ module.exports = grammar({
       $.operator_declaration,
       $.property_declaration,
       $.record_declaration,
+      $.record_struct_declaration,
       $.struct_declaration,
       $.using_directive,
     ),
@@ -138,7 +139,8 @@ module.exports = grammar({
       $.interface_declaration,
       $.enum_declaration,
       $.delegate_declaration,
-      $.record_declaration
+      $.record_declaration,
+      $.record_struct_declaration
     ),
 
     extern_alias_directive: $ => seq('extern', 'alias', $.identifier, ';'),
@@ -584,6 +586,19 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'record',
+      field('name', $.identifier),
+      field('type_parameters', optional($.type_parameter_list)),
+      field('parameters', optional($.parameter_list)),
+      field('bases', optional(alias($.record_base, $.base_list))),
+      repeat($.type_parameter_constraints_clause),
+      field('body', $._record_body),
+    ),
+
+    record_struct_declaration: $ => seq(
+      repeat($.attribute_list),
+      repeat($.modifier),
+      'record',
+      'struct',
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
       field('parameters', optional($.parameter_list)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -115,6 +115,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "record_struct_declaration"
+        },
+        {
+          "type": "SYMBOL",
           "name": "struct_declaration"
         },
         {
@@ -162,6 +166,10 @@
         {
           "type": "SYMBOL",
           "name": "record_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_struct_declaration"
         }
       ]
     },
@@ -2918,6 +2926,109 @@
         {
           "type": "STRING",
           "value": "record"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type_parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "bases",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "record_base"
+                },
+                "named": true,
+                "value": "base_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "type_parameter_constraints_clause"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_record_body"
+          }
+        }
+      ]
+    },
+    "record_struct_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_list"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "modifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "record"
+        },
+        {
+          "type": "STRING",
+          "value": "struct"
         },
         {
           "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -68,6 +68,10 @@
         "named": true
       },
       {
+        "type": "record_struct_declaration",
+        "named": true
+      },
+      {
         "type": "struct_declaration",
         "named": true
       },
@@ -1507,6 +1511,10 @@
         },
         {
           "type": "record_declaration",
+          "named": true
+        },
+        {
+          "type": "record_struct_declaration",
           "named": true
         },
         {
@@ -4503,6 +4511,84 @@
   },
   {
     "type": "record_declaration",
+    "named": true,
+    "fields": {
+      "bases": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "base_list",
+            "named": true
+          }
+        ]
+      },
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": ";",
+            "named": false
+          },
+          {
+            "type": "declaration_list",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "parameter_list",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameter_list",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "type_parameter_constraints_clause",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "record_struct_declaration",
     "named": true,
     "fields": {
       "bases": {


### PR DESCRIPTION
See spec here: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs

Syntax wise they are just records with an extra keyword, so I have only added one test to see that we can parse the basic version. 