### PR TITLE
Support `scoped` as identifier name

### DIFF
--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -135,3 +135,190 @@ file class file { }
     (modifier)
     (identifier)
     (declaration_list)))
+
+================================================================================
+Scoped contextual keyword
+================================================================================
+
+void scoped() { }
+void m(scoped p) { }
+void m(scoped ref int p) { }
+void m(scoped ref scoped p) { }
+void m(int scoped) { }
+void m()
+{
+    scoped v = null;
+    scoped ref int v = null;
+    scoped ref scoped v = null;
+    int scoped = null;
+
+    scoped();
+    m(scoped);
+
+    var x = scoped + 1;
+    var l = scoped => null;
+    var l = (scoped i) => null;
+    var l = (scoped, i) => null;
+    var l = scoped (int i, int j) => null;
+}
+
+class scoped { }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list)
+      (block)))
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list
+        (parameter
+          (parameter_modifier)
+          (identifier)))
+      (block)))
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list
+        (parameter
+          (parameter_modifier)
+          (parameter_modifier)
+          (predefined_type)
+          (identifier)))
+      (block)))
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list
+        (parameter
+          (parameter_modifier)
+          (parameter_modifier)
+          (identifier)
+          (identifier)))
+      (block)))
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list
+        (parameter
+          (predefined_type)
+          (identifier)))
+      (block)))
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list)
+      (block
+        (local_declaration_statement
+          (variable_declaration
+            (scoped_type
+              (identifier))
+            (variable_declarator
+              (identifier
+                (MISSING _identifier_token))
+              (equals_value_clause
+                (null_literal)))))
+        (local_declaration_statement
+          (variable_declaration
+            (scoped_type
+              (ref_type
+                (predefined_type)))
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (null_literal)))))
+        (local_declaration_statement
+          (variable_declaration
+            (scoped_type
+              (ref_type
+                (identifier)))
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (null_literal)))))
+        (local_declaration_statement
+          (variable_declaration
+            (predefined_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (null_literal)))))
+        (ERROR
+          (parameter_list))
+        (empty_statement)
+        (expression_statement
+          (invocation_expression
+            (identifier)
+            (argument_list
+              (ERROR))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ERROR)
+                (prefix_unary_expression
+                  (integer_literal))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ERROR)
+                (null_literal)))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (parameter_list
+                    (parameter
+                      (parameter_modifier)
+                      (identifier)))
+                  (null_literal))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (lambda_expression
+                  (parameter_list
+                    (parameter
+                      (parameter_modifier)
+                      (ERROR)
+                      (identifier)))
+                  (null_literal))))))
+        (local_declaration_statement
+          (variable_declaration
+            (implicit_type)
+            (variable_declarator
+              (identifier)
+              (equals_value_clause
+                (ERROR)
+                (lambda_expression
+                  (parameter_list
+                    (parameter
+                      (predefined_type)
+                      (identifier))
+                    (parameter
+                      (predefined_type)
+                      (identifier)))
+                  (null_literal)))))))))
+  (class_declaration
+    (identifier)
+    (declaration_list)))

--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -179,7 +179,7 @@ class scoped { }
       (identifier)
       (parameter_list
         (parameter
-          (parameter_modifier)
+          (identifier)
           (identifier)))
       (block)))
   (global_statement
@@ -288,7 +288,7 @@ class scoped { }
                 (lambda_expression
                   (parameter_list
                     (parameter
-                      (parameter_modifier)
+                      (identifier)
                       (identifier)))
                   (null_literal))))))
         (local_declaration_statement

--- a/corpus/contextual-keywords.txt
+++ b/corpus/contextual-keywords.txt
@@ -221,11 +221,9 @@ class scoped { }
       (block
         (local_declaration_statement
           (variable_declaration
-            (scoped_type
-              (identifier))
+            (identifier)
             (variable_declarator
-              (identifier
-                (MISSING _identifier_token))
+              (identifier)
               (equals_value_clause
                 (null_literal)))))
         (local_declaration_statement
@@ -253,22 +251,24 @@ class scoped { }
               (identifier)
               (equals_value_clause
                 (null_literal)))))
-        (ERROR
-          (parameter_list))
-        (empty_statement)
+        (expression_statement
+          (invocation_expression
+            (identifier)
+            (argument_list)))
         (expression_statement
           (invocation_expression
             (identifier)
             (argument_list
-              (ERROR))))
+              (argument
+                (identifier)))))
         (local_declaration_statement
           (variable_declaration
             (implicit_type)
             (variable_declarator
               (identifier)
               (equals_value_clause
-                (ERROR)
-                (prefix_unary_expression
+                (binary_expression
+                  (identifier)
                   (integer_literal))))))
         (local_declaration_statement
           (variable_declaration
@@ -276,8 +276,9 @@ class scoped { }
             (variable_declarator
               (identifier)
               (equals_value_clause
-                (ERROR)
-                (null_literal)))))
+                (lambda_expression
+                  (identifier)
+                  (null_literal))))))
         (local_declaration_statement
           (variable_declaration
             (implicit_type)
@@ -299,8 +300,8 @@ class scoped { }
                 (lambda_expression
                   (parameter_list
                     (parameter
-                      (parameter_modifier)
-                      (ERROR)
+                      (identifier))
+                    (parameter
                       (identifier)))
                   (null_literal))))))
         (local_declaration_statement
@@ -309,8 +310,8 @@ class scoped { }
             (variable_declarator
               (identifier)
               (equals_value_clause
-                (ERROR)
                 (lambda_expression
+                  (identifier)
                   (parameter_list
                     (parameter
                       (predefined_type)

--- a/grammar.js
+++ b/grammar.js
@@ -70,6 +70,9 @@ module.exports = grammar({
     [$._contextual_keywords, $.accessor_declaration],
     [$._contextual_keywords, $.type_parameter_constraint],
     [$._contextual_keywords, $.modifier],
+    [$._contextual_keywords, $.scoped_type],
+    [$._contextual_keywords, $.scoped_type, $.parameter],
+    [$._contextual_keywords, $.parameter],
 
     [$._type, $.attribute],
     [$._type, $._nullable_base_type],
@@ -1830,7 +1833,7 @@ module.exports = grammar({
       // 'record',
       'remove',
       // 'required',
-      // 'scoped',
+      'scoped',
       'select',
       'set',
       'unmanaged',

--- a/grammar.js
+++ b/grammar.js
@@ -71,8 +71,8 @@ module.exports = grammar({
     [$._contextual_keywords, $.type_parameter_constraint],
     [$._contextual_keywords, $.modifier],
     [$._contextual_keywords, $.scoped_type],
-    [$._contextual_keywords, $.scoped_type, $.parameter],
-    [$._contextual_keywords, $.parameter],
+    [$._contextual_keywords, $.scoped_type, $._parameter_type_with_modifiers],
+    [$._contextual_keywords, $._parameter_type_with_modifiers],
 
     [$._type, $.attribute],
     [$._type, $._nullable_base_type],
@@ -97,14 +97,13 @@ module.exports = grammar({
     [$.array_creation_expression, $._nullable_base_type],
     [$.array_creation_expression, $._pointer_base_type],
 
-    [$.parameter, $.this_expression],
+    [$._parameter_type_with_modifiers, $.this_expression],
+    [$._parameter_type_with_modifiers, $.ref_type],
     [$.parameter, $._simple_name],
     [$.parameter, $.tuple_element],
     [$.parameter, $.tuple_pattern],
     [$.parameter, $.tuple_element, $.declaration_expression],
     [$.parameter, $.declaration_expression],
-
-    [$.ref_type, $.parameter],
 
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
@@ -353,11 +352,15 @@ module.exports = grammar({
       $._parameter_array
     )),
 
-    parameter: $ => seq(
-      repeat($.attribute_list),
+    _parameter_type_with_modifiers: $ => seq(
       alias(optional('scoped'), $.parameter_modifier),
       optional(alias(choice('ref', 'out', 'this', 'in'), $.parameter_modifier)),
-      optional(field('type', $._ref_base_type)),
+      field('type', $._ref_base_type),
+    ),
+
+    parameter: $ => seq(
+      repeat($.attribute_list),
+      optional($._parameter_type_with_modifiers),
       field('name', $.identifier),
       optional($.equals_value_clause)
     ),

--- a/script/file_sizes.txt
+++ b/script/file_sizes.txt
@@ -1,5 +1,5 @@
-src/grammar.json    	0.2MB	     10900
+src/grammar.json    	0.2MB	     10909
 src/node-types.json 	0.1MB	      7665
-src/parser.c        	50.6MB	   1578185
+src/parser.c        	50.6MB	   1576511
 src/scanner.c       	0.0MB	        29
-total               	51.0MB	   1596779
+total               	51.0MB	   1595114

--- a/script/file_sizes.txt
+++ b/script/file_sizes.txt
@@ -1,5 +1,5 @@
-src/grammar.json    	0.2MB	     10891
-src/node-types.json 	0.1MB	      7673
-src/parser.c        	52.4MB	   1585765
+src/grammar.json    	0.2MB	     10900
+src/node-types.json 	0.1MB	      7665
+src/parser.c        	50.6MB	   1578185
 src/scanner.c       	0.0MB	        29
-total               	52.8MB	   1604358
+total               	51.0MB	   1596779

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9840,6 +9840,10 @@
         },
         {
           "type": "STRING",
+          "value": "scoped"
+        },
+        {
+          "type": "STRING",
           "value": "select"
         },
         {
@@ -10727,6 +10731,19 @@
     [
       "_contextual_keywords",
       "modifier"
+    ],
+    [
+      "_contextual_keywords",
+      "scoped_type"
+    ],
+    [
+      "_contextual_keywords",
+      "scoped_type",
+      "parameter"
+    ],
+    [
+      "_contextual_keywords",
+      "parameter"
     ],
     [
       "_type",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1211,16 +1211,9 @@
         }
       ]
     },
-    "parameter": {
+    "_parameter_type_with_modifiers": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "attribute_list"
-          }
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1273,15 +1266,31 @@
           ]
         },
         {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ref_base_type"
+          }
+        }
+      ]
+    },
+    "parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute_list"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "type",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_ref_base_type"
-              }
+              "type": "SYMBOL",
+              "name": "_parameter_type_with_modifiers"
             },
             {
               "type": "BLANK"
@@ -10739,11 +10748,11 @@
     [
       "_contextual_keywords",
       "scoped_type",
-      "parameter"
+      "_parameter_type_with_modifiers"
     ],
     [
       "_contextual_keywords",
-      "parameter"
+      "_parameter_type_with_modifiers"
     ],
     [
       "_type",
@@ -10818,8 +10827,12 @@
       "_pointer_base_type"
     ],
     [
-      "parameter",
+      "_parameter_type_with_modifiers",
       "this_expression"
+    ],
+    [
+      "_parameter_type_with_modifiers",
+      "ref_type"
     ],
     [
       "parameter",
@@ -10841,10 +10854,6 @@
     [
       "parameter",
       "declaration_expression"
-    ],
-    [
-      "ref_type",
-      "parameter"
     ],
     [
       "tuple_element",


### PR DESCRIPTION
Commit-by-commit review is advised.

This PR is adding support for `scoped` as identifier name. I had to somewhat rework the parameter rule, which previously allowed parameter modifiers without a parameter type. I found it somewhat odd that parameters can be declared without a type, but that's the case in lambdas, such as `System.Func<int, int, object> l = (i, j) => null;`, and also in the rare case of `__arglist`. I don't think parameter modifiers could be used in such cases.

I have no systematic way of finding issues regarding contextual keywords (such as the issue fixed in the [last commit](https://github.com/tree-sitter/tree-sitter-c-sharp/pull/275/commits/21d7dbcc22b7022e6897073b4620254fc97d27bd)), so there might be other cases too, when `scoped` doesn't work as an identifier. 