### PR TITLE
0.19.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "tree-sitter-c-sharp"
 description = "C# grammar for the tree-sitter parsing library"
-version = "0.19.0"
+version = "0.19.1"
 authors = [
+    "Damien Guard <damieng@gmail.com>",
     "Max Brunsfeld <maxbrunsfeld@gmail.com>",
+    "Martin Midtgaard <martin.midtgaard@gmail.com>",
+    "Sjoerd Langkemper <sjoerd-github@linuxonly.nl>",
+    "Patrick Thomson <patrickt@github.com>",
     "Noelle Caldwell <noelle.caldwell@microsoft.com>",
     "Douglas Creager <dcreager@dcreager.net>",
-    "Damien Guard <damieng@gmail.com>",
-    "Martin Midtgaard <martin.midtgaard@gmail.com>",
-    "Patrick Thomson <patrickt@github.com>",
 ]
 license = "MIT"
 readme = "bindings/rust/README.md"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "tree-sitter-c-sharp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "C# grammar for tree-sitter",
   "main": "bindings/node",
   "keywords": [
     "parser",
+    "tree-sitter",
     "lexer"
   ],
   "repository": {


### PR DESCRIPTION
Bump to get out all the great C# 10 work and many fixes for earlier versions.

@dcreager I think I can publish this to npm - do you need to do something for Rust/crate manually? 