### PR TITLE
Allow tree-sitter 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
The current generated grammars are compatible with both 0.19 and 0.20 tree-sitter crates.