### PR TITLE
Update stack size check in tree_sitter_c_sharp_external_scanner_serialize()

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,7 +62,7 @@ void tree_sitter_c_sharp_external_scanner_destroy(void *payload) {
 unsigned tree_sitter_c_sharp_external_scanner_serialize(void *payload, char *buffer) {
     Scanner *scanner = (Scanner *)payload;
 
-    if (scanner->interpolation_stack.size * 4 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
+    if ((scanner->interpolation_stack.size * 4) + 2 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
         return 0;
     }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,7 +62,7 @@ void tree_sitter_c_sharp_external_scanner_destroy(void *payload) {
 unsigned tree_sitter_c_sharp_external_scanner_serialize(void *payload, char *buffer) {
     Scanner *scanner = (Scanner *)payload;
 
-    if ((scanner->interpolation_stack.size * 4) + 2 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
+    if (scanner->interpolation_stack.size * 4 + 2 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
         return 0;
     }
 


### PR DESCRIPTION
It looks like the interpolation stack size check against `TREE_SITTER_SERIALIZATION_BUFFER_SIZE` wasn't updated when the two increments before the loop were added. 

Fixes https://github.com/tree-sitter/tree-sitter/issues/3416