### PR TITLE
Remove unnecessary conflict rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -51,10 +51,6 @@ module.exports = grammar({
 
     [$.event_declaration, $.variable_declarator],
 
-    [$.type_pattern, $.declaration_pattern],
-    [$.type_pattern, $.declaration_pattern, $.recursive_pattern],
-    [$.type_pattern, $.tuple_element],
-
     [$._name, $._lvalue_expression],
     [$._simple_name, $.type_parameter],
     [$._simple_name, $.generic_name],
@@ -96,22 +92,18 @@ module.exports = grammar({
 
     [$.parameter, $.this_expression],
     [$.parameter, $._simple_name],
-    [$.parameter, $.tuple_element],
     [$.parameter, $.tuple_pattern],
-    [$.parameter, $.tuple_element, $.declaration_expression],
-    [$.parameter, $.declaration_expression],
-
-    [$.ref_type, $.parameter],
+    [$.parameter, $.ref_type],
 
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
+    [$.tuple_element, $.type_pattern],
 
     [$.constant_pattern, $._name],
     [$.constant_pattern, $._name, $._lvalue_expression],
     [$.constant_pattern, $._non_lvalue_expression],
     [$.constant_pattern, $._lvalue_expression],
     [$.constant_pattern, $._expression_statement_expression],
-
   ],
 
   inline: $ => [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "nan": "^2.14.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.0"
+    "tree-sitter-cli": "^0.20.7"
   },
   "scripts": {
     "test": "tree-sitter test && script/parse-examples",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10659,19 +10659,6 @@
       "variable_declarator"
     ],
     [
-      "type_pattern",
-      "declaration_pattern"
-    ],
-    [
-      "type_pattern",
-      "declaration_pattern",
-      "recursive_pattern"
-    ],
-    [
-      "type_pattern",
-      "tuple_element"
-    ],
-    [
       "_name",
       "_lvalue_expression"
     ],
@@ -10805,24 +10792,11 @@
     ],
     [
       "parameter",
-      "tuple_element"
-    ],
-    [
-      "parameter",
       "tuple_pattern"
     ],
     [
       "parameter",
-      "tuple_element",
-      "declaration_expression"
-    ],
-    [
-      "parameter",
-      "declaration_expression"
-    ],
-    [
-      "ref_type",
-      "parameter"
+      "ref_type"
     ],
     [
       "tuple_element",
@@ -10831,6 +10805,10 @@
     [
       "tuple_element",
       "variable_declarator"
+    ],
+    [
+      "tuple_element",
+      "type_pattern"
     ],
     [
       "constant_pattern",


### PR DESCRIPTION
Just removes some unnecessary conflict rules we don't need any more and also sets the min version of tree-sitter-cli so we don't regress back from languageversion 14.