### PR TITLE
Raw string literals support

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -768,3 +768,268 @@ var x = $@"/* {world} */";
               (interpolation
                 (identifier))
               (interpolated_verbatim_string_text))))))))
+
+==================================================
+Raw string literal (basic)
+==================================================
+
+var x = """Hello"""; 
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (raw_string_literal)))))))
+
+==================================================
+Raw string literal (multi-line)
+==================================================
+
+var x = """
+  Hello
+  """; 
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (raw_string_literal)))))))
+
+==================================================
+Raw string literal (embedded one double quotes)
+==================================================
+
+var x = """
+  Hello "Damien"
+  """; 
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (raw_string_literal)))))))
+
+
+==================================================
+Raw string literal (embedded two double quotes)
+==================================================
+
+var x = """
+  Hello ""Damien""
+  """; 
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (raw_string_literal)))))))
+
+==================================================
+Raw string literal (UTF-8)
+==================================================
+
+var x = """
+  Hello "Damien"
+  """u8; 
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (raw_string_literal)))))))
+
+==================================================
+Interpolated raw string literal (basic)
+==================================================
+
+var x = $"""The point {X}, {Y} is {Math.Sqrt(X * X + Y * Y)} from the origin""";
+
+---
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolation
+                (invocation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (argument_list
+                    (argument
+                      (binary_expression
+                        (binary_expression
+                          (identifier)
+                          (identifier))
+                        (binary_expression
+                          (identifier)
+                          (identifier)))))))
+              (interpolated_raw_string_text))))))))
+
+==================================================
+Interpolated raw string literal (one double quotes)
+==================================================
+
+var x = $"""The point "{X}, {Y}" is {Math.Sqrt(X * X + Y * Y)} from the origin""";
+
+---
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (invocation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (argument_list
+                    (argument
+                      (binary_expression
+                        (binary_expression
+                          (identifier)
+                          (identifier))
+                        (binary_expression
+                          (identifier)
+                          (identifier)))))))
+              (interpolated_raw_string_text))))))))
+
+
+==================================================
+Interpolated raw string literal (two double quotes)
+==================================================
+
+var x = $"""The point ""{X}, {Y}"" is {Math.Sqrt(X * X + Y * Y)} from the origin""";
+
+---
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (invocation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (argument_list
+                    (argument
+                      (binary_expression
+                        (binary_expression
+                          (identifier)
+                          (identifier))
+                        (binary_expression
+                          (identifier)
+                          (identifier)))))))
+              (interpolated_raw_string_text))))))))
+
+==================================================
+Interpolated raw string literal (multi-line)
+==================================================
+
+var x = $"""The point 
+  ""{X}, {Y}""
+  is {Math.Sqrt(X * X + Y * Y)}
+  from the origin""";
+
+---
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (interpolated_string_expression
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolation
+                (identifier))
+              (interpolated_raw_string_text)
+              (interpolated_raw_string_text)
+              (interpolation
+                (invocation_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (argument_list
+                    (argument
+                      (binary_expression
+                        (binary_expression
+                          (identifier)
+                          (identifier))
+                        (binary_expression
+                          (identifier)
+                          (identifier)))))))
+              (interpolated_raw_string_text))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1219,6 +1219,7 @@ module.exports = grammar({
       seq('$"', repeat($._interpolated_string_content), '"'),
       seq('$@"', repeat($._interpolated_verbatim_string_content), '"'),
       seq('@$"', repeat($._interpolated_verbatim_string_content), '"'),
+      seq('$"""', repeat($._interpolated_raw_string_content), '"""'),
     ),
 
     _interpolated_string_content: $ => choice(
@@ -1228,6 +1229,11 @@ module.exports = grammar({
 
     _interpolated_verbatim_string_content: $ => choice(
       $.interpolated_verbatim_string_text,
+      $.interpolation
+    ),
+
+    _interpolated_raw_string_content: $ => choice(
+      $.interpolated_raw_string_text,
       $.interpolation
     ),
 
@@ -1243,6 +1249,12 @@ module.exports = grammar({
       '{{',
       $._interpolated_verbatim_string_text_fragment,
       '""'
+    ),
+
+    interpolated_raw_string_text: $ => choice(
+      $._interpolated_verbatim_string_text_fragment,
+      '"',
+      '""',
     ),
 
     _interpolated_verbatim_string_text_fragment: $ => token.immediate(prec(1, /[^{"]+/)),
@@ -1578,7 +1590,8 @@ module.exports = grammar({
       $.integer_literal,
       // Or strings and verbatim strings
       $.string_literal,
-      $.verbatim_string_literal
+      $.verbatim_string_literal,
+      $.raw_string_literal,
     ),
 
     boolean_literal: $ => choice(
@@ -1659,6 +1672,16 @@ module.exports = grammar({
       choice('"', '"U8', '"u8')
     )),
 
+    raw_string_literal: $ => token(seq(
+      '"""',
+      repeat(choice(
+        /[^"]/,
+        '"',
+        '""',
+      )),
+      choice('"""', '"""U8', '"""u8')
+    )),
+    
     // Comments
 
     comment: $ => token(choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6692,6 +6692,26 @@
               "value": "\""
             }
           ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "$\"\"\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_interpolated_raw_string_content"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "\"\"\""
+            }
+          ]
         }
       ]
     },
@@ -6714,6 +6734,19 @@
         {
           "type": "SYMBOL",
           "name": "interpolated_verbatim_string_text"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolation"
+        }
+      ]
+    },
+    "_interpolated_raw_string_content": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "interpolated_raw_string_text"
         },
         {
           "type": "SYMBOL",
@@ -6759,6 +6792,23 @@
         {
           "type": "SYMBOL",
           "name": "_interpolated_verbatim_string_text_fragment"
+        },
+        {
+          "type": "STRING",
+          "value": "\"\""
+        }
+      ]
+    },
+    "interpolated_raw_string_text": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_interpolated_verbatim_string_text_fragment"
+        },
+        {
+          "type": "STRING",
+          "value": "\""
         },
         {
           "type": "STRING",
@@ -8952,6 +9002,10 @@
         {
           "type": "SYMBOL",
           "name": "verbatim_string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "raw_string_literal"
         }
       ]
     },
@@ -9278,6 +9332,55 @@
               {
                 "type": "STRING",
                 "value": "\"u8"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "raw_string_literal": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\"\"\""
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\"]"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\""
+                },
+                {
+                  "type": "STRING",
+                  "value": "\"\""
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\"\"\""
+              },
+              {
+                "type": "STRING",
+                "value": "\"\"\"U8"
+              },
+              {
+                "type": "STRING",
+                "value": "\"\"\"u8"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -242,6 +242,10 @@
         "named": true
       },
       {
+        "type": "raw_string_literal",
+        "named": true
+      },
+      {
         "type": "real_literal",
         "named": true
       },
@@ -1702,6 +1706,10 @@
         },
         {
           "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "raw_string_literal",
           "named": true
         },
         {
@@ -3214,6 +3222,11 @@
     }
   },
   {
+    "type": "interpolated_raw_string_text",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "interpolated_string_expression",
     "named": true,
     "fields": {},
@@ -3221,6 +3234,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "interpolated_raw_string_text",
+          "named": true
+        },
         {
           "type": "interpolated_string_text",
           "named": true
@@ -6270,6 +6287,10 @@
     "named": false
   },
   {
+    "type": "\"\"\"",
+    "named": false
+  },
+  {
     "type": "\"U8",
     "named": false
   },
@@ -6279,6 +6300,10 @@
   },
   {
     "type": "$\"",
+    "named": false
+  },
+  {
+    "type": "$\"\"\"",
     "named": false
   },
   {
@@ -6868,6 +6893,10 @@
   {
     "type": "public",
     "named": false
+  },
+  {
+    "type": "raw_string_literal",
+    "named": true
   },
   {
     "type": "readonly",


### PR DESCRIPTION
 Fixes #222 by including support for:

- Raw string literals `"""hello ""bob"" """`
- Raw string literals utf-8 `"""hello ""bob"" """u8;`
- Interpolated raw string literals `$"""hello ""{name}"""."";`

Supporting spanning multiple lines. 

## Known limitations:

### Does not support an unlimited number of opening and closing double quotes

I have no idea how we can do this - the number of closing quotes must match the number of opening quotes which is not a pattern I've seen before in tree-sitter grammars (I don't think it's supported?). Anything inside this with *less* quotes than the opening number of quotes is valid literal text. - any thoughts @maxbrunsfeld  ?

e.g. the following is valid

```csharp
var x = $""""""""""""""""""The point """{X}, {Y}"""""" 
 is {Math.Sqrt(X * X + Y * Y)} from the origin$"""""""""""""""""";
```

and would emit

```The point """1, 2"""""" is 2.23606797749979 from the origin```

### Quotes inside literal emit additional `interpolated_raw_string_text`

Would be nice to eliminate this (somehow) but I can live with it otherwise.