### PR TITLE
Add CSX preprocessor directives

### DIFF
--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -215,3 +215,36 @@ class Of1879 {
             (variable_declarator (identifier)
               (equals_value_clause (verbatim_string_literal)))))
         (comment))))))
+
+===================================
+Reference (r) directive
+===================================
+
+#r "Microsoft.WindowsAzure.Storage"
+
+---
+
+(compilation_unit
+  (reference_directive (preproc_string_literal)))
+
+===================================
+Load directive
+===================================
+
+#load "mylogger.csx"
+
+---
+
+(compilation_unit
+  (load_directive (preproc_string_literal)))
+
+===================================
+Shebang directive
+===================================
+
+#!/usr/bin/env scriptcs
+
+---
+
+(compilation_unit
+  (shebang_directive))

--- a/grammar.js
+++ b/grammar.js
@@ -1732,6 +1732,8 @@ module.exports = grammar({
       'yield'
     ),
 
+    // Preprocessor
+
     _preprocessor_call: $ => seq(
       $._preproc_directive_start,
       choice(
@@ -1747,7 +1749,10 @@ module.exports = grammar({
         $.error_directive,
         $.warning_directive,
         $.line_directive,
-        $.pragma_directive
+        $.pragma_directive,
+        $.reference_directive,
+        $.load_directive,
+        $.shebang_directive
       ),
       $._preproc_directive_end
     ),
@@ -1759,8 +1764,6 @@ module.exports = grammar({
       choice('disable', 'enable', 'restore'),
       optional(choice('annotations', 'warnings'))
     ),
-
-    // Preprocessor
 
     define_directive: $ => seq('define', $.identifier),
     undef_directive: $ => seq('undef', $.identifier),
@@ -1796,6 +1799,9 @@ module.exports = grammar({
         seq('checksum', $.preproc_string_literal, $.preproc_string_literal, $.preproc_string_literal)
       )
     ),
+    reference_directive: $ => seq('r', $.preproc_string_literal),
+    load_directive: $ => seq('load', $.preproc_string_literal),
+    shebang_directive: $ => seq('!', /[^\n\r]*/),
 
     preproc_message: $ => /[^\n\r]+/,
     preproc_integer_literal: $ => /[0-9]+/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9626,6 +9626,18 @@
             {
               "type": "SYMBOL",
               "name": "pragma_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "reference_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "load_directive"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "shebang_directive"
             }
           ]
         },
@@ -10037,6 +10049,45 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "reference_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "r"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preproc_string_literal"
+        }
+      ]
+    },
+    "load_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "load"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preproc_string_literal"
+        }
+      ]
+    },
+    "shebang_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[^\\n\\r]*"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3647,6 +3647,21 @@
     }
   },
   {
+    "type": "load_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "preproc_string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "local_declaration_statement",
     "named": true,
     "fields": {},
@@ -5259,6 +5274,21 @@
     }
   },
   {
+    "type": "reference_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "preproc_string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "region_directive",
     "named": true,
     "fields": {},
@@ -5317,6 +5347,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "shebang_directive",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "simple_assignment_expression",
@@ -6763,6 +6798,10 @@
     "named": false
   },
   {
+    "type": "load",
+    "named": false
+  },
+  {
     "type": "lock",
     "named": false
   },
@@ -6880,6 +6919,10 @@
   },
   {
     "type": "public",
+    "named": false
+  },
+  {
+    "type": "r",
     "named": false
   },
   {


### PR DESCRIPTION
Fixes #241 by adding support for:

- `#r "some reference` for references
- `#load "some file"` for loads
- `#! whatever` for shebang style start of script indicators (allowed anywhere in tree-sitter-c-sharp by design)