### PR TITLE
Adds GH tags queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,46 +1,23 @@
-(class_declaration
- name: (identifier) @name
- ) @definition.class
+(class_declaration name: (identifier) @name) @definition.class
 
-(class_declaration
-   bases: (base_list (_) @name)
- ) @reference.class
+(class_declaration bases: (base_list (_) @name)) @reference.class
 
-(interface_declaration
- name: (identifier) @name
- ) @definition.interface
+(interface_declaration name: (identifier) @name) @definition.interface
 
-(interface_declaration
- bases: (base_list (_) @name)
- ) @reference.interface
+(interface_declaration bases: (base_list (_) @name)) @reference.interface
 
-(method_declaration
- name: (identifier) @name
- ) @definition.method
+(method_declaration name: (identifier) @name) @definition.method
 
-(object_creation_expression
- type: (identifier) @name
- ) @reference.class
+(object_creation_expression type: (identifier) @name) @reference.class
 
-(type_parameter_constraints_clause
- target: (identifier) @name
- ) @reference.class
+(type_parameter_constraints_clause target: (identifier) @name) @reference.class
 
-(type_constraint
- type: (identifier) @name
- ) @reference.class
+(type_constraint type: (identifier) @name) @reference.class
 
-(variable_declaration
- type: (identifier) @name
- ) @reference.class
+(variable_declaration type: (identifier) @name) @reference.class
 
-(invocation_expression
- function:
-  (member_access_expression
-    name: (identifier) @name
- )
-) @reference.send
+(invocation_expression function: (member_access_expression name: (identifier) @name)) @reference.send
 
-(namespace_declaration
- name: (identifier) @name
-) @definition.module
+(namespace_declaration name: (identifier) @name) @definition.module
+
+(namespace_declaration name: (identifier) @name) @module


### PR DESCRIPTION
This PR adds new tags queries to `tags.scm` to support code search on Github.com.