### PR TITLE
Fixes precedence between is and as

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1592,6 +1592,7 @@ is pattern
 
 var b = s is string s2;
 var c = s is "test";
+var a = 1 is int.MaxValue;
 
 ---
 
@@ -1618,17 +1619,7 @@ var c = s is "test";
             (is_pattern_expression
               (identifier)
                 (constant_pattern
-                  (string_literal)))))))))
-
-=====================================
-Precedence between is operator and as operator
-=====================================
-
-var a = new object() is null as Object;
-
----
-
-(compilation_unit
+                  (string_literal))))))))
   (global_statement
     (local_declaration_statement
       (variable_declaration
@@ -1636,14 +1627,79 @@ var a = new object() is null as Object;
         (variable_declarator
           (identifier)
           (equals_value_clause
-            (as_expression
-              (is_pattern_expression
-                (object_creation_expression
+            (is_pattern_expression
+              (integer_literal)
+              (constant_pattern
+                (member_access_expression
                   (predefined_type)
-                  (argument_list))
+                  (identifier))))))))))
+
+=====================================
+Precedence between is operator and conditional_expression
+=====================================
+
+int a = 1 is Object ? 1 : 2;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (predefined_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (conditional_expression
+              (is_pattern_expression
+                (integer_literal)
                 (constant_pattern
-                  (null_literal)))
-              (identifier))))))))
+                  (identifier)))
+              (integer_literal)
+              (integer_literal))))))))
+
+=====================================
+Precedence between is operator and as operator
+=====================================
+
+//var a = new object() is null as Object == false; // this parses with wrong precedence
+var a = new object() is null as Object;
+var b = true == 1 as int? is int;
+
+---
+
+(compilation_unit
+  (comment)
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+              (as_expression
+                (is_pattern_expression
+                  (object_creation_expression
+                    (predefined_type)
+                    (argument_list))
+                  (constant_pattern
+                    (null_literal)))
+                (identifier)))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (binary_expression
+              (boolean_literal)
+              (is_expression
+                (as_expression
+                  (integer_literal)
+                  (nullable_type
+                    (predefined_type)))
+                (predefined_type)))))))))
 
 =====================================
 Discard pattern

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1621,6 +1621,31 @@ var c = s is "test";
                   (string_literal)))))))))
 
 =====================================
+Precedence between is operator and as operator
+=====================================
+
+var a = new object() is null as Object;
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (as_expression
+              (is_pattern_expression
+                (object_creation_expression
+                  (predefined_type)
+                  (argument_list))
+                (constant_pattern
+                  (null_literal)))
+              (identifier))))))))
+
+=====================================
 Discard pattern
 =====================================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1593,6 +1593,8 @@ is pattern
 var b = s is string s2;
 var c = s is "test";
 var a = 1 is int.MaxValue;
+var d = a is nameof(a);
+var e = a is (int)b;
 
 ---
 
@@ -1631,6 +1633,33 @@ var a = 1 is int.MaxValue;
               (integer_literal)
               (constant_pattern
                 (member_access_expression
+                  (predefined_type)
+                  (identifier)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (constant_pattern
+                (invocation_expression
+                  (identifier)
+                  (argument_list
+                    (argument (identifier)))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (constant_pattern
+                (cast_expression
                   (predefined_type)
                   (identifier))))))))))
 

--- a/grammar.js
+++ b/grammar.js
@@ -75,6 +75,9 @@ module.exports = grammar({
 
     [$._type, $.array_creation_expression],
     [$._type, $.stack_alloc_array_creation_expression],
+    [$._type, $._nullable_base_type],
+    [$._type, $._nullable_base_type, $.array_creation_expression],
+    [$._nullable_base_type, $.stack_alloc_array_creation_expression],
 
     [$.parameter_modifier, $.this_expression],
     [$.parameter, $._simple_name],
@@ -667,14 +670,15 @@ module.exports = grammar({
     // expression but we can't match empty rules.
     array_rank_specifier: $ => seq('[', commaSep(optional($._expression)), ']'),
 
-    // When used in a nullable type, the '?' operator binds tighter than the
-    // binary operators `as` and `is`. But in a conditional expression, the `?`
-    // binds *looser*. This weird double precedence is required in order to
-    // preserve the conflict, so that `?` can be used in both ways, depending
-    // on what follows.
-    nullable_type: $ => choice(
-      prec(PREC.REL + 1, seq($._type, '?')),
-      prec(PREC.COND - 1, seq($._type, '?'))
+    nullable_type: $ => seq($._nullable_base_type, '?'),
+
+    _nullable_base_type: $ => choice(
+      $.array_type,
+      $._name,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.predefined_type,
+      $.tuple_type
     ),
 
     pointer_type: $ => prec(PREC.POSTFIX, seq($._type, '*')),

--- a/grammar.js
+++ b/grammar.js
@@ -962,6 +962,8 @@ module.exports = grammar({
         $.tuple_expression,
         $.type_of_expression,
         $.member_access_expression,
+        $.invocation_expression,
+        $.cast_expression,
   
         $._simple_name,
         $._literal

--- a/grammar.js
+++ b/grammar.js
@@ -1,17 +1,19 @@
 const PREC = {
-  DOT: 18,
-  INVOCATION: 18,
-  POSTFIX: 18,
-  PREFIX: 17,
-  UNARY: 17,
-  CAST: 17,
-  RANGE: 16,
-  SWITCH: 15,
-  WITH: 14,
-  MULT: 13,
-  ADD: 12,
-  SHIFT: 11,
-  REL: 10,
+  DOT: 20,
+  INVOCATION: 20,
+  POSTFIX: 20,
+  PREFIX: 19,
+  UNARY: 19,
+  CAST: 19,
+  RANGE: 18,
+  SWITCH: 17,
+  WITH: 16,
+  MULT: 15,
+  ADD: 14,
+  SHIFT: 13,
+  REL: 12,
+  IS: 11,
+  AS: 10,
   EQUAL: 9,
   AND: 8,
   XOR: 7,
@@ -86,7 +88,11 @@ module.exports = grammar({
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
 
-    [$.array_creation_expression, $.element_access_expression]
+    [$.array_creation_expression, $.element_access_expression],
+
+    [$.constant_pattern, $._name],
+    [$.constant_pattern, $._name, $._expression],
+    [$.constant_pattern, $._expression],
   ],
 
   inline: $ => [
@@ -669,7 +675,7 @@ module.exports = grammar({
     // preserve the conflict, so that `?` can be used in both ways, depending
     // on what follows.
     nullable_type: $ => choice(
-      prec(PREC.EQUAL + 1, seq($._type, '?')),
+      prec(PREC.IS + 1, seq($._type, '?')),
       prec(PREC.COND - 1, seq($._type, '?'))
     ),
 
@@ -946,7 +952,22 @@ module.exports = grammar({
       )),
     ),
 
-    constant_pattern: $ => prec.right($._expression),
+    //We may need to expand this list if more things can be evaluated at compile time
+    constant_pattern: $ => choice(
+        $.binary_expression,
+        $.conditional_expression,
+        $.default_expression,
+        $.interpolated_string_expression,
+        $.parenthesized_expression,
+        $.postfix_unary_expression,
+        $.prefix_unary_expression,
+        $.size_of_expression,
+        $.tuple_expression,
+        $.type_of_expression,
+  
+        $._simple_name,
+        $._literal
+      ),
 
     declaration_pattern: $ => seq(
       field('type', $._type),
@@ -1228,7 +1249,7 @@ module.exports = grammar({
       field('arguments', $.argument_list)
     )),
 
-    is_pattern_expression: $ => prec.left(PREC.EQUAL, seq(
+    is_pattern_expression: $ => prec.left(PREC.IS, seq(
       field('expression', $._expression),
       'is',
       field('pattern', $._pattern)
@@ -1512,13 +1533,13 @@ module.exports = grammar({
       ))
     ),
 
-    as_expression: $ => prec.left(PREC.EQUAL, seq(
+    as_expression: $ => prec.left(PREC.AS, seq(
       field('left', $._expression),
       field('operator', 'as'),
       field('right', $._type)
     )),
 
-    is_expression: $ => prec.left(PREC.EQUAL, seq(
+    is_expression: $ => prec.left(PREC.IS, seq(
       field('left', $._expression),
       field('operator', 'is'),
       field('right', $._type)

--- a/grammar.js
+++ b/grammar.js
@@ -1,19 +1,17 @@
 const PREC = {
-  DOT: 20,
-  INVOCATION: 20,
-  POSTFIX: 20,
-  PREFIX: 19,
-  UNARY: 19,
-  CAST: 19,
-  RANGE: 18,
-  SWITCH: 17,
-  WITH: 16,
-  MULT: 15,
-  ADD: 14,
-  SHIFT: 13,
-  REL: 12,
-  IS: 11,
-  AS: 10,
+  DOT: 18,
+  INVOCATION: 18,
+  POSTFIX: 18,
+  PREFIX: 17,
+  UNARY: 17,
+  CAST: 17,
+  RANGE: 16,
+  SWITCH: 15,
+  WITH: 14,
+  MULT: 13,
+  ADD: 12,
+  SHIFT: 11,
+  REL: 10,
   EQUAL: 9,
   AND: 8,
   XOR: 7,
@@ -675,7 +673,7 @@ module.exports = grammar({
     // preserve the conflict, so that `?` can be used in both ways, depending
     // on what follows.
     nullable_type: $ => choice(
-      prec(PREC.IS + 1, seq($._type, '?')),
+      prec(PREC.REL + 1, seq($._type, '?')),
       prec(PREC.COND - 1, seq($._type, '?'))
     ),
 
@@ -955,7 +953,6 @@ module.exports = grammar({
     //We may need to expand this list if more things can be evaluated at compile time
     constant_pattern: $ => choice(
         $.binary_expression,
-        $.conditional_expression,
         $.default_expression,
         $.interpolated_string_expression,
         $.parenthesized_expression,
@@ -964,6 +961,7 @@ module.exports = grammar({
         $.size_of_expression,
         $.tuple_expression,
         $.type_of_expression,
+        $.member_access_expression,
   
         $._simple_name,
         $._literal
@@ -1249,7 +1247,7 @@ module.exports = grammar({
       field('arguments', $.argument_list)
     )),
 
-    is_pattern_expression: $ => prec.left(PREC.IS, seq(
+    is_pattern_expression: $ => prec.left(PREC.REL, seq(
       field('expression', $._expression),
       'is',
       field('pattern', $._pattern)
@@ -1533,13 +1531,13 @@ module.exports = grammar({
       ))
     ),
 
-    as_expression: $ => prec.left(PREC.AS, seq(
+    as_expression: $ => prec.left(PREC.REL, seq(
       field('left', $._expression),
       field('operator', 'as'),
       field('right', $._type)
     )),
 
-    is_expression: $ => prec.left(PREC.IS, seq(
+    is_expression: $ => prec.left(PREC.REL, seq(
       field('left', $._expression),
       field('operator', 'is'),
       field('right', $._type)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3450,41 +3450,44 @@
       ]
     },
     "nullable_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_nullable_base_type"
+        },
+        {
+          "type": "STRING",
+          "value": "?"
+        }
+      ]
+    },
+    "_nullable_base_type": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC",
-          "value": 11,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_type"
-              },
-              {
-                "type": "STRING",
-                "value": "?"
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "array_type"
         },
         {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_type"
-              },
-              {
-                "type": "STRING",
-                "value": "?"
-              }
-            ]
-          }
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "predefined_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
         }
       ]
     },
@@ -9969,6 +9972,19 @@
     ],
     [
       "_type",
+      "stack_alloc_array_creation_expression"
+    ],
+    [
+      "_type",
+      "_nullable_base_type"
+    ],
+    [
+      "_type",
+      "_nullable_base_type",
+      "array_creation_expression"
+    ],
+    [
+      "_nullable_base_type",
       "stack_alloc_array_creation_expression"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5024,6 +5024,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "invocation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cast_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_simple_name"
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -387,7 +387,7 @@
     },
     "qualified_name": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1648,7 +1648,7 @@
     },
     "explicit_interface_specifier": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3364,7 +3364,7 @@
     },
     "array_type": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3454,7 +3454,7 @@
       "members": [
         {
           "type": "PREC",
-          "value": 10,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3490,7 +3490,7 @@
     },
     "pointer_type": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4980,12 +4980,57 @@
       ]
     },
     "constant_pattern": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SYMBOL",
-        "name": "_expression"
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "binary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "default_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolated_string_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postfix_unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefix_unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "size_of_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_of_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_simple_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_literal"
+        }
+      ]
     },
     "declaration_pattern": {
       "type": "SEQ",
@@ -5880,7 +5925,7 @@
     },
     "array_creation_expression": {
       "type": "PREC_DYNAMIC",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6049,7 +6094,7 @@
     },
     "await_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6066,7 +6111,7 @@
     },
     "cast_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6284,7 +6329,7 @@
     },
     "element_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6584,7 +6629,7 @@
     },
     "invocation_expression": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6609,7 +6654,7 @@
     },
     "is_pattern_expression": {
       "type": "PREC_LEFT",
-      "value": 9,
+      "value": 11,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6659,7 +6704,7 @@
     },
     "member_access_expression": {
       "type": "PREC",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6797,7 +6842,7 @@
     },
     "postfix_unary_expression": {
       "type": "PREC_LEFT",
-      "value": 18,
+      "value": 20,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -6845,7 +6890,7 @@
     },
     "prefix_unary_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -7318,7 +7363,7 @@
     },
     "range_expression": {
       "type": "PREC_RIGHT",
-      "value": 16,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7476,7 +7521,7 @@
     },
     "switch_expression": {
       "type": "PREC",
-      "value": 15,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7646,7 +7691,7 @@
     },
     "with_expression": {
       "type": "PREC_LEFT",
-      "value": 14,
+      "value": 16,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7979,7 +8024,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 11,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8012,7 +8057,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 11,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8144,7 +8189,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 14,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8177,7 +8222,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 14,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8210,7 +8255,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 15,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8243,7 +8288,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 15,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8276,7 +8321,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 15,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8309,7 +8354,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 10,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8342,7 +8387,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 10,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8441,7 +8486,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 10,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8474,7 +8519,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 10,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8542,7 +8587,7 @@
     },
     "as_expression": {
       "type": "PREC_LEFT",
-      "value": 9,
+      "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
@@ -8575,7 +8620,7 @@
     },
     "is_expression": {
       "type": "PREC_LEFT",
-      "value": 9,
+      "value": 11,
       "content": {
         "type": "SEQ",
         "members": [
@@ -9655,7 +9700,7 @@
     },
     "preproc_unary_expression": {
       "type": "PREC_LEFT",
-      "value": 17,
+      "value": 19,
       "content": {
         "type": "SEQ",
         "members": [
@@ -9957,6 +10002,19 @@
     [
       "array_creation_expression",
       "element_access_expression"
+    ],
+    [
+      "constant_pattern",
+      "_name"
+    ],
+    [
+      "constant_pattern",
+      "_name",
+      "_expression"
+    ],
+    [
+      "constant_pattern",
+      "_expression"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -387,7 +387,7 @@
     },
     "qualified_name": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1648,7 +1648,7 @@
     },
     "explicit_interface_specifier": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3364,7 +3364,7 @@
     },
     "array_type": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3454,7 +3454,7 @@
       "members": [
         {
           "type": "PREC",
-          "value": 12,
+          "value": 11,
           "content": {
             "type": "SEQ",
             "members": [
@@ -3490,7 +3490,7 @@
     },
     "pointer_type": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4988,10 +4988,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "conditional_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "default_expression"
         },
         {
@@ -5021,6 +5017,10 @@
         {
           "type": "SYMBOL",
           "name": "type_of_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "member_access_expression"
         },
         {
           "type": "SYMBOL",
@@ -5925,7 +5925,7 @@
     },
     "array_creation_expression": {
       "type": "PREC_DYNAMIC",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6094,7 +6094,7 @@
     },
     "await_expression": {
       "type": "PREC_RIGHT",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6111,7 +6111,7 @@
     },
     "cast_expression": {
       "type": "PREC_RIGHT",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6329,7 +6329,7 @@
     },
     "element_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6629,7 +6629,7 @@
     },
     "invocation_expression": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6654,7 +6654,7 @@
     },
     "is_pattern_expression": {
       "type": "PREC_LEFT",
-      "value": 11,
+      "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6704,7 +6704,7 @@
     },
     "member_access_expression": {
       "type": "PREC",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6842,7 +6842,7 @@
     },
     "postfix_unary_expression": {
       "type": "PREC_LEFT",
-      "value": 20,
+      "value": 18,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -6890,7 +6890,7 @@
     },
     "prefix_unary_expression": {
       "type": "PREC_RIGHT",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -7363,7 +7363,7 @@
     },
     "range_expression": {
       "type": "PREC_RIGHT",
-      "value": 18,
+      "value": 16,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7521,7 +7521,7 @@
     },
     "switch_expression": {
       "type": "PREC",
-      "value": 17,
+      "value": 15,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7691,7 +7691,7 @@
     },
     "with_expression": {
       "type": "PREC_LEFT",
-      "value": 16,
+      "value": 14,
       "content": {
         "type": "SEQ",
         "members": [
@@ -8024,7 +8024,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 11,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8057,7 +8057,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 13,
+          "value": 11,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8189,7 +8189,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 14,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8222,7 +8222,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 14,
+          "value": 12,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8255,7 +8255,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 15,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8288,7 +8288,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 15,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8321,7 +8321,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 15,
+          "value": 13,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8354,7 +8354,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 10,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8387,7 +8387,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 10,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8486,7 +8486,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 10,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8519,7 +8519,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 12,
+          "value": 10,
           "content": {
             "type": "SEQ",
             "members": [
@@ -8620,7 +8620,7 @@
     },
     "is_expression": {
       "type": "PREC_LEFT",
-      "value": 11,
+      "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
@@ -9700,7 +9700,7 @@
     },
     "preproc_unary_expression": {
       "type": "PREC_LEFT",
-      "value": 19,
+      "value": 17,
       "content": {
         "type": "SEQ",
         "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1615,6 +1615,10 @@
           "named": true
         },
         {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
           "type": "character_literal",
           "named": true
         },
@@ -1640,6 +1644,10 @@
         },
         {
           "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "invocation_expression",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1607,7 +1607,83 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "default_expression",
+          "named": true
+        },
+        {
+          "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "size_of_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "type_of_expression",
+          "named": true
+        },
+        {
+          "type": "verbatim_string_literal",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3946,7 +3946,43 @@
       "required": true,
       "types": [
         {
-          "type": "_type",
+          "type": "alias_qualified_name",
+          "named": true
+        },
+        {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "function_pointer_type",
+          "named": true
+        },
+        {
+          "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "pointer_type",
+          "named": true
+        },
+        {
+          "type": "predefined_type",
+          "named": true
+        },
+        {
+          "type": "qualified_name",
+          "named": true
+        },
+        {
+          "type": "tuple_type",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1619,10 +1619,6 @@
           "named": true
         },
         {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
           "type": "default_expression",
           "named": true
         },
@@ -1644,6 +1640,10 @@
         },
         {
           "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "member_access_expression",
           "named": true
         },
         {


### PR DESCRIPTION
'is' has higher precedence than 'as'. To get the test case to parse I also had to restrict the types of expressions that can be 'constant_pattern'.

This breaks with the official grammar for constant expression, but the official spec is vague. "A constant_expression is an expression that can be fully evaluated at compile-time."

I have limited it to the ones that I find reasonable that can be constant. We may have to add or remove some elements from the constant_pattern rule in the future as we learn more and as the official compiler is able to resolve more expressions at compile time.

fixes #150 