### PR TITLE
Add `commaSep2` helper

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -825,9 +825,7 @@ module.exports = grammar({
 
     tuple_type: $ => seq(
       '(',
-      $.tuple_element,
-      ',',
-      commaSep1($.tuple_element),
+      commaSep2($.tuple_element),
       ')'
     ),
 
@@ -1090,7 +1088,7 @@ module.exports = grammar({
 
     positional_pattern_clause: $ => prec(1, seq(
       '(',
-      optional(seq($.subpattern, ',', commaSep1($.subpattern))),// we really should allow single sub patterns, but that causes conficts, and will rarely be used
+      optional(commaSep2($.subpattern)),// we really should allow single sub patterns, but that causes conficts, and will rarely be used
       ')',
     )),
 
@@ -1543,11 +1541,7 @@ module.exports = grammar({
 
     tuple_expression: $ => seq(
       '(',
-      $.argument,
-      repeat1(seq(
-        ',',
-        $.argument,
-      )),
+      commaSep2($.argument),
       ')'
     ),
 
@@ -1972,5 +1966,13 @@ function commaSep1(rule) {
       ',',
       rule
     ))
+  )
+}
+
+function commaSep2(rule) {
+  return seq(
+    rule,
+    ',',
+    commaSep1(rule)
   )
 }

--- a/script/file_sizes.txt
+++ b/script/file_sizes.txt
@@ -1,5 +1,5 @@
-src/grammar.json    	0.2MB	     10881
+src/grammar.json    	0.2MB	     10904
 src/node-types.json 	0.1MB	      7645
-src/parser.c        	49.3MB	   1550969
+src/parser.c        	49.4MB	   1552210
 src/scanner.c       	0.0MB	        29
-total               	49.7MB	   1569524
+total               	49.7MB	   1570788

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4061,14 +4061,6 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "tuple_element"
-        },
-        {
-          "type": "STRING",
-          "value": ","
-        },
-        {
           "type": "SEQ",
           "members": [
             {
@@ -4076,20 +4068,33 @@
               "name": "tuple_element"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "tuple_element"
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "tuple_element"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "tuple_element"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         },
@@ -8171,24 +8176,42 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "argument"
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "argument"
-              }
-            ]
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argument"
+            },
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "argument"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "argument"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "STRING",


### PR DESCRIPTION
Adding `commaSep2` helper to use when a sequence needs to contain at least two items separated by commas. I was originally looking at `tuple_pattern`, which allows single item tuples too. In the end I didn't change that, but raised https://github.com/tree-sitter/tree-sitter-c-sharp/issues/289 instead.

