### PR TITLE
Support bodyless class/struct/record/enum/interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ dist/
 *.tar.gz
 *.tgz
 *.zip
+
+# Build artifacts
+parser.exp
+parser.lib
+bindings/*

--- a/grammar.js
+++ b/grammar.js
@@ -265,7 +265,10 @@ module.exports = grammar({
 
     class_declaration: $ => seq(
       $._class_declaration_initializer,
-      $._optional_semi,
+      choice(
+        seq(field('body', $.declaration_list), $._optional_semi),
+        ';'
+      )
     ),
 
     _class_declaration_initializer: $ => seq(
@@ -275,13 +278,14 @@ module.exports = grammar({
       field('name', $.identifier),
       repeat(choice($.type_parameter_list, $.parameter_list, $.base_list)),
       repeat($.type_parameter_constraints_clause),
-      field('body', $.declaration_list),
     ),
 
     struct_declaration: $ => seq(
       $._struct_declaration_initializer,
-      field('body', $.declaration_list),
-      $._optional_semi,
+      choice(
+        seq(field('body', $.declaration_list), $._optional_semi),
+        ';'
+      )
     ),
 
     _struct_declaration_initializer: $ => seq(
@@ -295,13 +299,19 @@ module.exports = grammar({
     ),
 
     enum_declaration: $ => seq(
+      $._enum_declaration_initializer,
+      choice(
+        seq(field('body', $.enum_member_declaration_list), $._optional_semi),
+        ';'
+      )
+    ),
+    
+    _enum_declaration_initializer: $ => seq(
       repeat($._attribute_list),
       repeat($.modifier),
       'enum',
       field('name', $.identifier),
       optional($.base_list),
-      field('body', $.enum_member_declaration_list),
-      $._optional_semi,
     ),
 
     enum_member_declaration_list: $ => seq(
@@ -322,8 +332,10 @@ module.exports = grammar({
 
     interface_declaration: $ => seq(
       $._interface_declaration_initializer,
-      field('body', $.declaration_list),
-      $._optional_semi,
+      choice(
+        seq(field('body', $.declaration_list), $._optional_semi),
+        ';'
+      )
     ),
 
     _interface_declaration_initializer: $ => seq(
@@ -354,8 +366,10 @@ module.exports = grammar({
 
     record_declaration: $ => seq(
       $._record_declaration_initializer,
-      choice(field('body', $.declaration_list), ';'),
-      $._optional_semi,
+      choice(
+        seq(field('body', $.declaration_list), $._optional_semi),
+        ';'
+      )
     ),
 
     _record_declaration_initializer: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -267,8 +267,8 @@ module.exports = grammar({
       $._class_declaration_initializer,
       choice(
         seq(field('body', $.declaration_list), $._optional_semi),
-        ';'
-      )
+        ';',
+      ),
     ),
 
     _class_declaration_initializer: $ => seq(
@@ -284,8 +284,8 @@ module.exports = grammar({
       $._struct_declaration_initializer,
       choice(
         seq(field('body', $.declaration_list), $._optional_semi),
-        ';'
-      )
+        ';',
+      ),
     ),
 
     _struct_declaration_initializer: $ => seq(
@@ -302,10 +302,10 @@ module.exports = grammar({
       $._enum_declaration_initializer,
       choice(
         seq(field('body', $.enum_member_declaration_list), $._optional_semi),
-        ';'
-      )
+        ';',
+      ),
     ),
-    
+
     _enum_declaration_initializer: $ => seq(
       repeat($._attribute_list),
       repeat($.modifier),
@@ -334,8 +334,8 @@ module.exports = grammar({
       $._interface_declaration_initializer,
       choice(
         seq(field('body', $.declaration_list), $._optional_semi),
-        ';'
-      )
+        ';',
+      ),
     ),
 
     _interface_declaration_initializer: $ => seq(
@@ -368,8 +368,8 @@ module.exports = grammar({
       $._record_declaration_initializer,
       choice(
         seq(field('body', $.declaration_list), $._optional_semi),
-        ';'
-      )
+        ';',
+      ),
     ),
 
     _record_declaration_initializer: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -265,10 +265,7 @@ module.exports = grammar({
 
     class_declaration: $ => seq(
       $._class_declaration_initializer,
-      choice(
-        seq(field('body', $.declaration_list), $._optional_semi),
-        ';',
-      ),
+      $._declaration_list_body,
     ),
 
     _class_declaration_initializer: $ => seq(
@@ -282,10 +279,7 @@ module.exports = grammar({
 
     struct_declaration: $ => seq(
       $._struct_declaration_initializer,
-      choice(
-        seq(field('body', $.declaration_list), $._optional_semi),
-        ';',
-      ),
+      $._declaration_list_body,
     ),
 
     _struct_declaration_initializer: $ => seq(
@@ -332,10 +326,7 @@ module.exports = grammar({
 
     interface_declaration: $ => seq(
       $._interface_declaration_initializer,
-      choice(
-        seq(field('body', $.declaration_list), $._optional_semi),
-        ';',
-      ),
+      $._declaration_list_body,
     ),
 
     _interface_declaration_initializer: $ => seq(
@@ -366,10 +357,7 @@ module.exports = grammar({
 
     record_declaration: $ => seq(
       $._record_declaration_initializer,
-      choice(
-        seq(field('body', $.declaration_list), $._optional_semi),
-        ';',
-      ),
+      $._declaration_list_body,
     ),
 
     _record_declaration_initializer: $ => seq(
@@ -386,6 +374,11 @@ module.exports = grammar({
     record_base: $ => choice(
       seq(':', commaSep1($._name)),
       seq(':', $.primary_constructor_base_type, optional(seq(',', commaSep1($._name)))),
+    ),
+
+    _declaration_list_body: $ => choice(
+      seq(field('body', $.declaration_list), $._optional_semi),
+      ';',
     ),
 
     primary_constructor_base_type: $ => seq(

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "eslint": "^9.14.0",
     "eslint-config-treesitter": "^1.0.2",
-    "tree-sitter-cli": "^0.24.4",
-    "prebuildify": "^6.0.1"
+    "prebuildify": "^6.0.1",
+    "tree-sitter-cli": "^0.24.4"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
     "lint": "eslint grammar.js",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
-    "test": "node --test bindings/node/*_test.js"
-  }
+    "test": "node --test bindings/node/*_test.js",
+    "prebuildify": "prebuildify --napi --strip"
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.c_sharp",
+      "injection-regex": "^c_sharp$"
+    }
+  ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -601,30 +601,8 @@
           "name": "_class_declaration_initializer"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "declaration_list"
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_optional_semi"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_declaration_list_body"
         }
       ]
     },
@@ -694,30 +672,8 @@
           "name": "_struct_declaration_initializer"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "declaration_list"
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_optional_semi"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_declaration_list_body"
         }
       ]
     },
@@ -1008,30 +964,8 @@
           "name": "_interface_declaration_initializer"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "declaration_list"
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_optional_semi"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_declaration_list_body"
         }
       ]
     },
@@ -1192,30 +1126,8 @@
           "name": "_record_declaration_initializer"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "declaration_list"
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_optional_semi"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ";"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_declaration_list_body"
         }
       ]
     },
@@ -1402,6 +1314,32 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "_declaration_list_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "declaration_list"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_optional_semi"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -601,8 +601,30 @@
           "name": "_class_declaration_initializer"
         },
         {
-          "type": "SYMBOL",
-          "name": "_optional_semi"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "declaration_list"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_optional_semi"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
         }
       ]
     },
@@ -661,14 +683,6 @@
             "type": "SYMBOL",
             "name": "type_parameter_constraints_clause"
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "declaration_list"
-          }
         }
       ]
     },
@@ -680,16 +694,30 @@
           "name": "_struct_declaration_initializer"
         },
         {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "declaration_list"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_optional_semi"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "declaration_list"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_optional_semi"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
         }
       ]
     },
@@ -767,6 +795,41 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "SYMBOL",
+          "name": "_enum_declaration_initializer"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "enum_member_declaration_list"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_optional_semi"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
+        }
+      ]
+    },
+    "_enum_declaration_initializer": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
@@ -803,18 +866,6 @@
               "type": "BLANK"
             }
           ]
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "enum_member_declaration_list"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_optional_semi"
         }
       ]
     },
@@ -957,16 +1008,30 @@
           "name": "_interface_declaration_initializer"
         },
         {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "declaration_list"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_optional_semi"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "declaration_list"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_optional_semi"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
         }
       ]
     },
@@ -1130,22 +1195,27 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "declaration_list"
-              }
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "declaration_list"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_optional_semi"
+                }
+              ]
             },
             {
               "type": "STRING",
               "value": ";"
             }
           ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_optional_semi"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1627,7 +1627,7 @@
     "fields": {
       "body": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "declaration_list",
@@ -2312,7 +2312,7 @@
     "fields": {
       "body": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "enum_member_declaration_list",
@@ -3171,7 +3171,7 @@
     "fields": {
       "body": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "declaration_list",
@@ -5481,7 +5481,7 @@
     "fields": {
       "body": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "declaration_list",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -85,6 +85,10 @@ file class A {}
 
 class Baz(int a, int b) : Bar(a, b) { }
 
+public class NoBody;
+
+private class NoBodyPrimary(int a, int b);
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -397,4 +401,20 @@ class Baz(int a, int b) : Bar(a, b) { }
           (identifier))
         (argument
           (identifier))))
-    body: (declaration_list)))
+    body: (declaration_list))
+  (class_declaration
+    (modifier)
+    name: (identifier)
+  )
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    (parameter_list
+      (parameter
+        type: (predefined_type)
+        name: (identifier))
+      (parameter
+        type: (predefined_type)
+        name: (identifier)))
+  ))
+

--- a/test/corpus/enums.txt
+++ b/test/corpus/enums.txt
@@ -4,6 +4,8 @@ global enum with one option
 
 enum A: byte { One, Two = 2, Three = 0x03 }
 
+enum NoBody;
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -19,4 +21,6 @@ enum A: byte { One, Two = 2, Three = 0x03 }
         value: (integer_literal))
       (enum_member_declaration
         name: (identifier)
-        value: (integer_literal)))))
+        value: (integer_literal))))
+(enum_declaration
+  name: (identifier)))

--- a/test/corpus/interfaces.txt
+++ b/test/corpus/interfaces.txt
@@ -42,6 +42,8 @@ public interface IGetNext<T> where T : IGetNext<T>
     static abstract T operator ++(T other);
 }
 
+private interface NoBody;
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -204,4 +206,8 @@ public interface IGetNext<T> where T : IGetNext<T>
         parameters: (parameter_list
           (parameter
             type: (identifier)
-            name: (identifier)))))))
+            name: (identifier))))))
+  (interface_declaration
+    (modifier)
+    name: (identifier)))
+

--- a/test/corpus/records.txt
+++ b/test/corpus/records.txt
@@ -35,6 +35,8 @@ public record Person { };
 
 public record struct Person2 { };
 
+record NoBody;
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -187,4 +189,6 @@ public record struct Person2 { };
   (record_declaration
     (modifier)
     name: (identifier)
-    body: (declaration_list)))
+    body: (declaration_list))
+  (record_declaration
+    name: (identifier)))

--- a/test/corpus/structs.txt
+++ b/test/corpus/structs.txt
@@ -12,6 +12,9 @@ private struct F<T1,T2> where T1 : I1, I2, new() where T2 : I2 { }
 
 ref struct Test { }
 
+struct NoBody;
+
+private struct NoBodyWithPrimary(int g);
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -66,4 +69,13 @@ ref struct Test { }
     body: (declaration_list))
   (struct_declaration
     name: (identifier)
-    body: (declaration_list)))
+    body: (declaration_list))
+  (struct_declaration
+    name: (identifier))
+  (struct_declaration
+    (modifier)
+    name: (identifier)
+    (parameter_list
+      (parameter
+        type: (predefined_type)
+        name: (identifier)))))


### PR DESCRIPTION
Fixes #339

Note: 

- Original issue has `enum()` and `interface()` in list of samples - those are not supported in C# as far as I know (latest VS does not support that syntax either)