### PR TITLE
Include literal content in the parse tree

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1734,9 +1734,11 @@ module.exports = grammar({
 
     character_literal: $ => seq(
       '\'',
-      choice(token.immediate(/[^'\\]/), $.escape_sequence),
+      choice($.character_literal_content, $.escape_sequence),
       '\'',
     ),
+
+    character_literal_content: $ => token.immediate(/[^'\\]/),
 
     integer_literal: _ => token(seq(
       choice(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.5.tgz",
-      "integrity": "sha512-c3VT46Bc3a6pEd0JAwufbqEw9Q2FRLDp5E230hGvnr+Hivw+Y6jyeP+3T89KDptvn48MOPVmbgaLm69xYgLVTw==",
+      "version": "0.22.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
+      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9308,11 +9308,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "PATTERN",
-                "value": "[^'\\\\]"
-              }
+              "type": "SYMBOL",
+              "name": "character_literal_content"
             },
             {
               "type": "SYMBOL",
@@ -9325,6 +9322,13 @@
           "value": "'"
         }
       ]
+    },
+    "character_literal_content": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[^'\\\\]"
+      }
     },
     "integer_literal": {
       "type": "TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1562,8 +1562,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "character_literal_content",
+          "named": true
+        },
         {
           "type": "escape_sequence",
           "named": true
@@ -6379,6 +6383,10 @@
   {
     "type": "catch",
     "named": false
+  },
+  {
+    "type": "character_literal_content",
+    "named": true
   },
   {
     "type": "checked",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2695,12 +2695,15 @@ var x = c is < '0' or >= 'A' and <= 'Z';
             expression: (identifier)
             pattern: (or_pattern
               left: (relational_pattern
-                (character_literal))
+                (character_literal
+                  (character_literal_content)))
               right: (and_pattern
                 left: (relational_pattern
-                  (character_literal))
+                  (character_literal
+                    (character_literal_content)))
                 right: (relational_pattern
-                  (character_literal))))))))))
+                  (character_literal
+                    (character_literal_content)))))))))))
 
 ================================================================================
 Precedence of prefix_unary_expression and invocation_expression

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -205,7 +205,8 @@ var x = $"{{";
         type: (predefined_type)
         (variable_declarator
           name: (identifier)
-          (character_literal)))))
+          (character_literal
+            (character_literal_content))))))
   (global_statement
     (local_declaration_statement
       (modifier)


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter-c-sharp/pull/333 follow-up. While it is [in principle possible to derive that character literal content](https://github.com/github/codeql/pull/16433), it's probably better to revert this change to the grammar.