### PR TITLE
Specify associativity for pointer indirection

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1397,6 +1397,7 @@ module.exports = grammar({
       ...[
         '!',
         '&',
+        // '*', Handled separately in _pointer_indirection_expression
         '+',
         '++',
         '-',
@@ -1405,7 +1406,7 @@ module.exports = grammar({
         '~'
       ].map(operator => seq(operator, $._expression)))),
 
-    _pointer_indirection_expression: $ => prec(PREC.UNARY, seq('*', $._expression)),
+    _pointer_indirection_expression: $ => prec.right(PREC.UNARY, seq('*', $._expression)),
 
     query_expression: $ => seq($.from_clause, $._query_body),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7525,7 +7525,7 @@
       }
     },
     "_pointer_indirection_expression": {
-      "type": "PREC",
+      "type": "PREC_RIGHT",
       "value": 17,
       "content": {
         "type": "SEQ",


### PR DESCRIPTION
This change doesn't seem to make any functional difference, but makes sure that `prefix_unary_expression` and `_pointer_indirection_expression` have the same structure.