### PR TITLE
WIP: Remove `implicit_type`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -668,7 +668,7 @@ module.exports = grammar({
     ),
 
     _type: $ => choice(
-      $.implicit_type,
+      //$.implicit_type,
       $.array_type,
       $._name,
       $.nullable_type,
@@ -679,7 +679,7 @@ module.exports = grammar({
       $.ref_type,
     ),
 
-    implicit_type: $ => 'var',
+    //implicit_type: $ => 'var',
 
     array_type: $ => seq(
       field('type', $._array_base_type),
@@ -787,7 +787,7 @@ module.exports = grammar({
     ),
 
     _ref_base_type: $ => choice(
-      $.implicit_type,
+      //$.implicit_type,
       $.array_type,
       $._name,
       $.nullable_type,
@@ -1778,6 +1778,7 @@ module.exports = grammar({
       // Async - These need to be more contextual
       // 'async',
       // 'await',
+      'var',
 
       // Misc
       'global',

--- a/grammar.js
+++ b/grammar.js
@@ -1776,8 +1776,8 @@ module.exports = grammar({
       'set',
 
       // Async - These need to be more contextual
-      // 'async',
-      // 'await',
+      'async',
+      'await',
       'var',
 
       // Misc

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -21,6 +21,9 @@
   (predefined_type)
 ] @type.builtin
 
+(_
+  type: (identifier ("var")) @type.builtin)
+
 ;; Enum
 (enum_member_declaration (identifier) @property.definition)
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -14,7 +14,7 @@
 (destructor_declaration name: (identifier) @type)
 
 [
-  (implicit_type)
+  ;;(implicit_type)
   (nullable_type)
   (pointer_type)
   (function_pointer_type)

--- a/script/fetch-examples
+++ b/script/fetch-examples
@@ -17,3 +17,4 @@ function checkout() {
 checkout examples/Newtonsoft.Json JamesNK/Newtonsoft.Json 7c3d7f8da7e35dde8fa74188b0decff70f8f10e3
 checkout examples/nunit           nunit/nunit             ad49f27294bd0f2677d8699756c6ccb10df600f8
 checkout examples/orchard         OrchardCMS/orchard      0a82721968232b07354edcaac63a9ccea02220c6
+checkout examples/roslyn          dotnet/roslyn           ac92012c0e64c8114ecf0024c2bad2f63dcc7c6b

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9670,6 +9670,14 @@
         },
         {
           "type": "STRING",
+          "value": "async"
+        },
+        {
+          "type": "STRING",
+          "value": "await"
+        },
+        {
+          "type": "STRING",
           "value": "var"
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3413,10 +3413,6 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "implicit_type"
-        },
-        {
-          "type": "SYMBOL",
           "name": "array_type"
         },
         {
@@ -3448,10 +3444,6 @@
           "name": "ref_type"
         }
       ]
-    },
-    "implicit_type": {
-      "type": "STRING",
-      "value": "var"
     },
     "array_type": {
       "type": "SEQ",
@@ -3955,10 +3947,6 @@
     "_ref_base_type": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "implicit_type"
-        },
         {
           "type": "SYMBOL",
           "name": "array_type"
@@ -9679,6 +9667,10 @@
         {
           "type": "STRING",
           "value": "set"
+        },
+        {
+          "type": "STRING",
+          "value": "var"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -434,10 +434,6 @@
         "named": true
       },
       {
-        "type": "implicit_type",
-        "named": true
-      },
-      {
         "type": "nullable_type",
         "named": true
       },
@@ -3118,11 +3114,6 @@
     }
   },
   {
-    "type": "implicit_type",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "indexer_declaration",
     "named": true,
     "fields": {
@@ -4590,10 +4581,6 @@
             "named": true
           },
           {
-            "type": "implicit_type",
-            "named": true
-          },
-          {
             "type": "nullable_type",
             "named": true
           },
@@ -5426,10 +5413,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "implicit_type",
           "named": true
         },
         {

--- a/test/highlight/var.cs
+++ b/test/highlight/var.cs
@@ -6,7 +6,7 @@ class X
         void M()
         {
             var var = new var();
-            // <- type
+            // <- type.builtin
             //   ^ variable
         }
     }
@@ -17,7 +17,9 @@ class Y
     void M()
     {
         var var = new Y();
-        // <- type
+        // <- type.builtin
         //   ^ variable
+        Y var = new Y();
+        // <- type
     }
 }

--- a/test/highlight/var.cs
+++ b/test/highlight/var.cs
@@ -1,0 +1,23 @@
+class X
+{
+    class var
+    //     ^ type
+    {
+        void M()
+        {
+            var var = new var();
+            // <- type
+            //   ^ variable
+        }
+    }
+}
+
+class Y
+{
+    void M()
+    {
+        var var = new Y();
+        // <- type
+        //   ^ variable
+    }
+}


### PR DESCRIPTION
This PR removes the `var` `implicit_type` from the type system. The change would align the grammar with the one in Roslyn, where `var` is parsed as
```
 Type 
 |_ IdentifierName 
    |_ IdentifierToken
 ```

This would probably fix https://github.com/tree-sitter/tree-sitter-c-sharp/issues/163.

TODO:
- [ ] I haven't yet adjusted the tests. 
- [ ] I haven't looked into highlighting at all, but we could probably still highlight `var` correctly if `_type` is removed from `supertypes`???