### PR TITLE
Remove all precedence from type system

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -77,10 +77,13 @@ module.exports = grammar({
     [$._type, $.stack_alloc_array_creation_expression],
     [$._type, $._nullable_base_type],
     [$._type, $._array_base_type],
+    [$._type, $._pointer_base_type],
     [$._type, $._nullable_base_type, $.array_creation_expression],
     [$._type, $._array_base_type, $.array_creation_expression],
+    [$._type, $._pointer_base_type, $.array_creation_expression],
     [$._nullable_base_type, $.stack_alloc_array_creation_expression],
     [$._array_base_type, $.stack_alloc_array_creation_expression],
+    [$._pointer_base_type, $.stack_alloc_array_creation_expression],
 
     [$.parameter, $.this_expression],
     [$.parameter, $._simple_name],
@@ -701,7 +704,17 @@ module.exports = grammar({
       $.tuple_type
     ),
 
-    pointer_type: $ => prec(PREC.POSTFIX, seq($._type, '*')),
+    pointer_type: $ => seq($._pointer_base_type, '*'),
+
+    _pointer_base_type: $ => choice(
+      $.array_type,
+      $._name,
+      $.nullable_type,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.predefined_type,
+      $.tuple_type,
+    ),
 
     function_pointer_type: $ => seq(
       'delegate',

--- a/grammar.js
+++ b/grammar.js
@@ -76,8 +76,11 @@ module.exports = grammar({
     [$._type, $.attribute],
     [$._type, $.stack_alloc_array_creation_expression],
     [$._type, $._nullable_base_type],
+    [$._type, $._array_base_type],
     [$._type, $._nullable_base_type, $.array_creation_expression],
+    [$._type, $._array_base_type, $.array_creation_expression],
     [$._nullable_base_type, $.stack_alloc_array_creation_expression],
+    [$._array_base_type, $.stack_alloc_array_creation_expression],
 
     [$.parameter, $.this_expression],
     [$.parameter, $._simple_name],
@@ -669,10 +672,20 @@ module.exports = grammar({
 
     implicit_type: $ => 'var',
 
-    array_type: $ => prec(PREC.POSTFIX, seq(
-      field('type', $._type),
+    array_type: $ => seq(
+      field('type', $._array_base_type),
       field('rank', $.array_rank_specifier)
-    )),
+    ),
+
+    _array_base_type: $ => choice(
+      $.array_type,
+      $._name,
+      $.nullable_type,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.predefined_type,
+      $.tuple_type,
+    ),
 
     // grammar.txt marks this non-optional and includes omitted_array_size_expression in
     // expression but we can't match empty rules.

--- a/grammar.js
+++ b/grammar.js
@@ -22,8 +22,6 @@ const PREC = {
   COND: 2,
   ASSIGN: 1,
   SELECT: 0,
-
-  PARAMETER: 1, // Needs higher precedence than ref_type, which is 0.
 };
 
 const decimalDigitSequence = /([0-9][0-9_]*[0-9]|[0-9])/;
@@ -72,18 +70,27 @@ module.exports = grammar({
     [$._contextual_keywords, $.type_parameter_constraint],
     [$._contextual_keywords, $.modifier],
 
-    [$._type, $.array_creation_expression],
     [$._type, $.attribute],
-    [$._type, $.stack_alloc_array_creation_expression],
     [$._type, $._nullable_base_type],
     [$._type, $._array_base_type],
     [$._type, $._pointer_base_type],
-    [$._type, $._nullable_base_type, $.array_creation_expression],
-    [$._type, $._array_base_type, $.array_creation_expression],
-    [$._type, $._pointer_base_type, $.array_creation_expression],
+    [$._type, $._ref_base_type],
+
     [$._nullable_base_type, $.stack_alloc_array_creation_expression],
     [$._array_base_type, $.stack_alloc_array_creation_expression],
     [$._pointer_base_type, $.stack_alloc_array_creation_expression],
+
+    [$._ref_base_type, $._array_base_type],
+    [$._ref_base_type, $._nullable_base_type],
+    [$._ref_base_type, $._pointer_base_type],
+
+    [$._object_creation_type, $._array_base_type],
+    [$._object_creation_type, $._nullable_base_type],
+    [$._object_creation_type, $._pointer_base_type],
+
+    [$.array_creation_expression, $._array_base_type],
+    [$.array_creation_expression, $._nullable_base_type],
+    [$.array_creation_expression, $._pointer_base_type],
 
     [$.parameter, $.this_expression],
     [$.parameter, $._simple_name],
@@ -91,10 +98,7 @@ module.exports = grammar({
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $.declaration_expression],
 
-    [$.ref_type, $.declaration_expression],
-    [$.ref_type, $.parameter, $.declaration_expression],
     [$.ref_type, $.parameter],
-    [$.ref_type, $.function_pointer_parameter],
 
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
@@ -337,13 +341,13 @@ module.exports = grammar({
       $._parameter_array
     )),
 
-    parameter: $ => prec.dynamic(PREC.PARAMETER, seq(
+    parameter: $ => seq(
       repeat($.attribute_list),
       optional(alias(choice('ref', 'out', 'this', 'in'), $.parameter_modifier)),
-      optional(field('type', $._type)),
+      optional(field('type', $._ref_base_type)),
       field('name', $.identifier),
       optional($.equals_value_clause)
-    )),
+    ),
 
     parameter_modifier: $ => choice('ref', 'out', 'this', 'in'),
 
@@ -746,11 +750,10 @@ module.exports = grammar({
       $.identifier
     ),
 
-    function_pointer_parameter: $ => prec(PREC.PARAMETER,
-      seq(
-        optional(alias(choice('ref', 'out', 'in'), $.parameter_modifier)),
-        $._type
-      )),
+    function_pointer_parameter: $ => seq(
+      optional(alias(choice('ref', 'out', 'in'), $.parameter_modifier)),
+      $._ref_base_type
+    ),
 
     function_pointer_return_type: $ => $._type,
 
@@ -778,7 +781,18 @@ module.exports = grammar({
     ref_type: $ => seq(
       'ref',
       optional('readonly'),
-      $._type
+      $._ref_base_type
+    ),
+
+    _ref_base_type: $ => choice(
+      $.implicit_type,
+      $.array_type,
+      $._name,
+      $.nullable_type,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.predefined_type,
+      $.tuple_type
     ),
 
     tuple_type: $ => seq(
@@ -1333,10 +1347,19 @@ module.exports = grammar({
 
     object_creation_expression: $ => prec.right(seq(
       'new',
-      field('type', $._type),
+      field('type', $._object_creation_type),
       field('arguments', optional($.argument_list)),
       field('initializer', optional($.initializer_expression))
     )),
+
+    _object_creation_type: $ => choice(
+      $._name,
+      $.nullable_type,
+      $.pointer_type,
+      $.function_pointer_type,
+      $.predefined_type,
+      $.tuple_type
+    ),
 
     parenthesized_expression: $ => seq('(', $._expression, ')'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -683,7 +683,6 @@ module.exports = grammar({
     _nullable_base_type: $ => choice(
       $.array_type,
       $._name,
-      $.pointer_type,
       $.function_pointer_type,
       $.predefined_type,
       $.tuple_type

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3458,29 +3458,58 @@
       "value": "var"
     },
     "array_type": {
-      "type": "PREC",
-      "value": 18,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "type",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_type"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "rank",
-            "content": {
-              "type": "SYMBOL",
-              "name": "array_rank_specifier"
-            }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_array_base_type"
           }
-        ]
-      }
+        },
+        {
+          "type": "FIELD",
+          "name": "rank",
+          "content": {
+            "type": "SYMBOL",
+            "name": "array_rank_specifier"
+          }
+        }
+      ]
+    },
+    "_array_base_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "array_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nullable_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "predefined_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
+        }
+      ]
     },
     "array_rank_specifier": {
       "type": "SEQ",
@@ -10468,11 +10497,24 @@
     ],
     [
       "_type",
+      "_array_base_type"
+    ],
+    [
+      "_type",
       "_nullable_base_type",
       "array_creation_expression"
     ],
     [
+      "_type",
+      "_array_base_type",
+      "array_creation_expression"
+    ],
+    [
       "_nullable_base_type",
+      "stack_alloc_array_creation_expression"
+    ],
+    [
+      "_array_base_type",
       "stack_alloc_array_creation_expression"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1212,90 +1212,86 @@
       ]
     },
     "parameter": {
-      "type": "PREC_DYNAMIC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "attribute_list"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "ref"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "out"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "this"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "in"
-                    }
-                  ]
-                },
-                "named": true,
-                "value": "parameter_modifier"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "type",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_type"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "equals_value_clause"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_list"
           }
-        ]
-      }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "ref"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "out"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "this"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "in"
+                  }
+                ]
+              },
+              "named": true,
+              "value": "parameter_modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "type",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_ref_base_type"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "equals_value_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
     },
     "parameter_modifier": {
       "type": "CHOICE",
@@ -3809,47 +3805,43 @@
       ]
     },
     "function_pointer_parameter": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "ref"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "out"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "in"
-                    }
-                  ]
-                },
-                "named": true,
-                "value": "parameter_modifier"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "ref"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "out"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "in"
+                  }
+                ]
               },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_type"
-          }
-        ]
-      }
+              "named": true,
+              "value": "parameter_modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ref_base_type"
+        }
+      ]
     },
     "function_pointer_return_type": {
       "type": "SYMBOL",
@@ -3956,7 +3948,44 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_type"
+          "name": "_ref_base_type"
+        }
+      ]
+    },
+    "_ref_base_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "implicit_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nullable_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "predefined_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
         }
       ]
     },
@@ -7166,7 +7195,7 @@
             "name": "type",
             "content": {
               "type": "SYMBOL",
-              "name": "_type"
+              "name": "_object_creation_type"
             }
           },
           {
@@ -7203,6 +7232,35 @@
           }
         ]
       }
+    },
+    "_object_creation_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nullable_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "predefined_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
+        }
+      ]
     },
     "parenthesized_expression": {
       "type": "SEQ",
@@ -10510,15 +10568,7 @@
     ],
     [
       "_type",
-      "array_creation_expression"
-    ],
-    [
-      "_type",
       "attribute"
-    ],
-    [
-      "_type",
-      "stack_alloc_array_creation_expression"
     ],
     [
       "_type",
@@ -10534,18 +10584,7 @@
     ],
     [
       "_type",
-      "_nullable_base_type",
-      "array_creation_expression"
-    ],
-    [
-      "_type",
-      "_array_base_type",
-      "array_creation_expression"
-    ],
-    [
-      "_type",
-      "_pointer_base_type",
-      "array_creation_expression"
+      "_ref_base_type"
     ],
     [
       "_nullable_base_type",
@@ -10558,6 +10597,42 @@
     [
       "_pointer_base_type",
       "stack_alloc_array_creation_expression"
+    ],
+    [
+      "_ref_base_type",
+      "_array_base_type"
+    ],
+    [
+      "_ref_base_type",
+      "_nullable_base_type"
+    ],
+    [
+      "_ref_base_type",
+      "_pointer_base_type"
+    ],
+    [
+      "_object_creation_type",
+      "_array_base_type"
+    ],
+    [
+      "_object_creation_type",
+      "_nullable_base_type"
+    ],
+    [
+      "_object_creation_type",
+      "_pointer_base_type"
+    ],
+    [
+      "array_creation_expression",
+      "_array_base_type"
+    ],
+    [
+      "array_creation_expression",
+      "_nullable_base_type"
+    ],
+    [
+      "array_creation_expression",
+      "_pointer_base_type"
     ],
     [
       "parameter",
@@ -10582,20 +10657,7 @@
     ],
     [
       "ref_type",
-      "declaration_expression"
-    ],
-    [
-      "ref_type",
-      "parameter",
-      "declaration_expression"
-    ],
-    [
-      "ref_type",
       "parameter"
-    ],
-    [
-      "ref_type",
-      "function_pointer_parameter"
     ],
     [
       "tuple_element",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3570,10 +3570,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "pointer_type"
-        },
-        {
-          "type": "SYMBOL",
           "name": "function_pointer_type"
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3612,21 +3612,50 @@
       ]
     },
     "pointer_type": {
-      "type": "PREC",
-      "value": 18,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_type"
-          },
-          {
-            "type": "STRING",
-            "value": "*"
-          }
-        ]
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_pointer_base_type"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        }
+      ]
+    },
+    "_pointer_base_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "array_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nullable_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_pointer_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "predefined_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_type"
+        }
+      ]
     },
     "function_pointer_type": {
       "type": "SEQ",
@@ -10501,6 +10530,10 @@
     ],
     [
       "_type",
+      "_pointer_base_type"
+    ],
+    [
+      "_type",
       "_nullable_base_type",
       "array_creation_expression"
     ],
@@ -10510,11 +10543,20 @@
       "array_creation_expression"
     ],
     [
+      "_type",
+      "_pointer_base_type",
+      "array_creation_expression"
+    ],
+    [
       "_nullable_base_type",
       "stack_alloc_array_creation_expression"
     ],
     [
       "_array_base_type",
+      "stack_alloc_array_creation_expression"
+    ],
+    [
+      "_pointer_base_type",
       "stack_alloc_array_creation_expression"
     ],
     [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -803,7 +803,47 @@
         "required": true,
         "types": [
           {
-            "type": "_type",
+            "type": "alias_qualified_name",
+            "named": true
+          },
+          {
+            "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "function_pointer_type",
+            "named": true
+          },
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "predefined_type",
+            "named": true
+          },
+          {
+            "type": "qualified_name",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4217,7 +4217,43 @@
         "required": true,
         "types": [
           {
-            "type": "_type",
+            "type": "alias_qualified_name",
+            "named": true
+          },
+          {
+            "type": "function_pointer_type",
+            "named": true
+          },
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "predefined_type",
+            "named": true
+          },
+          {
+            "type": "qualified_name",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
             "named": true
           }
         ]
@@ -4530,7 +4566,51 @@
         "required": false,
         "types": [
           {
-            "type": "_type",
+            "type": "alias_qualified_name",
+            "named": true
+          },
+          {
+            "type": "array_type",
+            "named": true
+          },
+          {
+            "type": "function_pointer_type",
+            "named": true
+          },
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "implicit_type",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "predefined_type",
+            "named": true
+          },
+          {
+            "type": "qualified_name",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
             "named": true
           }
         ]
@@ -5325,7 +5405,51 @@
       "required": true,
       "types": [
         {
-          "type": "_type",
+          "type": "alias_qualified_name",
+          "named": true
+        },
+        {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "function_pointer_type",
+          "named": true
+        },
+        {
+          "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "implicit_type",
+          "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
+          "type": "pointer_type",
+          "named": true
+        },
+        {
+          "type": "predefined_type",
+          "named": true
+        },
+        {
+          "type": "qualified_name",
+          "named": true
+        },
+        {
+          "type": "tuple_type",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4706,7 +4706,47 @@
       "required": true,
       "types": [
         {
-          "type": "_type",
+          "type": "alias_qualified_name",
+          "named": true
+        },
+        {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "function_pointer_type",
+          "named": true
+        },
+        {
+          "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
+          "type": "pointer_type",
+          "named": true
+        },
+        {
+          "type": "predefined_type",
+          "named": true
+        },
+        {
+          "type": "qualified_name",
+          "named": true
+        },
+        {
+          "type": "tuple_type",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4134,10 +4134,6 @@
           "named": true
         },
         {
-          "type": "pointer_type",
-          "named": true
-        },
-        {
           "type": "predefined_type",
           "named": true
         },


### PR DESCRIPTION
This PR makes some fundamental changes to the type system. All precedence specifications are removed. The type system is made tighter, so `ref ref int` is not valid any longer, similarly to `int??`, which was already not allowed. Furthermore the parameter in `void M(ref ref int i){}` is also not parsing correctly any longer. Additionally, pointer types are removed from nullable base types, so `int*?` is not allowed any longer.