### PR TITLE
Modernize and expand syntax highlighting

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,5 +1,5 @@
 ;; Methods
-(method_declaration (identifier) @type (identifier) @function)
+(method_declaration name: (identifier) @function)
 
 ;; Types
 (interface_declaration name: (identifier) @type)
@@ -8,10 +8,10 @@
 (struct_declaration (identifier) @type)
 (record_declaration (identifier) @type)
 (record_struct_declaration (identifier) @type)
-(namespace_declaration name: (identifier) @type)
+(namespace_declaration name: (identifier) @module)
 
-(constructor_declaration name: (identifier) @type)
-(destructor_declaration name: (identifier) @type)
+(constructor_declaration name: (identifier) @constructor)
+(destructor_declaration name: (identifier) @constructor)
 
 [
   (implicit_type)
@@ -102,6 +102,7 @@
 (escape_sequence) @keyword
 
 [
+  "add"
   "as"
   "base"
   "break"
@@ -120,6 +121,7 @@
   "finally"
   "for"
   "foreach"
+  "global"
   "goto"
   "if"
   "implicit"
@@ -127,9 +129,11 @@
   "is"
   "lock"
   "namespace"
+  "notnull"
   "operator"
   "params"
   "return"
+  "remove"
   "sizeof"
   "stackalloc"
   "struct"
@@ -198,7 +202,7 @@
 (lambda_expression) @variable
 
 ;; Attribute
-(attribute) @type
+(attribute) @attribute
 
 ;; Parameter
 (parameter

--- a/test/highlight/baseline.cs
+++ b/test/highlight/baseline.cs
@@ -19,16 +19,18 @@ using X = System.Console;
 //              ^ punctuation.delimiter
 //                      ^ punctuation.delimiter
 global using A;
+// <- keyword
 //     ^ keyword
 //            ^ punctuation.delimiter
 global using static A.B;
+// <- keyword
 //     ^ keyword
 //                   ^ punctuation.delimiter
 //                     ^ punctuation.delimiter
 
 namespace Namespace
 // <- keyword
-//        ^ type
+//        ^ module
 {
 // <- punctuation.bracket
     using A;
@@ -78,7 +80,7 @@ namespace Namespace
 
     [Nice]
     // <- punctuation.bracket
-     // <- type
+     // <- attribute
     //   ^ punctuation.bracket
     private record F<T1, T2> where T1 : I1, I2, new() where T2 : I2 { }
     // <- keyword
@@ -163,6 +165,7 @@ namespace Namespace
     //                                                 ^ operator
     //                                                   ^ keyword
     //                                                        ^ operator
+    //                                                           ^ keyword
     //                                                                  ^ punctuation.delimiter
     //                                                                    ^ type.builtin
     //                                                                     ^ operator
@@ -176,8 +179,10 @@ namespace Namespace
         //                        ^ type
         //                         ^ operator
         //                                     ^ punctuation.bracket
+        //                                       ^ keyword
         //                                           ^ punctuation.bracket
         //                                             ^ punctuation.bracket
+        //                                               ^ keyword
         //                                                      ^ punctuation.bracket
         //                                                        ^ punctuation.bracket
         //                                                          ^ punctuation.bracket
@@ -212,7 +217,7 @@ namespace Namespace
 
         [SomeAttribute]
         // <- punctuation.bracket
-         // <- type
+         // <- attribute
         //            ^ punctuation.bracket
         public static int operator +(A a) { return 0; }
         // <- keyword
@@ -242,14 +247,14 @@ namespace Namespace
         static extern Foo() { }
         // <- keyword
         //     ^ keyword
-        //            ^ type
+        //            ^ constructor
         //               ^ punctuation.bracket
         //                  ^ punctuation.bracket
         //                    ^ punctuation.bracket
 
         extern ~Class() { }
         //     ^ operator
-        //      ^ type
+        //      ^ constructor
         //           ^ punctuation.bracket
         //              ^ punctuation.bracket
         //                ^ punctuation.bracket
@@ -257,6 +262,7 @@ namespace Namespace
         public void Method()
         // <- keyword
         //     ^ type.builtin
+        //          ^ function
         //                ^ punctuation.bracket
         {
         // <- punctuation.bracket


### PR DESCRIPTION
We're planning to use this parser and highlighter in production. Before we do
that, though, we can get better results by using some of the newer highlighting
classes, and adding new keywords that weren't being highlighted previously.