### PR TITLE
Fix wrong parsing when a function call with a (one or more) variable …

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1264,11 +1264,51 @@ class A {
         parameters: (parameter_list)
         body: (block
           (using_statement
-            (variable_declaration
+            (using_variable_declaration
               type: (implicit_type)
-              (variable_declarator
+              (using_variable_declarator
                 name: (identifier)
                 (equals_value_clause
+                  (identifier))))
+            body: (block
+              (return_statement))))))))
+
+================================================================================
+Using statement with function call
+================================================================================
+
+class A {
+  void Sample() {
+    var four = 4;
+    using (func(four)) {
+      return;
+    }
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        type: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list)
+        body: (block
+          (local_declaration_statement
+              (variable_declaration
+                  type: (implicit_type)
+                  (variable_declarator
+                    name: (identifier)
+                    (equals_value_clause
+                      (integer_literal)))))
+          (using_statement
+            (invocation_expression
+              function: (identifier)
+              arguments: (argument_list
+                (argument
                   (identifier))))
             body: (block
               (return_statement))))))))
@@ -1297,9 +1337,9 @@ class A {
         parameters: (parameter_list)
         body: (block
           (using_statement
-            (variable_declaration
+            (using_variable_declaration
               type: (identifier)
-              (variable_declarator
+              (using_variable_declarator
                 name: (identifier)
                 (equals_value_clause
                   (invocation_expression
@@ -1310,7 +1350,7 @@ class A {
                       (argument
                         (string_literal
                           (string_literal_fragment)))))))
-              (variable_declarator
+              (using_variable_declarator
                 name: (identifier)
                 (equals_value_clause
                   (object_creation_expression
@@ -1376,9 +1416,9 @@ class A {
         parameters: (parameter_list)
         body: (block
           (using_statement
-            (variable_declaration
+            (using_variable_declaration
               type: (identifier)
-              (variable_declarator
+              (using_variable_declarator
                 name: (identifier)
                 (equals_value_clause
                   (identifier))))

--- a/grammar.js
+++ b/grammar.js
@@ -105,6 +105,7 @@ module.exports = grammar({
 
     [$.tuple_element, $.declaration_expression],
     [$.tuple_element, $.variable_declarator],
+    [$.tuple_element, $.using_variable_declarator],
 
     [$.constant_pattern, $._name],
     [$.constant_pattern, $._name, $._lvalue_expression],
@@ -1160,11 +1161,22 @@ module.exports = grammar({
 
     unsafe_statement: $ => seq('unsafe', $.block),
 
+    using_variable_declaration: $ => seq(
+      field('type', $._type),
+      commaSep1($.using_variable_declarator)
+    ),
+
+    using_variable_declarator: $ => seq(
+      field('name', $.identifier),
+      optional($.bracketed_argument_list),
+      optional($.equals_value_clause)
+    ),
+
     using_statement: $ => seq(
       optional('await'),
       'using',
       '(',
-      choice($.variable_declaration, $._expression),
+      choice($.using_variable_declaration, $._expression),
       ')',
       field('body', $._statement)
     ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -226,6 +226,7 @@
 
 ;; Variable declarations
 (variable_declarator (identifier) @variable)
+(using_variable_declarator (identifier) @variable)
 (for_each_statement left: (identifier) @variable)
 (catch_declaration (_) (identifier) @variable)
 


### PR DESCRIPTION
…is inside a using statement. Instead of being parsed as invocation_expression it is being parsed as variable_declaration because of tuple_pattern.