### PR TITLE
Pattern matching improvements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -46,6 +46,7 @@ module.exports = grammar({
   conflicts: $ => [
     [$._simple_name, $.generic_name],
     [$._simple_name, $.type_parameter],
+    [$._simple_name, $.subpattern],
 
     [$.tuple_element, $.type_pattern],
     [$.tuple_element, $.using_variable_declarator],
@@ -1174,14 +1175,15 @@ module.exports = grammar({
 
     type_pattern: $ => prec.right(field('type', $.type)),
 
-    list_pattern: $ => seq(
+    list_pattern: $ => prec.right(seq(
       '[',
       optional(seq(
         commaSep1(choice($.pattern, '..')),
         optional(','),
       )),
       ']',
-    ),
+      optional($._variable_designation),
+    )),
 
     recursive_pattern: $ => prec.left(seq(
       optional(field('type', $.type)),
@@ -1197,7 +1199,7 @@ module.exports = grammar({
 
     positional_pattern_clause: $ => prec(1, seq(
       '(',
-      optional(commaSep2($.subpattern)),
+      optional(commaSep($.subpattern)),
       ')',
     )),
 
@@ -1208,10 +1210,15 @@ module.exports = grammar({
       '}',
     )),
 
-    subpattern: $ => seq(
-      optional(seq($.expression, ':')),
+    subpattern: $ => prec.right(seq(
+      optional(
+        choice(
+          seq($.expression, ':'),
+          seq($.identifier, ':'),
+        ),
+      ),
       $.pattern,
-    ),
+    )),
 
     relational_pattern: $ => choice(
       seq('<', $.expression),
@@ -1720,6 +1727,7 @@ module.exports = grammar({
     _with_body: $ => seq(
       '{',
       commaSep($.with_initializer),
+      optional(','),
       '}',
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5690,85 +5690,101 @@
       }
     },
     "list_pattern": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "pattern"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ".."
-                        }
-                      ]
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
                         "members": [
                           {
-                            "type": "STRING",
-                            "value": ","
+                            "type": "SYMBOL",
+                            "name": "pattern"
                           },
                           {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "pattern"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ".."
-                              }
-                            ]
+                            "type": "STRING",
+                            "value": ".."
                           }
                         ]
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "pattern"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": ".."
+                                }
+                              ]
+                            }
+                          ]
+                        }
                       }
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        }
-      ]
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_variable_designation"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "recursive_pattern": {
       "type": "PREC_LEFT",
@@ -5851,27 +5867,35 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "subpattern"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "subpattern"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "subpattern"
+                            }
+                          ]
+                        }
+                      }
+                    ]
                   },
                   {
-                    "type": "REPEAT1",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "subpattern"
-                        }
-                      ]
-                    }
+                    "type": "BLANK"
                   }
                 ]
               },
@@ -5950,34 +5974,56 @@
       }
     },
     "subpattern": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                },
-                {
-                  "type": "STRING",
-                  "value": ":"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "pattern"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ":"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ":"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "pattern"
+          }
+        ]
+      }
     },
     "relational_pattern": {
       "type": "CHOICE",
@@ -9106,6 +9152,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "}"
         }
@@ -11676,6 +11734,10 @@
     [
       "_simple_name",
       "type_parameter"
+    ],
+    [
+      "_simple_name",
+      "subpattern"
     ],
     [
       "tuple_element",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3545,11 +3545,26 @@
   {
     "type": "list_pattern",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "parenthesized_variable_designation",
+          "named": true
+        },
         {
           "type": "pattern",
           "named": true
@@ -5545,6 +5560,10 @@
       "types": [
         {
           "type": "expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
           "named": true
         },
         {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1863,6 +1863,11 @@ void b() {
       2 => "two",
       _ => "more"
   };
+
+  var t = obj.Parent.Parent switch {
+    A(S.G) { Parent: A { Parent: B baseProperty } } => baseProperty.Type,
+    _ => null,
+  };
 }
 
 --------------------------------------------------------------------------------
@@ -1894,7 +1899,44 @@ void b() {
                 (switch_expression_arm
                   (discard)
                   (string_literal
-                    (string_literal_content)))))))))))
+                    (string_literal_content)))))))
+        (local_declaration_statement
+          (variable_declaration
+            type: (implicit_type)
+            (variable_declarator
+              name: (identifier)
+              (switch_expression
+                (member_access_expression
+                  expression: (member_access_expression
+                    expression: (identifier)
+                    name: (identifier))
+                  name: (identifier))
+                (switch_expression_arm
+                  (recursive_pattern
+                    type: (identifier)
+                    (positional_pattern_clause
+                      (subpattern
+                        (type_pattern
+                          type: (qualified_name
+                            qualifier: (identifier)
+                            name: (identifier)))))
+                    (property_pattern_clause
+                      (subpattern
+                        (identifier)
+                        (recursive_pattern
+                          type: (identifier)
+                          (property_pattern_clause
+                            (subpattern
+                              (identifier)
+                              (declaration_pattern
+                                type: (identifier)
+                                name: (identifier))))))))
+                  (member_access_expression
+                    expression: (identifier)
+                    name: (identifier)))
+                (switch_expression_arm
+                  (discard)
+                  (null_literal))))))))))
 
 ================================================================================
 switch expression with trailing comma
@@ -2456,6 +2498,7 @@ var c = s is "test";
 var a = 1 is int.MaxValue;
 var d = a is nameof(a);
 var e = a is (int)b;
+var f = b is A { E: C(S.C) bb } ? bb : null;
 
 --------------------------------------------------------------------------------
 
@@ -2519,7 +2562,32 @@ var e = a is (int)b;
             pattern: (constant_pattern
               (cast_expression
                 type: (predefined_type)
-                value: (identifier)))))))))
+                value: (identifier))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (conditional_expression
+            condition: (is_pattern_expression
+              expression: (identifier)
+              pattern: (recursive_pattern
+                type: (identifier)
+                (property_pattern_clause
+                  (subpattern
+                    (identifier)
+                    (recursive_pattern
+                      type: (identifier)
+                      (positional_pattern_clause
+                        (subpattern
+                          (type_pattern
+                            type: (qualified_name
+                              qualifier: (identifier)
+                              name: (identifier)))))
+                      name: (identifier))))))
+            consequence: (identifier)
+            alternative: (null_literal)))))))
 
 ================================================================================
 Precedence between is operator and conditional_expression
@@ -2638,6 +2706,7 @@ Negated pattern
 ================================================================================
 
 var x = name is not null;
+if (a is not B { E: C(S.E) x }) {}
 
 --------------------------------------------------------------------------------
 
@@ -2652,7 +2721,27 @@ var x = name is not null;
             expression: (identifier)
             pattern: (negated_pattern
               (constant_pattern
-                (null_literal)))))))))
+                (null_literal))))))))
+  (global_statement
+    (if_statement
+      condition: (is_pattern_expression
+        expression: (identifier)
+        pattern: (negated_pattern
+          (recursive_pattern
+            type: (identifier)
+            (property_pattern_clause
+              (subpattern
+                (identifier)
+                (recursive_pattern
+                  type: (identifier)
+                  (positional_pattern_clause
+                    (subpattern
+                      (type_pattern
+                        type: (qualified_name
+                          qualifier: (identifier)
+                          name: (identifier)))))
+                  name: (identifier)))))))
+      consequence: (block))))
 
 ================================================================================
 Parenthesized pattern
@@ -2872,6 +2961,7 @@ List patterns
 ================================================================================
 
 var a = p is [1,2,x,] and [] or [2,..];
+if (aa is [(name: A.B), ..]) { }
 
 --------------------------------------------------------------------------------
 
@@ -2896,7 +2986,21 @@ var a = p is [1,2,x,] and [] or [2,..];
                 right: (list_pattern))
               right: (list_pattern
                 (constant_pattern
-                  (integer_literal))))))))))
+                  (integer_literal)))))))))
+  (global_statement
+    (if_statement
+      condition: (is_pattern_expression
+        expression: (identifier)
+        pattern: (list_pattern
+          (recursive_pattern
+            (positional_pattern_clause
+              (subpattern
+                (identifier)
+                (constant_pattern
+                  (member_access_expression
+                    expression: (identifier)
+                    name: (identifier))))))))
+      consequence: (block))))
 
 ================================================================================
 Conditional expression with member accesses


### PR DESCRIPTION
- Allows single sub pattern in positional pattern clauses.
- Allows variable designation in list patterns.
- Allows name_colon in sub pattern.

Reference:
https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4