### PR TITLE
Add `void` to predefined types

### DIFF
--- a/corpus/attributes.txt
+++ b/corpus/attributes.txt
@@ -258,7 +258,7 @@ class Class<[A, B][C()]T1> {
         (attribute_list (attribute (identifier) (attribute_argument_list)))
         (identifier)))
       (declaration_list
-        (method_declaration (void_keyword) (identifier)
+        (method_declaration (predefined_type) (identifier)
           (type_parameter_list
             (type_parameter
               (attribute_list (attribute (identifier)))
@@ -312,7 +312,7 @@ void A() { }
   (global_statement
     (local_function_statement
       (attribute_list (attribute (identifier)))
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block))))
@@ -330,7 +330,7 @@ void A() { }
     (local_function_statement
       (attribute_list
         (attribute (generic_name (identifier) (type_argument_list (identifier) (identifier)))))
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -15,7 +15,7 @@ class Foo {
     name: (identifier)
     body: (declaration_list
       (method_declaration
-        type: (void_keyword)
+        type: (predefined_type)
         name: (identifier)
         parameters: (parameter_list)
         body: (block
@@ -43,7 +43,7 @@ class Foo {
     name: (identifier)
     body: (declaration_list
       (method_declaration
-        type: (void_keyword)
+        type: (predefined_type)
         name: (identifier)
         parameters: (parameter_list)
         body: (block
@@ -116,7 +116,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -140,7 +140,7 @@ void Test() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -218,7 +218,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -243,7 +243,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -271,7 +271,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -298,7 +298,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -326,7 +326,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -362,7 +362,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -410,7 +410,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -436,7 +436,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -461,7 +461,7 @@ void b() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -487,7 +487,7 @@ void a() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -511,7 +511,7 @@ void a() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -538,7 +538,7 @@ void m() {
     (compilation_unit
       (global_statement
         (local_function_statement
-          (void_keyword)
+          (predefined_type)
           (identifier)
           (parameter_list)
           (block
@@ -618,7 +618,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (expression_statement
           (lambda_expression
@@ -647,7 +647,7 @@ void a()
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (expression_statement (invocation_expression (identifier)
         (argument_list
@@ -668,7 +668,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -724,7 +724,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -787,7 +787,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (expression_statement
           (invocation_expression
@@ -811,7 +811,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (expression_statement
           (assignment_expression (identifier) (assignment_operator)
@@ -833,7 +833,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -859,7 +859,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -891,7 +891,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -917,7 +917,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -945,7 +945,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -991,7 +991,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1028,7 +1028,7 @@ void a() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1060,7 +1060,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1085,7 +1085,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (expression_statement (postfix_unary_expression (identifier)))
         (expression_statement (postfix_unary_expression (identifier)))
@@ -1110,7 +1110,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1133,7 +1133,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1157,7 +1157,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1181,7 +1181,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration (implicit_type)
@@ -1213,7 +1213,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1249,7 +1249,7 @@ void b() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -1333,7 +1333,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1358,7 +1358,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1406,7 +1406,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1452,7 +1452,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1503,7 +1503,7 @@ class Foo {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1648,7 +1648,7 @@ void Test(int value) {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier)
+    (local_function_statement (predefined_type) (identifier)
       (parameter_list (parameter (predefined_type) (identifier)))
       (block
         (expression_statement
@@ -1679,7 +1679,7 @@ void Test(int value) {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier)
+    (local_function_statement (predefined_type) (identifier)
       (parameter_list (parameter (predefined_type) (identifier)))
       (block
         (local_declaration_statement
@@ -1872,7 +1872,7 @@ void Do() {
 (compilation_unit
   (global_statement
     (local_function_statement
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
         (block

--- a/corpus/interfaces.txt
+++ b/corpus/interfaces.txt
@@ -64,7 +64,7 @@ interface IOne {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list))
       (method_declaration
@@ -72,7 +72,7 @@ interface IOne {
         (identifier)
         (parameter_list))
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list (parameter (predefined_type) (identifier))))
       (method_declaration
@@ -251,7 +251,7 @@ interface MyDefault {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (predefined_type) (identifier)))

--- a/corpus/preprocessor.txt
+++ b/corpus/preprocessor.txt
@@ -127,7 +127,7 @@ class Of1879 {
   (identifier)
   (declaration_list
     (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -166,7 +166,7 @@ class Of1879 {
   (identifier)
   (declaration_list
     (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -206,7 +206,7 @@ class Of1879 {
   (identifier)
   (declaration_list
     (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block

--- a/corpus/records.txt
+++ b/corpus/records.txt
@@ -267,7 +267,7 @@ void A() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration
@@ -297,7 +297,7 @@ void A() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration

--- a/corpus/source-file-structure.txt
+++ b/corpus/source-file-structure.txt
@@ -183,14 +183,14 @@ class Z {
         (predefined_type)
         (identifier)
         (equals_value_clause (character_literal (escape_sequence))))))
-  (delegate_declaration (void_keyword) (identifier)
+  (delegate_declaration (predefined_type) (identifier)
     (type_parameter_list (type_parameter (identifier)))
     (parameter_list)
     (type_parameter_constraints_clause (identifier) (type_parameter_constraint)))
-  (delegate_declaration (void_keyword) (identifier)
+  (delegate_declaration (predefined_type) (identifier)
     (parameter_list (array_type (predefined_type) (array_rank_specifier)) (identifier)))
   (class_declaration (identifier) (declaration_list
-    (delegate_declaration (void_keyword) (identifier) (parameter_list)))))
+    (delegate_declaration (predefined_type) (identifier) (parameter_list)))))
 
 =====================================
 Var declared equal to integer literal

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -37,7 +37,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -60,7 +60,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -83,7 +83,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -106,7 +106,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -128,7 +128,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -150,7 +150,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list
         (parameter (predefined_type) (identifier)))
@@ -177,7 +177,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -359,7 +359,7 @@ void M() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_function_statement
           (tuple_type
@@ -552,7 +552,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -579,7 +579,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -608,7 +608,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -639,7 +639,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -670,7 +670,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -699,7 +699,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -725,7 +725,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -751,7 +751,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -802,7 +802,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -837,9 +837,9 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list
-      (method_declaration (void_keyword) (identifier) (parameter_list)
+      (method_declaration (predefined_type) (identifier) (parameter_list)
       (block
-        (local_function_statement (modifier) (void_keyword) (identifier)
+        (local_function_statement (modifier) (predefined_type) (identifier)
           (type_parameter_list
             (type_parameter (identifier))
             (type_parameter (identifier)))
@@ -872,11 +872,11 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
-        (local_function_statement (void_keyword) (identifier)
+        (local_function_statement (predefined_type) (identifier)
           (type_parameter_list
             (type_parameter (identifier))
             (type_parameter (identifier)))
@@ -905,7 +905,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -931,7 +931,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -963,7 +963,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -991,7 +991,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1023,7 +1023,7 @@ class A {
   (identifier)
   (declaration_list
     (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1077,7 +1077,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1109,7 +1109,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1140,7 +1140,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1168,7 +1168,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1200,7 +1200,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1226,7 +1226,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1257,7 +1257,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1287,7 +1287,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1317,7 +1317,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1345,7 +1345,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1376,7 +1376,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1416,7 +1416,7 @@ class A {
   (class_declaration
     (identifier)
     (declaration_list (method_declaration
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block
@@ -1445,7 +1445,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list)
         (block
@@ -1494,7 +1494,7 @@ void A() {
 
 (compilation_unit
   (global_statement
-    (local_function_statement (void_keyword) (identifier) (parameter_list)
+    (local_function_statement (predefined_type) (identifier) (parameter_list)
       (block
         (local_declaration_statement
           (variable_declaration (identifier)
@@ -1519,7 +1519,7 @@ async void Sample() {
   (global_statement
     (local_function_statement
       (modifier)
-      (void_keyword)
+      (predefined_type)
       (identifier)
       (parameter_list)
       (block

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -84,24 +84,33 @@ Class field pointer type
 class A {
   public readonly int* i;
   private Byte* b;
+  private void* c;
 }
 
 ---
 
 (compilation_unit
-  (class_declaration
+  (ERROR
     (identifier)
-    (declaration_list
-      (field_declaration
-        (modifier) (modifier)
-        (variable_declaration
-          (pointer_type (predefined_type))
-          (variable_declarator (identifier))))
-      (field_declaration
-        (modifier)
-        (variable_declaration
-          (pointer_type (identifier))
-          (variable_declarator (identifier)))))))
+    (field_declaration
+      (modifier)
+      (modifier)
+      (variable_declaration
+        (pointer_type
+          (predefined_type))
+        (variable_declarator
+          (identifier))))
+    (field_declaration
+      (modifier)
+      (variable_declaration
+        (pointer_type
+          (identifier))
+        (variable_declarator
+          (identifier))))
+    (modifier)
+    (void_keyword)
+    (ERROR)
+    (identifier)))
 
 =======================================
 Function pointer type

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -90,27 +90,31 @@ class A {
 ---
 
 (compilation_unit
-  (ERROR
+  (class_declaration
     (identifier)
-    (field_declaration
-      (modifier)
-      (modifier)
-      (variable_declaration
-        (pointer_type
-          (predefined_type))
-        (variable_declarator
-          (identifier))))
-    (field_declaration
-      (modifier)
-      (variable_declaration
-        (pointer_type
-          (identifier))
-        (variable_declarator
-          (identifier))))
-    (modifier)
-    (void_keyword)
-    (ERROR)
-    (identifier)))
+    (declaration_list
+      (field_declaration
+        (modifier)
+        (modifier)
+        (variable_declaration
+          (pointer_type
+            (predefined_type))
+          (variable_declarator
+            (identifier))))
+      (field_declaration
+        (modifier)
+        (variable_declaration
+          (pointer_type
+            (identifier))
+          (variable_declarator
+            (identifier))))
+      (field_declaration
+        (modifier)
+        (variable_declaration
+          (pointer_type
+            (predefined_type))
+          (variable_declarator
+            (identifier)))))))
 
 =======================================
 Function pointer type

--- a/corpus/type-methods.txt
+++ b/corpus/type-methods.txt
@@ -39,7 +39,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (identifier) (identifier))
@@ -62,7 +62,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (type_parameter_list (type_parameter (identifier)))
         (parameter_list
@@ -85,7 +85,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (type_parameter_list (type_parameter (identifier)))
         (parameter_list
@@ -113,7 +113,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (type_parameter_list
           (type_parameter (identifier))
@@ -146,7 +146,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (parameter_modifier) (predefined_type) (identifier)))
@@ -168,7 +168,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (parameter_modifier) (predefined_type) (identifier)))
@@ -190,7 +190,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (parameter_modifier) (predefined_type) (identifier)))
@@ -212,7 +212,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter (predefined_type) (identifier))
@@ -235,7 +235,7 @@ class A {
     (identifier)
     (declaration_list
       (method_declaration
-        (void_keyword)
+        (predefined_type)
         (identifier)
         (parameter_list
           (parameter

--- a/grammar.js
+++ b/grammar.js
@@ -99,7 +99,6 @@ module.exports = grammar({
   ],
 
   inline: $ => [
-    $.return_type,
     $._identifier_or_global,
   ],
 
@@ -391,7 +390,7 @@ module.exports = grammar({
     method_declaration: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
-      field('type', $.return_type),
+      field('type', $._type),
       optional($.explicit_interface_specifier),
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
@@ -587,7 +586,7 @@ module.exports = grammar({
       repeat($.attribute_list),
       repeat($.modifier),
       'delegate',
-      field('type', $.return_type),
+      field('type', $._type),
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
       field('parameters', $.parameter_list),
@@ -720,7 +719,7 @@ module.exports = grammar({
 
     function_pointer_parameter: $ => seq(
       optional(choice('ref', 'out', 'in', seq('ref', 'readonly'))),
-      choice($._type, $.void_keyword)
+      $._type
     ),
 
     predefined_type: $ => token(choice(
@@ -740,8 +739,8 @@ module.exports = grammar({
       'ulong',
       'ushort',
       'nint',
-      'nuint'
-      // void is handled in return_type for better matching
+      'nuint',
+      'void'
     )),
 
     ref_type: $ => seq(
@@ -870,7 +869,7 @@ module.exports = grammar({
     local_function_statement: $ => seq(
       repeat($.attribute_list),
       repeat($.modifier),
-      field('type', $.return_type),
+      field('type', $._type),
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
       field('parameters', $.parameter_list),
@@ -1732,10 +1731,6 @@ module.exports = grammar({
       'when',
       'yield'
     ),
-
-    // We use this instead of type so 'void' is only treated as type in the right contexts
-    return_type: $ => choice($._type, $.void_keyword),
-    void_keyword: $ => 'void',
 
     _preprocessor_call: $ => seq(
       $._preproc_directive_start,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -45,7 +45,6 @@
 [
   (boolean_literal)
   (null_literal)
-  (void_keyword)
 ] @constant.builtin
 
 ;; Comments

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1620,7 +1620,7 @@
           "name": "type",
           "content": {
             "type": "SYMBOL",
-            "name": "return_type"
+            "name": "_type"
           }
         },
         {
@@ -2910,7 +2910,7 @@
           "name": "type",
           "content": {
             "type": "SYMBOL",
-            "name": "return_type"
+            "name": "_type"
           }
         },
         {
@@ -3775,17 +3775,8 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_type"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "void_keyword"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_type"
         }
       ]
     },
@@ -3861,6 +3852,10 @@
           {
             "type": "STRING",
             "value": "nuint"
+          },
+          {
+            "type": "STRING",
+            "value": "void"
           }
         ]
       }
@@ -4608,7 +4603,7 @@
           "name": "type",
           "content": {
             "type": "SYMBOL",
-            "name": "return_type"
+            "name": "_type"
           }
         },
         {
@@ -9570,23 +9565,6 @@
         }
       ]
     },
-    "return_type": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_type"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "void_keyword"
-        }
-      ]
-    },
-    "void_keyword": {
-      "type": "STRING",
-      "value": "void"
-    },
     "_preprocessor_call": {
       "type": "SEQ",
       "members": [
@@ -10493,7 +10471,6 @@
     }
   ],
   "inline": [
-    "return_type",
     "_identifier_or_global"
   ],
   "supertypes": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2028,10 +2028,6 @@
           {
             "type": "_type",
             "named": true
-          },
-          {
-            "type": "void_keyword",
-            "named": true
           }
         ]
       },
@@ -2806,10 +2802,6 @@
       "types": [
         {
           "type": "_type",
-          "named": true
-        },
-        {
-          "type": "void_keyword",
           "named": true
         }
       ]
@@ -3718,10 +3710,6 @@
           {
             "type": "_type",
             "named": true
-          },
-          {
-            "type": "void_keyword",
-            "named": true
           }
         ]
       },
@@ -3903,10 +3891,6 @@
         "types": [
           {
             "type": "_type",
-            "named": true
-          },
-          {
-            "type": "void_keyword",
             "named": true
           }
         ]
@@ -7025,10 +7009,6 @@
   {
     "type": "virtual",
     "named": false
-  },
-  {
-    "type": "void_keyword",
-    "named": true
   },
   {
     "type": "volatile",


### PR DESCRIPTION
Having `void` in the predefined types list makes `void*` a viable (pointer) type.

This PR partly addresses https://github.com/tree-sitter/tree-sitter-c-sharp/issues/247.