### PR TITLE
Tree sitter 0.20, Missing HIGHLIGHT_QUERY Rust binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">= 0.19, < 0.21"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -54,6 +54,9 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 /// The symbol tagging query for this language.
 pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Not sure why the odd version logic in tree-sitter dependency, but when consuming this repository it still resolves to 0.19.*. Most of the other related language crates have seem to bumped to `0.20` explicitly, so I have done so also.

Additionally, upon consuming the crate, I noticed that the binding for `HIGHLIGHT_QUERY` was missing (also as in other crates), so I've also added that.

Let me know if I've missing something if there is a proper binding template to go from? New to all of this!

Cheers