### PR TITLE
Fix `_lvalue_expression` to include pointer indirection

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -428,11 +428,11 @@ var x = new A
         (integer_literal))))
   (global_statement
     (expression_statement
-      (prefix_unary_expression
-        (assignment_expression
-          (identifier)
-          (assignment_operator)
-          (integer_literal))))))
+      (assignment_expression
+        (prefix_unary_expression
+          (identifier))
+        (assignment_operator)
+        (integer_literal)))))
 
 ================================================================================
 Ternary Expression

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -339,6 +339,7 @@ var x = new A
   [b] = 1
 };
 (a) = 1;
+*p = 0;
 
 --------------------------------------------------------------------------------
 
@@ -424,7 +425,14 @@ var x = new A
         (parenthesized_expression
           (identifier))
         (assignment_operator)
-        (integer_literal)))))
+        (integer_literal))))
+  (global_statement
+    (expression_statement
+      (prefix_unary_expression
+        (assignment_expression
+          (identifier)
+          (assignment_operator)
+          (integer_literal))))))
 
 ================================================================================
 Ternary Expression

--- a/grammar.js
+++ b/grammar.js
@@ -112,6 +112,8 @@ module.exports = grammar({
     [$.constant_pattern, $._lvalue_expression],
     [$.constant_pattern, $._expression_statement_expression],
 
+    [$.assignment_expression, $._expression],
+
   ],
 
   inline: $ => [
@@ -1254,7 +1256,7 @@ module.exports = grammar({
       ))
     )),
 
-    element_access_expression: $ => prec.right(PREC.UNARY, seq(
+    element_access_expression: $ => prec.right(PREC.POSTFIX, seq(
       field('expression', $._expression),
       field('subscript', $.bracketed_argument_list)
     )),
@@ -1395,7 +1397,6 @@ module.exports = grammar({
       ...[
         '!',
         '&',
-        '*',
         '+',
         '++',
         '-',
@@ -1403,6 +1404,8 @@ module.exports = grammar({
         '^',
         '~'
       ].map(operator => seq(operator, $._expression)))),
+
+    _pointer_indirection_expression: $ => prec(PREC.UNARY, seq('*', $._expression)),
 
     query_expression: $ => seq($.from_clause, $._query_body),
 
@@ -1603,6 +1606,7 @@ module.exports = grammar({
       $._simple_name,
       $.element_access_expression,
       $.element_binding_expression,
+      alias($._pointer_indirection_expression, $.prefix_unary_expression),
       alias($._parenthesized_lvalue_expression, $.parenthesized_expression),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6756,7 +6756,7 @@
     },
     "element_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -7448,19 +7448,6 @@
             "members": [
               {
                 "type": "STRING",
-                "value": "*"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
                 "value": "+"
               },
               {
@@ -7533,6 +7520,23 @@
                 "name": "_expression"
               }
             ]
+          }
+        ]
+      }
+    },
+    "_pointer_indirection_expression": {
+      "type": "PREC",
+      "value": 17,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "*"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
           }
         ]
       }
@@ -8467,6 +8471,15 @@
         {
           "type": "SYMBOL",
           "name": "element_binding_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_pointer_indirection_expression"
+          },
+          "named": true,
+          "value": "prefix_unary_expression"
         },
         {
           "type": "ALIAS",
@@ -10852,6 +10865,10 @@
     [
       "constant_pattern",
       "_expression_statement_expression"
+    ],
+    [
+      "assignment_expression",
+      "_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -942,6 +942,10 @@
             "named": true
           },
           {
+            "type": "prefix_unary_expression",
+            "named": true
+          },
+          {
             "type": "this_expression",
             "named": true
           },


### PR DESCRIPTION
I missed this case in https://github.com/tree-sitter/tree-sitter-c-sharp/pull/269.