### PR TITLE
Split expression rule to improve parsing conflicting input

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -325,12 +325,114 @@ a >>>= a;
         (identifier)))))
 
 ================================================================================
+Assignment LValue types
+================================================================================
+
+a = 1;
+a.b = 1;
+a[b] = 1;
+(a, b) = (1, 2);
+(var a, b) = (1, 2);
+var x = new A
+{
+  a = 1,
+  [b] = 1
+};
+(a) = 1;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (identifier)
+        (assignment_operator)
+        (integer_literal))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (member_access_expression
+          (identifier)
+          (identifier))
+        (assignment_operator)
+        (integer_literal))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (element_access_expression
+          (identifier)
+          (bracketed_argument_list
+            (argument
+              (identifier))))
+        (assignment_operator)
+        (integer_literal))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (tuple_expression
+          (argument
+            (identifier))
+          (argument
+            (identifier)))
+        (assignment_operator)
+        (tuple_expression
+          (argument
+            (integer_literal))
+          (argument
+            (integer_literal))))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (tuple_expression
+          (argument
+            (declaration_expression
+              (implicit_type)
+              (identifier)))
+          (argument
+            (identifier)))
+        (assignment_operator)
+        (tuple_expression
+          (argument
+            (integer_literal))
+          (argument
+            (integer_literal))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (object_creation_expression
+              (identifier)
+              (initializer_expression
+                (assignment_expression
+                  (identifier)
+                  (assignment_operator)
+                  (integer_literal))
+                (assignment_expression
+                  (element_binding_expression
+                    (bracketed_argument_list
+                      (argument
+                        (identifier))))
+                  (assignment_operator)
+                  (integer_literal)))))))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (parenthesized_expression
+          (identifier))
+        (assignment_operator)
+        (integer_literal)))))
+
+================================================================================
 Ternary Expression
 ================================================================================
 
 class Foo {
   void Test() {
-    x ? "foo" : "bar";
+    var y = x ? "foo" : "bar";
   }
 }
 
@@ -345,11 +447,16 @@ class Foo {
         name: (identifier)
         parameters: (parameter_list)
         body: (block
-          (expression_statement
-            (conditional_expression
-              condition: (identifier)
-              consequence: (string_literal)
-              alternative: (string_literal))))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                (identifier)
+                (equals_value_clause
+                  (conditional_expression
+                    condition: (identifier)
+                    consequence: (string_literal)
+                    alternative: (string_literal)))))))))))
 
 ================================================================================
 Binary Expressions
@@ -357,8 +464,8 @@ Binary Expressions
 
 class Foo {
   void Test() {
-    x == y;
-    1 + 2;
+    var b = x == y;
+    var i = 1 + 2;
   }
 }
 
@@ -373,14 +480,24 @@ class Foo {
         name: (identifier)
         parameters: (parameter_list)
         body: (block
-          (expression_statement
-            (binary_expression
-              left: (identifier)
-              right: (identifier)))
-          (expression_statement
-            (binary_expression
-              left: (integer_literal)
-              right: (integer_literal))))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                (identifier)
+                (equals_value_clause
+                  (binary_expression
+                    left: (identifier)
+                    right: (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                (identifier)
+                (equals_value_clause
+                  (binary_expression
+                    left: (integer_literal)
+                    right: (integer_literal)))))))))))
 
 ================================================================================
 Ternary expressions is type
@@ -517,45 +634,65 @@ b = (float)a[0];
 Cast with parenthesized expression
 ================================================================================
 
-(A.A)(a.a.a);
-(Int32)(1);
-(Int32)(1);
-(Int32)((1));
+var o = (A.A)(a.a.a);
+var o = (Int32)(1);
+var o = (Int32)(1);
+var o = (Int32)((1));
 
 --------------------------------------------------------------------------------
 
 (compilation_unit
   (global_statement
-    (expression_statement
-      (cast_expression
-        (qualified_name
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
           (identifier)
-          (identifier))
-        (parenthesized_expression
-          (member_access_expression
-            (member_access_expression
+          (equals_value_clause
+            (cast_expression
+              (qualified_name
+                (identifier)
+                (identifier))
+              (parenthesized_expression
+                (member_access_expression
+                  (member_access_expression
+                    (identifier)
+                    (identifier))
+                  (identifier)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (cast_expression
               (identifier)
-              (identifier))
-            (identifier))))))
+              (parenthesized_expression
+                (integer_literal))))))))
   (global_statement
-    (expression_statement
-      (cast_expression
-        (identifier)
-        (parenthesized_expression
-          (integer_literal)))))
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (cast_expression
+              (identifier)
+              (parenthesized_expression
+                (integer_literal))))))))
   (global_statement
-    (expression_statement
-      (cast_expression
-        (identifier)
-        (parenthesized_expression
-          (integer_literal)))))
-  (global_statement
-    (expression_statement
-      (cast_expression
-        (identifier)
-        (parenthesized_expression
-          (parenthesized_expression
-            (integer_literal)))))))
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (cast_expression
+              (identifier)
+              (parenthesized_expression
+                (parenthesized_expression
+                  (integer_literal))))))))))
 
 ================================================================================
 Precedence of unary prefix operator and element access
@@ -922,7 +1059,7 @@ Anonymous method expressions
 ================================================================================
 
 void a() {
-  delegate(int a) {
+  var d = delegate(int a) {
     return a;
   };
 }
@@ -936,22 +1073,27 @@ void a() {
       (identifier)
       (parameter_list)
       (block
-        (expression_statement
-          (anonymous_method_expression
-            (parameter_list
-              (parameter
-                (predefined_type)
-                (identifier)))
-            (block
-              (return_statement
-                (identifier)))))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (anonymous_method_expression
+                  (parameter_list
+                    (parameter
+                      (predefined_type)
+                      (identifier)))
+                  (block
+                    (return_statement
+                      (identifier))))))))))))
 
 ================================================================================
 Anonymous method expression with discard parameters
 ================================================================================
 
 void a() {
-  delegate(int _, int _) {
+  var d = delegate(int _, int _) {
     return a;
   };
 }
@@ -965,18 +1107,23 @@ void a() {
       (identifier)
       (parameter_list)
       (block
-        (expression_statement
-          (anonymous_method_expression
-            (parameter_list
-              (parameter
-                (predefined_type)
-                (identifier))
-              (parameter
-                (predefined_type)
-                (identifier)))
-            (block
-              (return_statement
-                (identifier)))))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (anonymous_method_expression
+                  (parameter_list
+                    (parameter
+                      (predefined_type)
+                      (identifier))
+                    (parameter
+                      (predefined_type)
+                      (identifier)))
+                  (block
+                    (return_statement
+                      (identifier))))))))))))
 
 ================================================================================
 Anonymous method expression with modifiers
@@ -1066,9 +1213,9 @@ Lambda expressions
 ================================================================================
 
 void a() {
-  x => x + 1;
-  (A a, B b) => { return a.c(b); };
-  RetType (A a, B b) => { return 1; };
+  var l = x => x + 1;
+  var l = (A a, B b) => { return a.c(b); };
+  var l = RetType (A a, B b) => { return 1; };
 }
 
 --------------------------------------------------------------------------------
@@ -1080,43 +1227,58 @@ void a() {
       (identifier)
       (parameter_list)
       (block
-        (expression_statement
-          (lambda_expression
-            (identifier)
-            (binary_expression
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
               (identifier)
-              (integer_literal))))
-        (expression_statement
-          (lambda_expression
-            (parameter_list
-              (parameter
-                (identifier)
-                (identifier))
-              (parameter
-                (identifier)
-                (identifier)))
-            (block
-              (return_statement
-                (invocation_expression
-                  (member_access_expression
+              (equals_value_clause
+                (lambda_expression
+                  (identifier)
+                  (binary_expression
                     (identifier)
-                    (identifier))
-                  (argument_list
-                    (argument
-                      (identifier))))))))
-        (expression_statement
-          (lambda_expression
-            (identifier)
-            (parameter_list
-              (parameter
-                (identifier)
-                (identifier))
-              (parameter
-                (identifier)
-                (identifier)))
-            (block
-              (return_statement
-                (integer_literal)))))))))
+                    (integer_literal)))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (parameter_list
+                    (parameter
+                      (identifier)
+                      (identifier))
+                    (parameter
+                      (identifier)
+                      (identifier)))
+                  (block
+                    (return_statement
+                      (invocation_expression
+                        (member_access_expression
+                          (identifier)
+                          (identifier))
+                        (argument_list
+                          (argument
+                            (identifier)))))))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (identifier)
+                  (parameter_list
+                    (parameter
+                      (identifier)
+                      (identifier))
+                    (parameter
+                      (identifier)
+                      (identifier)))
+                  (block
+                    (return_statement
+                      (integer_literal))))))))))))
 
 ================================================================================
 Async Lambda

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -326,6 +326,26 @@ Declared tuple type with default
             (default_expression)))))))
 
 ================================================================================
+Declaration with generic type
+================================================================================
+
+A<B> a = null;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (binary_expression
+          (binary_expression
+            (identifier)
+            (identifier))
+          (identifier))
+        (assignment_operator)
+        (null_literal)))))
+
+================================================================================
 Assignment and declaration in same deconstruction
 ================================================================================
 
@@ -1938,6 +1958,30 @@ b = obj ?? a == 0;
 
 ================================================================================
 Null literal arguments
+================================================================================
+
+person = new Person(null!, null!);
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (identifier)
+        (assignment_operator)
+        (object_creation_expression
+          (identifier)
+          (argument_list
+            (argument
+              (postfix_unary_expression
+                (null_literal)))
+            (argument
+              (postfix_unary_expression
+                (null_literal)))))))))
+
+================================================================================
+Variable declaration
 ================================================================================
 
 person = new Person(null!, null!);

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -335,15 +335,16 @@ A<B> a = null;
 
 (compilation_unit
   (global_statement
-    (expression_statement
-      (assignment_expression
-        (binary_expression
-          (binary_expression
-            (identifier)
-            (identifier))
-          (identifier))
-        (assignment_operator)
-        (null_literal)))))
+    (local_declaration_statement
+      (variable_declaration
+        (generic_name
+          (identifier)
+          (type_argument_list
+            (identifier)))
+        (variable_declarator
+          (identifier)
+          (equals_value_clause
+            (null_literal)))))))
 
 ================================================================================
 Assignment and declaration in same deconstruction

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4310,7 +4310,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_expression"
+          "name": "_expression_statement_expression"
         },
         {
           "type": "STRING",
@@ -6440,7 +6440,7 @@
             "name": "left",
             "content": {
               "type": "SYMBOL",
-              "name": "_expression"
+              "name": "_lvalue_expression"
             }
           },
           {
@@ -7338,7 +7338,24 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
+          "name": "_non_lvalue_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_parenthesized_lvalue_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lvalue_expression"
         },
         {
           "type": "STRING",
@@ -8279,6 +8296,19 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_non_lvalue_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lvalue_expression"
+        }
+      ]
+    },
+    "_non_lvalue_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
           "name": "anonymous_method_expression"
         },
         {
@@ -8292,14 +8322,6 @@
         {
           "type": "SYMBOL",
           "name": "as_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "assignment_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "await_expression"
         },
         {
           "type": "SYMBOL",
@@ -8331,14 +8353,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "element_access_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "element_binding_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "implicit_array_creation_expression"
         },
         {
@@ -8359,10 +8373,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "invocation_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "is_expression"
         },
         {
@@ -8376,26 +8386,6 @@
         {
           "type": "SYMBOL",
           "name": "make_ref_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "member_access_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "object_creation_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parenthesized_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "postfix_unary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "prefix_unary_expression"
         },
         {
           "type": "SYMBOL",
@@ -8431,15 +8421,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "this_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "throw_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "tuple_expression"
         },
         {
           "type": "SYMBOL",
@@ -8451,11 +8433,82 @@
         },
         {
           "type": "SYMBOL",
+          "name": "_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression_statement_expression"
+        }
+      ]
+    },
+    "_lvalue_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "this_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "member_access_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_simple_name"
         },
         {
           "type": "SYMBOL",
-          "name": "_literal"
+          "name": "element_access_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "element_binding_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_parenthesized_lvalue_expression"
+          },
+          "named": true,
+          "value": "parenthesized_expression"
+        }
+      ]
+    },
+    "_expression_statement_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "assignment_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "invocation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postfix_unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefix_unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "await_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "object_creation_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
         }
       ]
     },
@@ -10620,7 +10673,7 @@
     ],
     [
       "_name",
-      "_expression"
+      "_lvalue_expression"
     ],
     [
       "_simple_name",
@@ -10786,11 +10839,19 @@
     [
       "constant_pattern",
       "_name",
-      "_expression"
+      "_lvalue_expression"
     ],
     [
       "constant_pattern",
-      "_expression"
+      "_non_lvalue_expression"
+    ],
+    [
+      "constant_pattern",
+      "_lvalue_expression"
+    ],
+    [
+      "constant_pattern",
+      "_expression_statement_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -914,7 +914,39 @@
         "required": true,
         "types": [
           {
-            "type": "_expression",
+            "type": "element_access_expression",
+            "named": true
+          },
+          {
+            "type": "element_binding_expression",
+            "named": true
+          },
+          {
+            "type": "generic_name",
+            "named": true
+          },
+          {
+            "type": "global",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "member_access_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "tuple_expression",
             "named": true
           }
         ]
@@ -2550,7 +2582,31 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
+          "type": "await_expression",
+          "named": true
+        },
+        {
+          "type": "invocation_expression",
+          "named": true
+        },
+        {
+          "type": "object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
           "named": true
         }
       ]
@@ -4694,7 +4750,219 @@
       "required": true,
       "types": [
         {
-          "type": "_expression",
+          "type": "anonymous_method_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "as_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
+          "type": "await_expression",
+          "named": true
+        },
+        {
+          "type": "base_expression",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "cast_expression",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "checked_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_access_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "default_expression",
+          "named": true
+        },
+        {
+          "type": "element_access_expression",
+          "named": true
+        },
+        {
+          "type": "element_binding_expression",
+          "named": true
+        },
+        {
+          "type": "generic_name",
+          "named": true
+        },
+        {
+          "type": "global",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "implicit_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "implicit_object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "implicit_stack_alloc_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "initializer_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "invocation_expression",
+          "named": true
+        },
+        {
+          "type": "is_expression",
+          "named": true
+        },
+        {
+          "type": "is_pattern_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_expression",
+          "named": true
+        },
+        {
+          "type": "make_ref_expression",
+          "named": true
+        },
+        {
+          "type": "member_access_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "object_creation_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_unary_expression",
+          "named": true
+        },
+        {
+          "type": "query_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "ref_expression",
+          "named": true
+        },
+        {
+          "type": "ref_type_expression",
+          "named": true
+        },
+        {
+          "type": "ref_value_expression",
+          "named": true
+        },
+        {
+          "type": "size_of_expression",
+          "named": true
+        },
+        {
+          "type": "stack_alloc_array_creation_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "switch_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "throw_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "type_of_expression",
+          "named": true
+        },
+        {
+          "type": "verbatim_string_literal",
+          "named": true
+        },
+        {
+          "type": "with_expression",
           "named": true
         }
       ]


### PR DESCRIPTION
This PR splits expressions into two main categories based on whether they can or cannot be on the left side of assignments. Additionally the underlying expression types of expression statements are also limited.

These make the parser more restrictive than before. The following are not accepted any longer:
```C#
a < b;
m() = 0;
```

As a result, the PR fixes https://github.com/tree-sitter/tree-sitter-c-sharp/issues/243. Initially `A<B> C = null;` was parsed as `((A < B) > C) = null;`. By not allowing comparison to be on the left side of assignments, the parse tree changes to `A < (B > (C = null));`, and by not allowing comparisons to be expression statements, the parse tree becomes a generic variable declaration `A<B> C = null;`. This is added as [a test case](https://github.com/tree-sitter/tree-sitter-c-sharp/pull/269/files#diff-9fc0f8e85b9fec5af062d8d60144a45bf395006ac261b5388fccc77f2f0271a3R328-R348).

There are some slightly adjusted test cases in the PR, those were using invalid expression statements.

There's at least one drawback to this approach:
```
var x = 
#if true
  0;
#else 
  1;
#endif
```
is not parsed without an error any longer. I think previously it was basically equivalent to
```
var x =
  0;
  1;
```
where `1;` was an expression statement. But that's not a valid expression statement any longer. We're basically trading an incorrectly parsed input to a failed parsing.