### PR TITLE
Re-expose HIGHLIGHTS_QUERY.

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -36,7 +36,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");


### PR DESCRIPTION
It looks like this was exposed in v0.21, but regressed with the release of 0.23.