### PR TITLE
Highlight lambda expressions with specified return values (C# 10).

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,5 +1,6 @@
 ;; Methods
 (method_declaration name: (identifier) @function)
+(local_function_statement name: (identifier) @function)
 
 ;; Types
 (interface_declaration name: (identifier) @type)

--- a/test/highlight/baseline.cs
+++ b/test/highlight/baseline.cs
@@ -696,6 +696,16 @@ namespace Namespace
             //                                  ^ punctuation.bracket
             //                                     ^ punctuation.bracket
 
+            int Add(int left, int right) => a + b;
+            // <- type.builtin
+            //  ^ function
+            //      ^ type.builtin
+            //          ^ variable.parameter
+            //                 ^ type.builtin
+            //                     ^ variable.parameter
+            //                            ^ operator
+            //                                ^ operator
+
             Do(async () => { });
             //^ punctuation.bracket
             // ^ keyword


### PR DESCRIPTION
Beginning in C# 10, you can specify the return type of a lambda expression using
syntactic constructs you'd associate with a standard (non-lambda) method
declaration. This ensures they're highlighted correctly.