### PR TITLE
fix: properly handle raw strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -102,6 +102,9 @@ module.exports = grammar({
     $.interpolation_open_brace,
     $.interpolation_close_brace,
     $.interpolation_string_content,
+    $.raw_string_start,
+    $.raw_string_end,
+    $.raw_string_content,
   ],
 
   extras: $ => [
@@ -1813,12 +1816,12 @@ module.exports = grammar({
       optional(stringEncoding),
     )),
 
-    raw_string_literal: _ => token(seq(
-      /""["]+/,
-      optional(/([^"]|("[^"])|(""[^"]))+/),
-      /""["]+/,
+    raw_string_literal: $ => seq(
+      $.raw_string_start,
+      $.raw_string_content,
+      $.raw_string_end,
       optional(stringEncoding),
-    )),
+    ),
 
     boolean_literal: _ => choice('true', 'false'),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9682,44 +9682,33 @@
       }
     },
     "raw_string_literal": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "\"\"[\"]+"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "([^\"]|(\"[^\"])|(\"\"[^\"]))+"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "PATTERN",
-            "value": "\"\"[\"]+"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "(u|U)8"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "raw_string_start"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "raw_string_content"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "raw_string_end"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "(u|U)8"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
     },
     "boolean_literal": {
       "type": "CHOICE",
@@ -11590,6 +11579,18 @@
     {
       "type": "SYMBOL",
       "name": "interpolation_string_content"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "raw_string_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "raw_string_end"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "raw_string_content"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4954,6 +4954,29 @@
     }
   },
   {
+    "type": "raw_string_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "raw_string_content",
+          "named": true
+        },
+        {
+          "type": "raw_string_end",
+          "named": true
+        },
+        {
+          "type": "raw_string_start",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "record_declaration",
     "named": true,
     "fields": {
@@ -6681,7 +6704,15 @@
     "named": false
   },
   {
-    "type": "raw_string_literal",
+    "type": "raw_string_content",
+    "named": true
+  },
+  {
+    "type": "raw_string_end",
+    "named": true
+  },
+  {
+    "type": "raw_string_start",
     "named": true
   },
   {

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -117,6 +117,16 @@ var x = $"""The point "{X}, {Y}" is
 
 var x = $"{{";
 
+var x = $@"""{foo}""";
+
+var x = $"""{bar}""";
+
+var x = """"baz"""";
+var x = $""""
+    [||]
+    """
+"""";
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -704,21 +714,30 @@ var x = $"{{";
         type: (implicit_type)
         (variable_declarator
           name: (identifier)
-          (raw_string_literal)))))
+          (raw_string_literal
+            (raw_string_start)
+            (raw_string_content)
+            (raw_string_end))))))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         type: (implicit_type)
         (variable_declarator
           name: (identifier)
-          (raw_string_literal)))))
+          (raw_string_literal
+            (raw_string_start)
+            (raw_string_content)
+            (raw_string_end))))))
   (global_statement
     (local_declaration_statement
       (variable_declaration
         type: (implicit_type)
         (variable_declarator
           name: (identifier)
-          (raw_string_literal)))))
+          (raw_string_literal
+            (raw_string_start)
+            (raw_string_content)
+            (raw_string_end))))))
   (global_statement
     (local_declaration_statement
       (variable_declaration
@@ -765,4 +784,53 @@ var x = $"{{";
           name: (identifier)
           (interpolated_string_expression
             (interpolation_start)
-            (string_content)))))))
+            (string_content))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (interpolated_string_expression
+            (interpolation_start)
+            (interpolation_quote)
+            (interpolation
+              (interpolation_brace)
+              (identifier)
+              (interpolation_brace))
+            (interpolation_quote))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (interpolated_string_expression
+            (interpolation_start)
+            (interpolation_quote)
+            (interpolation
+              (interpolation_brace)
+              (identifier)
+              (interpolation_brace))
+            (interpolation_quote))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (raw_string_literal
+            (raw_string_start)
+            (raw_string_content)
+            (raw_string_end))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (interpolated_string_expression
+            (interpolation_start)
+            (interpolation_quote)
+            (string_content)
+            (interpolation_quote)))))))


### PR DESCRIPTION
Similar story to interpolated raw strings, they can contain 3 or more quotes, and then anything in between. Also improves the logic for content parsing to avoid edge case hangs