### PR TITLE
Added support for extended property patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Comprehensive support for C# exists with the following exceptions:
 
 - [x] global using directives
 - [x] File-scoped namespace declaration
-- [ ] Extended property patterns
+- [x] Extended property patterns
 - [x] Allow const interpolated strings
 - [x] Record types can seal ToString()
 - [x] Allow both assignment and declaration in the same deconstruction

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1753,6 +1753,7 @@ Property patterns
 =====================================
 
 var x = operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } };
+var x = operand is ILiteralOperation { ConstantValue.HasValue: true, ConstantValue.Value: null};
 
 ---
 
@@ -1770,15 +1771,35 @@ var x = operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: n
                 (identifier)
                 (property_pattern_clause
                   (subpattern
-                    (name_colon (identifier))
+                    (expression_colon (identifier))
                     (recursive_pattern
                       (property_pattern_clause
                         (subpattern
-                          (name_colon (identifier))
+                          (expression_colon (identifier))
                           (constant_pattern (boolean_literal)))
                         (subpattern
-                          (name_colon (identifier))
-                          (constant_pattern (null_literal)))))))))))))))
+                          (expression_colon (identifier))
+                          (constant_pattern (null_literal))))))))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (is_pattern_expression
+              (identifier)
+              (recursive_pattern
+                (identifier)
+                (property_pattern_clause
+                  (subpattern
+                    (expression_colon
+                      (member_access_expression (identifier) (identifier)))
+                    (constant_pattern (boolean_literal)))
+                  (subpattern
+                    (expression_colon
+                      (member_access_expression (identifier) (identifier)))
+                    (constant_pattern (null_literal))))))))))))
 
 =====================================
 Positional patterns
@@ -1820,7 +1841,7 @@ var c = p is (var x, var y) { x: 0 };
                     (var_pattern (identifier))))
                 (property_pattern_clause
                   (subpattern
-                    (name_colon (identifier))
+                    (expression_colon (identifier))
                     (constant_pattern (integer_literal))))))))))))
 
 =====================================

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -493,7 +493,7 @@ switch (A)
             (recursive_pattern
               (property_pattern_clause
                 (subpattern
-                  (name_colon (identifier))
+                  (expression_colon (identifier))
                   (constant_pattern (integer_literal)))))
             (when_clause
               (prefix_unary_expression (identifier))))

--- a/grammar.js
+++ b/grammar.js
@@ -63,6 +63,7 @@ module.exports = grammar({
     [$._simple_name, $.type_parameter],
     [$._simple_name, $.generic_name],
     [$._simple_name, $.constructor_declaration],
+    [$._simple_name, $.name_colon],
 
     [$.qualified_name, $.explicit_interface_specifier],
     [$.qualified_name, $.member_access_expression],
@@ -983,9 +984,11 @@ module.exports = grammar({
       optional(seq($.subpattern, ',', commaSep1($.subpattern))),// we really should allow single sub patterns, but that causes conficts, and will rarely be used
       ')',
     )),
+    
+    expression_colon: $ => seq($._expression, ':'),
 
     subpattern: $ => seq(
-      optional($.name_colon),
+      optional($.expression_colon),
       $._pattern
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5201,6 +5201,19 @@
         ]
       }
     },
+    "expression_colon": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        }
+      ]
+    },
     "subpattern": {
       "type": "SEQ",
       "members": [
@@ -5209,7 +5222,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "name_colon"
+              "name": "expression_colon"
             },
             {
               "type": "BLANK"
@@ -9868,6 +9881,10 @@
     [
       "_simple_name",
       "constructor_declaration"
+    ],
+    [
+      "_simple_name",
+      "name_colon"
     ],
     [
       "qualified_name",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2331,6 +2331,21 @@
     }
   },
   {
+    "type": "expression_colon",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "expression_statement",
     "named": true,
     "fields": {},
@@ -5043,7 +5058,7 @@
           "named": true
         },
         {
-          "type": "name_colon",
+          "type": "expression_colon",
           "named": true
         },
         {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
subpatterns now use expression_colon instead of name_colon. This alligns with how it is parsed in Roslyn, but resulted in me adding another conflict to the grammar.