### PR TITLE
Remove unnecessary conflict rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -55,8 +55,6 @@ module.exports = grammar({
 
     [$.event_declaration, $.variable_declarator],
 
-    [$.type_pattern, $.declaration_pattern],
-    [$.type_pattern, $.declaration_pattern, $.recursive_pattern],
     [$.type_pattern, $.tuple_element],
 
     [$._name, $._lvalue_expression],
@@ -102,10 +100,7 @@ module.exports = grammar({
     [$._parameter_type_with_modifiers, $.this_expression],
     [$._parameter_type_with_modifiers, $.ref_type],
     [$.parameter, $._simple_name],
-    [$.parameter, $.tuple_element],
     [$.parameter, $.tuple_pattern],
-    [$.parameter, $.tuple_element, $.declaration_expression],
-    [$.parameter, $.declaration_expression],
 
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],

--- a/script/file_sizes.txt
+++ b/script/file_sizes.txt
@@ -1,5 +1,5 @@
-src/grammar.json    	0.2MB	     10997
+src/grammar.json    	0.2MB	     10975
 src/node-types.json 	0.1MB	      7685
 src/parser.c        	48.9MB	   1534188
 src/scanner.c       	0.0MB	        37
-total               	49.3MB	   1552907
+total               	49.3MB	   1552885

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10770,15 +10770,6 @@
     ],
     [
       "type_pattern",
-      "declaration_pattern"
-    ],
-    [
-      "type_pattern",
-      "declaration_pattern",
-      "recursive_pattern"
-    ],
-    [
-      "type_pattern",
       "tuple_element"
     ],
     [
@@ -10924,20 +10915,7 @@
     ],
     [
       "parameter",
-      "tuple_element"
-    ],
-    [
-      "parameter",
       "tuple_pattern"
-    ],
-    [
-      "parameter",
-      "tuple_element",
-      "declaration_expression"
-    ],
-    [
-      "parameter",
-      "declaration_expression"
     ],
     [
       "tuple_element",


### PR DESCRIPTION
Unfortunately does not do much to reduce the parser size.

I did find out however that 20MB of the 49.9MB of parser.c is dealing with contextual keywords. Replacing the line

`identifier: $ => choice($._identifier_token, $._contextual_keywords),`

with 

`identifier: $ => $.identifier_token,`

Cuts the generated files in half. This needs more investigation as to how better we can handle them without this crazy bloat.