### PR TITLE
Fix C# raw_string_literal

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1179,3 +1179,68 @@ var x = $"""The point
                           (identifier)
                           (identifier)))))))
               (interpolated_raw_string_text))))))))
+
+================================================================================
+multiple raw string literals should not be combined
+================================================================================
+
+using System;
+
+public class RawStringLiterals {
+  public static void Main(string[] args) {
+    string tb1, tb2, tb3;
+    tb1 = """text block 1""";
+    tb2 = """
+    text block 2
+    """;
+    tb3 = """"
+    text block 3
+    """";
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (using_directive
+    (identifier))
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        (modifier)
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (array_type
+              type: (predefined_type)
+              rank: (array_rank_specifier))
+            name: (identifier)))
+        body: (block
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                (identifier))
+              (variable_declarator
+                (identifier))
+              (variable_declarator
+                (identifier))))
+          (expression_statement
+            (assignment_expression
+              left: (identifier)
+              (assignment_operator)
+              right: (raw_string_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (identifier)
+              (assignment_operator)
+              right: (raw_string_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (identifier)
+              (assignment_operator)
+              right: (raw_string_literal))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1768,13 +1768,9 @@ module.exports = grammar({
     )),
 
     raw_string_literal: $ => token(seq(
-      '"""',
-      repeat(choice(
-        /[^"]/,
-        '"',
-        '""',
-      )),
-      choice('"""', '"""U8', '"""u8')
+      /""["]+/,
+      optional(/([^"]|("[^"])|(""[^"]))+/),
+      choice(/""["]+/, /""["]+u8/, /""["]+U8/)
     )),
 
     // Comments

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9706,43 +9706,35 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "\"\"\""
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "[^\"]"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\""
-                },
-                {
-                  "type": "STRING",
-                  "value": "\"\""
-                }
-              ]
-            }
+            "type": "PATTERN",
+            "value": "\"\"[\"]+"
           },
           {
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "\"\"\""
+                "type": "PATTERN",
+                "value": "([^\"]|(\"[^\"])|(\"\"[^\"]))+"
               },
               {
-                "type": "STRING",
-                "value": "\"\"\"U8"
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "\"\"[\"]+"
               },
               {
-                "type": "STRING",
-                "value": "\"\"\"u8"
+                "type": "PATTERN",
+                "value": "\"\"[\"]+u8"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\"\"[\"]+U8"
               }
             ]
           }


### PR DESCRIPTION
Example program:

```csharp
# define DEBUG

using System;



/** <summary>Class constructor</summary>
  * <param>param1</param>
*/
public class HelloWorld {
  /// <summary>
  ///   This is a C sharp docstring.
  /// </summary>
  public static void Main(string[] args) {
    int x, y;
    string z, zz;
    char zzz;
    string tb1, tb2, tb3;
    for (x = 0; x < 10; x++) {
      y = x + 1;
      break;  // 123
      // this is another comment.
    }
    /* This is a block comment,
    that has two lines.
    */
    if (x < 5) {
      y = 2;
    }
#line 100 "special"
    z = "123";
    zz = @"456";
    zzz = 'T';
    tb1 = """text block 1""";
    tb2 = """
    text block 2
    """;
    tb3 = """"
    text block 3
    """";
    Console.WriteLine($"Hello, {z}! Do you know {tb1}?");
    var bytes = "hello"u8;
#if DEBUG
    Console.WriteLine("Debug version");
#endif
  }
}
```

In this program, `tb1`, `tb2` and `tb3` are assigned with three `raw_string_literal`s. However, the parser in tree-sitter considers them as a single `raw_string_literal` of

```
text block 1""";
    tb2 = """
    text block 2
    """;
    tb3 = """"
    text block 3
    "
```

which is incorrect. A change in grammar can fix this issue.