### PR TITLE
Add missing contextual keywords to `_contextual_keywords`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1788,9 +1788,14 @@ module.exports = grammar({
     // Custom non-Roslyn additions beyond this point that will not sync up with grammar.txt
 
     // Contextual keywords - keywords that can also be identifiers...
+    // The below list contains all contextual keywords listed in https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/#contextual-keywords
+    // Tree-sitter performs context-aware lexing, so some of these are not going to be needed and can be commented out. The list should be kept for completeness.
+    // Currently keywords are commented out based on whether they were in the grammar already or not.
     _contextual_keywords: $ => choice(
       'add',
       'alias',
+      // 'and',
+      // 'args',
       'ascending',
       // 'async',
       // 'await',
@@ -1803,19 +1808,32 @@ module.exports = grammar({
       'get',
       'global',
       'group',
+      // 'init',
       'into',
       'join',
       'let',
+      // 'managed',
       'nameof',
+      // 'nint',
+      // 'not',
       'notnull',
+      // 'nuint',
       'on',
+      // 'or',
       'orderby',
+      // 'partial',
+      // 'record',
       'remove',
+      // 'required',
+      // 'scoped',
       'select',
       'set',
       'unmanaged',
+      // 'value',
+      // 'var',
       'when',
       'where',
+      // 'with',
       'yield',
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1789,42 +1789,34 @@ module.exports = grammar({
 
     // Contextual keywords - keywords that can also be identifiers...
     _contextual_keywords: $ => choice(
-      // LINQ comprehension syntax
+      'add',
+      'alias',
       'ascending',
+      // 'async',
+      // 'await',
       'by',
       'descending',
+      'dynamic',
       'equals',
+      'file',
       'from',
+      'get',
+      'global',
       'group',
       'into',
       'join',
       'let',
-      'on',
-      'orderby',
-      'select',
-      'where',
-
-      // Property/event handlers
-      'add',
-      'get',
-      'remove',
-      'set',
-
-      // Async - These need to be more contextual
-      // 'async',
-      // 'await',
-
-      // Misc
-      'global',
-      'alias',
-      'dynamic',
       'nameof',
       'notnull',
+      'on',
+      'orderby',
+      'remove',
+      'select',
+      'set',
       'unmanaged',
       'when',
+      'where',
       'yield',
-
-      'file'
     ),
 
     // Preprocessor

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9755,6 +9755,14 @@
       "members": [
         {
           "type": "STRING",
+          "value": "add"
+        },
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "STRING",
           "value": "ascending"
         },
         {
@@ -9767,11 +9775,27 @@
         },
         {
           "type": "STRING",
+          "value": "dynamic"
+        },
+        {
+          "type": "STRING",
           "value": "equals"
         },
         {
           "type": "STRING",
+          "value": "file"
+        },
+        {
+          "type": "STRING",
           "value": "from"
+        },
+        {
+          "type": "STRING",
+          "value": "get"
+        },
+        {
+          "type": "STRING",
+          "value": "global"
         },
         {
           "type": "STRING",
@@ -9791,6 +9815,14 @@
         },
         {
           "type": "STRING",
+          "value": "nameof"
+        },
+        {
+          "type": "STRING",
+          "value": "notnull"
+        },
+        {
+          "type": "STRING",
           "value": "on"
         },
         {
@@ -9799,47 +9831,15 @@
         },
         {
           "type": "STRING",
-          "value": "select"
-        },
-        {
-          "type": "STRING",
-          "value": "where"
-        },
-        {
-          "type": "STRING",
-          "value": "add"
-        },
-        {
-          "type": "STRING",
-          "value": "get"
-        },
-        {
-          "type": "STRING",
           "value": "remove"
         },
         {
           "type": "STRING",
+          "value": "select"
+        },
+        {
+          "type": "STRING",
           "value": "set"
-        },
-        {
-          "type": "STRING",
-          "value": "global"
-        },
-        {
-          "type": "STRING",
-          "value": "alias"
-        },
-        {
-          "type": "STRING",
-          "value": "dynamic"
-        },
-        {
-          "type": "STRING",
-          "value": "nameof"
-        },
-        {
-          "type": "STRING",
-          "value": "notnull"
         },
         {
           "type": "STRING",
@@ -9851,11 +9851,11 @@
         },
         {
           "type": "STRING",
-          "value": "yield"
+          "value": "where"
         },
         {
           "type": "STRING",
-          "value": "file"
+          "value": "yield"
         }
       ]
     },


### PR DESCRIPTION
This change updates the list of keywords in `_contextual_keywords`. The missing ones are only added as a comment, so this PR doesn't introduce any functional change.

