### PR TITLE
Add `ref`/`ref readonly` types to the type system

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1574,7 +1574,7 @@ int b = default;
             (default_expression)))))))
 
 =====================================
-Generic type name no type args
+Ref local declaration and ref expression
 =====================================
 
 ref VeryLargeStruct reflocal = ref veryLargeStruct;
@@ -1585,9 +1585,9 @@ ref var elementRef = ref arr[0];
 (compilation_unit
   (global_statement
     (local_declaration_statement
-      (modifier)
       (variable_declaration
-        (identifier)
+        (ref_type
+          (identifier))
         (variable_declarator
           (identifier)
           (equals_value_clause
@@ -1595,9 +1595,9 @@ ref var elementRef = ref arr[0];
               (identifier)))))))
   (global_statement
     (local_declaration_statement
-      (modifier)
       (variable_declaration
-        (implicit_type)
+        (ref_type
+          (implicit_type))
         (variable_declarator
           (identifier)
           (equals_value_clause

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -317,14 +317,14 @@ int x = 0;
     (expression_statement
       (assignment_expression
         (tuple_expression
-          (argument 
+          (argument
             (identifier))
           (argument
             (declaration_expression
               (predefined_type)
               (identifier))))
         (assignment_operator)
-        (identifier))))) 
+        (identifier)))))
 
 =====================================
 Invocation with inline tuple_type declaration
@@ -1028,9 +1028,9 @@ class A {
       (parameter_list)
       (block
         (local_declaration_statement
-          (modifier)
           (variable_declaration
-            (implicit_type)
+            (ref_type
+              (implicit_type))
             (variable_declarator
               (identifier)
               (equals_value_clause
@@ -1099,7 +1099,7 @@ class A {
   void Sample() {
     using (Stream a = File.OpenRead("a"), b = new BinaryReader(a)) {
       return;
-    } 
+    }
   }
 }
 
@@ -1118,7 +1118,7 @@ class A {
             (variable_declarator (identifier)
               (equals_value_clause
                 (invocation_expression
-                (member_access_expression (identifier) (identifier)) (argument_list (argument (string_literal)))))) 
+                (member_access_expression (identifier) (identifier)) (argument_list (argument (string_literal))))))
             (variable_declarator (identifier)
               (equals_value_clause
                 (object_creation_expression (identifier) (argument_list (argument (identifier)))))))
@@ -1572,14 +1572,14 @@ ref T Choice(bool condition, ref T a, ref T b)
 
 (compilation_unit
   (global_statement
-    (local_function_statement (modifier) (identifier) (identifier)
+    (local_function_statement (ref_type (identifier)) (identifier)
       (parameter_list
         (parameter (predefined_type) (identifier))
         (parameter (parameter_modifier) (identifier) (identifier))
         (parameter (parameter_modifier) (identifier) (identifier)))
       (block
-        (local_declaration_statement (modifier)
-          (variable_declaration (implicit_type)
+        (local_declaration_statement
+          (variable_declaration (ref_type (implicit_type))
             (variable_declarator (identifier)
               (equals_value_clause
                 (ref_expression

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -123,7 +123,7 @@ Function pointer type
 class A {
   // Function pointer equivalent without calling convention
   delegate*<string, int> a;
-  delegate*<delegate*<in string, int>, delegate*<string, ref readonly int>> b;
+  delegate*<delegate*<in string, int>, delegate*<ref string, ref readonly int>> b;
 
   // Function pointer equivalent with calling convention
   delegate* managed<string, int> c;
@@ -141,19 +141,19 @@ class A {
         (variable_declaration
           (function_pointer_type
             (function_pointer_parameter (predefined_type))
-            (function_pointer_parameter (predefined_type)))
+            (function_pointer_return_type (predefined_type)))
           (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
           (function_pointer_type
             (function_pointer_parameter
               (function_pointer_type
-                (function_pointer_parameter (predefined_type))
-                (function_pointer_parameter (predefined_type))))
-            (function_pointer_parameter
+                (function_pointer_parameter (parameter_modifier) (predefined_type))
+                (function_pointer_return_type (predefined_type))))
+            (function_pointer_return_type
               (function_pointer_type
-                (function_pointer_parameter (predefined_type))
-                (function_pointer_parameter (predefined_type)))))
+                (function_pointer_parameter (parameter_modifier) (predefined_type))
+                (function_pointer_return_type (ref_type (predefined_type))))))
           (variable_declarator (identifier))))
       (comment)
       (field_declaration
@@ -161,7 +161,7 @@ class A {
           (function_pointer_type
             (function_pointer_calling_convention)
             (function_pointer_parameter (predefined_type))
-            (function_pointer_parameter (predefined_type)))
+            (function_pointer_return_type (predefined_type)))
           (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
@@ -173,11 +173,11 @@ class A {
                     (function_pointer_unmanaged_calling_convention (identifier))
                     (function_pointer_unmanaged_calling_convention (identifier))))
                 (function_pointer_parameter (predefined_type))
-                (function_pointer_parameter (predefined_type))))
-            (function_pointer_parameter
+                (function_pointer_return_type (predefined_type))))
+            (function_pointer_return_type
               (function_pointer_type
                 (function_pointer_parameter (predefined_type))
-                (function_pointer_parameter (predefined_type)))))
+                (function_pointer_return_type (predefined_type)))))
           (variable_declarator (identifier)))))))
 
 =======================================
@@ -186,6 +186,9 @@ Ref readonly
 
 class A {
   ref readonly Point Origin => ref origin;
+  ref readonly Point* Origin;
+  ref readonly Point[] Origin;
+  ref readonly Point? Origin;
 }
 
 ---
@@ -195,11 +198,32 @@ class A {
     (identifier)
     (declaration_list
       (property_declaration
-        (modifier)
-        (modifier)
+        (ref_type
+          (identifier))
         (identifier)
-        (identifier)
-          (arrow_expression_clause (ref_expression (identifier)))))))
+        (arrow_expression_clause (ref_expression (identifier))))
+      (field_declaration
+        (variable_declaration
+          (ref_type
+            (pointer_type
+              (identifier)))
+          (variable_declarator
+            (identifier))))
+      (field_declaration
+        (variable_declaration
+          (ref_type
+            (array_type
+              (identifier)
+              (array_rank_specifier)))
+          (variable_declarator
+            (identifier))))
+          (field_declaration
+            (variable_declaration
+              (ref_type
+                (nullable_type
+                  (identifier)))
+              (variable_declarator
+                (identifier)))))))
 
 =======================================
 Nullable reference types

--- a/corpus/type-fields.txt
+++ b/corpus/type-fields.txt
@@ -141,7 +141,7 @@ class A {
         (variable_declaration
           (function_pointer_type
             (function_pointer_parameter (predefined_type))
-            (function_pointer_return_type (predefined_type)))
+            (function_pointer_parameter (predefined_type)))
           (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
@@ -149,11 +149,11 @@ class A {
             (function_pointer_parameter
               (function_pointer_type
                 (function_pointer_parameter (parameter_modifier) (predefined_type))
-                (function_pointer_return_type (predefined_type))))
-            (function_pointer_return_type
+                (function_pointer_parameter (predefined_type))))
+            (function_pointer_parameter
               (function_pointer_type
                 (function_pointer_parameter (parameter_modifier) (predefined_type))
-                (function_pointer_return_type (ref_type (predefined_type))))))
+                (function_pointer_parameter (ref_type (predefined_type))))))
           (variable_declarator (identifier))))
       (comment)
       (field_declaration
@@ -161,7 +161,7 @@ class A {
           (function_pointer_type
             (function_pointer_calling_convention)
             (function_pointer_parameter (predefined_type))
-            (function_pointer_return_type (predefined_type)))
+            (function_pointer_parameter (predefined_type)))
           (variable_declarator (identifier))))
       (field_declaration
         (variable_declaration
@@ -173,11 +173,11 @@ class A {
                     (function_pointer_unmanaged_calling_convention (identifier))
                     (function_pointer_unmanaged_calling_convention (identifier))))
                 (function_pointer_parameter (predefined_type))
-                (function_pointer_return_type (predefined_type))))
-            (function_pointer_return_type
+                (function_pointer_parameter (predefined_type))))
+            (function_pointer_parameter
               (function_pointer_type
                 (function_pointer_parameter (predefined_type))
-                (function_pointer_return_type (predefined_type)))))
+                (function_pointer_parameter (predefined_type)))))
           (variable_declarator (identifier)))))))
 
 =======================================

--- a/grammar.js
+++ b/grammar.js
@@ -711,7 +711,7 @@ module.exports = grammar({
       optional($.function_pointer_calling_convention),
       '<',
       repeat(seq($.function_pointer_parameter, ',')),
-      $.function_pointer_return_type,
+      alias($.function_pointer_return_type, $.function_pointer_parameter),
       '>'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -103,8 +103,6 @@ module.exports = grammar({
     [$.constant_pattern, $._name],
     [$.constant_pattern, $._name, $._expression],
     [$.constant_pattern, $._expression],
-
-    [$.modifier, $.modifier_with_ref],
   ],
 
   inline: $ => [
@@ -253,7 +251,7 @@ module.exports = grammar({
       ';'
     )),
 
-    _modifier_no_ref: $ => prec.right(choice(
+    modifier: $ => prec.right(choice(
       'abstract',
       'async',
       'const',
@@ -274,13 +272,6 @@ module.exports = grammar({
       'unsafe',
       'virtual',
       'volatile'
-    )),
-
-    modifier: $ => $._modifier_no_ref,
-
-    modifier_with_ref: $ => prec.right(choice(
-      $._modifier_no_ref,
-      'ref'
     )),
 
     variable_declaration: $ => seq(
@@ -588,7 +579,8 @@ module.exports = grammar({
 
     struct_declaration: $ => seq(
       repeat($.attribute_list),
-      repeat(alias($.modifier_with_ref, $.modifier)),
+      repeat($.modifier),
+      optional(alias('ref', $.modifier)),
       'struct',
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),

--- a/grammar.js
+++ b/grammar.js
@@ -22,6 +22,8 @@ const PREC = {
   COND: 2,
   ASSIGN: 1,
   SELECT: 0,
+
+  PARAMETER: 1, // Needs higher precedence than ref_type, which is 0.
 };
 
 const decimalDigitSequence = /([0-9][0-9_]*[0-9]|[0-9])/;
@@ -87,6 +89,11 @@ module.exports = grammar({
     [$.parameter, $._pattern],
     [$.parameter, $.declaration_expression],
 
+    [$.ref_type, $.declaration_expression],
+    [$.ref_type, $.parameter, $.declaration_expression],
+    [$.ref_type, $.parameter],
+    [$.ref_type, $.function_pointer_parameter],
+
     [$.tuple_element],
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
@@ -96,6 +103,8 @@ module.exports = grammar({
     [$.constant_pattern, $._name],
     [$.constant_pattern, $._name, $._expression],
     [$.constant_pattern, $._expression],
+
+    [$.modifier, $.modifier_with_ref],
   ],
 
   inline: $ => [
@@ -244,7 +253,7 @@ module.exports = grammar({
       ';'
     )),
 
-    modifier: $ => prec.right(choice(
+    _modifier_no_ref: $ => prec.right(choice(
       'abstract',
       'async',
       'const',
@@ -259,12 +268,19 @@ module.exports = grammar({
       'public',
       'readonly',
       'required',
-      prec(1, 'ref'), //make sure that 'ref' is treated as a modifier for local variable declarations instead of as a ref expression
+      // 'ref', // `ref` as a modifier can only be used on struct declarations. Other than that it's a ref type or a ref parameter in a declaration.
       'sealed',
       'static',
       'unsafe',
       'virtual',
       'volatile'
+    )),
+
+    modifier: $ => $._modifier_no_ref,
+
+    modifier_with_ref: $ => prec.right(choice(
+      $._modifier_no_ref,
+      'ref'
     )),
 
     variable_declaration: $ => seq(
@@ -330,13 +346,13 @@ module.exports = grammar({
       $._parameter_array
     )),
 
-    parameter: $ => seq(
+    parameter: $ => prec.dynamic(PREC.PARAMETER, seq(
       repeat($.attribute_list),
       optional(alias(choice('ref', 'out', 'this', 'in'), $.parameter_modifier)),
       optional(field('type', $._type)),
       field('name', $.identifier),
       optional($.equals_value_clause)
-    ),
+    )),
 
     parameter_modifier: $ => choice('ref', 'out', 'this', 'in'),
 
@@ -572,7 +588,7 @@ module.exports = grammar({
 
     struct_declaration: $ => seq(
       repeat($.attribute_list),
-      repeat($.modifier),
+      repeat(alias($.modifier_with_ref, $.modifier)),
       'struct',
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameter_list)),
@@ -662,6 +678,7 @@ module.exports = grammar({
       $.function_pointer_type,
       $.predefined_type,
       $.tuple_type,
+      $.ref_type,
     ),
 
     implicit_type: $ => 'var',
@@ -693,7 +710,8 @@ module.exports = grammar({
       '*',
       optional($.function_pointer_calling_convention),
       '<',
-      commaSep1($.function_pointer_parameter),
+      repeat(seq($.function_pointer_parameter, ',')),
+      $.function_pointer_return_type,
       '>'
     ),
 
@@ -717,10 +735,13 @@ module.exports = grammar({
       $.identifier
     ),
 
-    function_pointer_parameter: $ => seq(
-      optional(choice('ref', 'out', 'in', seq('ref', 'readonly'))),
-      $._type
-    ),
+    function_pointer_parameter: $ => prec(PREC.PARAMETER,
+      seq(
+        optional(alias(choice('ref', 'out', 'in'), $.parameter_modifier)),
+        $._type
+      )),
+
+    function_pointer_return_type: $ => $._type,
 
     predefined_type: $ => token(choice(
       'bool',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3652,8 +3652,13 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "function_pointer_return_type"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "function_pointer_return_type"
+          },
+          "named": true,
+          "value": "function_pointer_parameter"
         },
         {
           "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -722,7 +722,7 @@
         ]
       }
     },
-    "_modifier_no_ref": {
+    "modifier": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -803,27 +803,6 @@
           {
             "type": "STRING",
             "value": "volatile"
-          }
-        ]
-      }
-    },
-    "modifier": {
-      "type": "SYMBOL",
-      "name": "_modifier_no_ref"
-    },
-    "modifier_with_ref": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_modifier_no_ref"
-          },
-          {
-            "type": "STRING",
-            "value": "ref"
           }
         ]
       }
@@ -2824,14 +2803,26 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "modifier_with_ref"
-            },
-            "named": true,
-            "value": "modifier"
+            "type": "SYMBOL",
+            "name": "modifier"
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "ref"
+              },
+              "named": true,
+              "value": "modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -10555,10 +10546,6 @@
     [
       "constant_pattern",
       "_expression"
-    ],
-    [
-      "modifier",
-      "modifier_with_ref"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -722,7 +722,7 @@
         ]
       }
     },
-    "modifier": {
+    "_modifier_no_ref": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -785,14 +785,6 @@
             "value": "required"
           },
           {
-            "type": "PREC",
-            "value": 1,
-            "content": {
-              "type": "STRING",
-              "value": "ref"
-            }
-          },
-          {
             "type": "STRING",
             "value": "sealed"
           },
@@ -811,6 +803,27 @@
           {
             "type": "STRING",
             "value": "volatile"
+          }
+        ]
+      }
+    },
+    "modifier": {
+      "type": "SYMBOL",
+      "name": "_modifier_no_ref"
+    },
+    "modifier_with_ref": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_modifier_no_ref"
+          },
+          {
+            "type": "STRING",
+            "value": "ref"
           }
         ]
       }
@@ -1216,86 +1229,90 @@
       ]
     },
     "parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "attribute_list"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "ref"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "out"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "this"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "in"
-                  }
-                ]
-              },
-              "named": true,
-              "value": "parameter_modifier"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "type",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_type"
-              }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
               "type": "SYMBOL",
-              "name": "equals_value_clause"
-            },
-            {
-              "type": "BLANK"
+              "name": "attribute_list"
             }
-          ]
-        }
-      ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "ref"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "out"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "this"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "in"
+                    }
+                  ]
+                },
+                "named": true,
+                "value": "parameter_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "type",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_type"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "equals_value_clause"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "parameter_modifier": {
       "type": "CHOICE",
@@ -2807,8 +2824,13 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "modifier"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "modifier_with_ref"
+            },
+            "named": true,
+            "value": "modifier"
           }
         },
         {
@@ -3429,6 +3451,10 @@
         {
           "type": "SYMBOL",
           "name": "tuple_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ref_type"
         }
       ]
     },
@@ -3610,29 +3636,24 @@
           "value": "<"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "function_pointer_parameter"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "function_pointer_parameter"
-                  }
-                ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "function_pointer_parameter"
+              },
+              {
+                "type": "STRING",
+                "value": ","
               }
-            }
-          ]
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_return_type"
         },
         {
           "type": "STRING",
@@ -3734,28 +3755,18 @@
       ]
     },
     "function_pointer_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "ref"
-                },
-                {
-                  "type": "STRING",
-                  "value": "out"
-                },
-                {
-                  "type": "STRING",
-                  "value": "in"
-                },
-                {
-                  "type": "SEQ",
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "CHOICE",
                   "members": [
                     {
                       "type": "STRING",
@@ -3763,22 +3774,32 @@
                     },
                     {
                       "type": "STRING",
-                      "value": "readonly"
+                      "value": "out"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "in"
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_type"
-        }
-      ]
+                },
+                "named": true,
+                "value": "parameter_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_type"
+          }
+        ]
+      }
+    },
+    "function_pointer_return_type": {
+      "type": "SYMBOL",
+      "name": "_type"
     },
     "predefined_type": {
       "type": "TOKEN",
@@ -10486,6 +10507,23 @@
       "declaration_expression"
     ],
     [
+      "ref_type",
+      "declaration_expression"
+    ],
+    [
+      "ref_type",
+      "parameter",
+      "declaration_expression"
+    ],
+    [
+      "ref_type",
+      "parameter"
+    ],
+    [
+      "ref_type",
+      "function_pointer_parameter"
+    ],
+    [
       "tuple_element"
     ],
     [
@@ -10512,6 +10550,10 @@
     [
       "constant_pattern",
       "_expression"
+    ],
+    [
+      "modifier",
+      "modifier_with_ref"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -454,6 +454,10 @@
         "named": true
       },
       {
+        "type": "ref_type",
+        "named": true
+      },
+      {
         "type": "tuple_type",
         "named": true
       }
@@ -2797,6 +2801,25 @@
     "named": true,
     "fields": {},
     "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_type",
+          "named": true
+        },
+        {
+          "type": "parameter_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_pointer_return_type",
+    "named": true,
+    "fields": {},
+    "children": {
       "multiple": false,
       "required": true,
       "types": [
@@ -2821,6 +2844,10 @@
         },
         {
           "type": "function_pointer_parameter",
+          "named": true
+        },
+        {
+          "type": "function_pointer_return_type",
           "named": true
         }
       ]
@@ -5227,6 +5254,21 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ref_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_type",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2816,21 +2816,6 @@
     }
   },
   {
-    "type": "function_pointer_return_type",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "_type",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "function_pointer_type",
     "named": true,
     "fields": {},
@@ -2844,10 +2829,6 @@
         },
         {
           "type": "function_pointer_parameter",
-          "named": true
-        },
-        {
-          "type": "function_pointer_return_type",
           "named": true
         }
       ]


### PR DESCRIPTION
This PR partially covers https://github.com/tree-sitter/tree-sitter-c-sharp/issues/247.

Previously `public ref readonly int M()` was parsed with 3 modifiers on the method declaration, but this didn't match the semantics of the modifiers. Ref types are introduced in this PR, so the above method declaration parses with a single `public` modifier, and its return type is a `ref_type`.

I [tried solving](https://github.com/tree-sitter/tree-sitter-c-sharp/compare/master...tamasvajk:tree-sitter-c-sharp:fix/ref-type?expand=1) this issue with modifying the precedence of parameters vs types (and arguments vs ref_expressions), but that would require changing many other rule precedences. (I gave up on that approach). Instead, this PR removes `ref` from the general modifier list, and adjusts minimally the precedences.  