### PR TITLE
feat: preprocess entire regions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -116,8 +116,7 @@ module.exports = grammar({
   extras: $ => [
     /[\s\u00A0\uFEFF\u3000]+/,
     $.comment,
-    $.preproc_region,
-    $.preproc_endregion,
+    $.preproc_full_region,
     $.preproc_line,
     $.preproc_pragma,
     $.preproc_nullable,
@@ -1965,13 +1964,11 @@ module.exports = grammar({
       }));
     },
 
-    preproc_region: $ => seq(
+    preproc_full_region: $ => seq(
       preprocessor('region'),
       optional(field('content', $.preproc_arg)),
       /\n/,
-    ),
-
-    preproc_endregion: $ => seq(
+      repeat($.declaration),
       preprocessor('endregion'),
       optional(field('content', $.preproc_arg)),
       /\n/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11121,7 +11121,7 @@
         }
       ]
     },
-    "preproc_region": {
+    "preproc_full_region": {
       "type": "SEQ",
       "members": [
         {
@@ -11152,12 +11152,14 @@
         {
           "type": "PATTERN",
           "value": "\\n"
-        }
-      ]
-    },
-    "preproc_endregion": {
-      "type": "SEQ",
-      "members": [
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "declaration"
+          }
+        },
         {
           "type": "ALIAS",
           "content": {
@@ -11633,11 +11635,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "preproc_region"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "preproc_endregion"
+      "name": "preproc_full_region"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4621,22 +4621,6 @@
     }
   },
   {
-    "type": "preproc_endregion",
-    "named": true,
-    "fields": {
-      "content": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "preproc_arg",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
     "type": "preproc_error",
     "named": true,
     "fields": {},
@@ -4646,6 +4630,32 @@
       "types": [
         {
           "type": "preproc_arg",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "preproc_full_region",
+    "named": true,
+    "fields": {
+      "content": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "preproc_arg",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "declaration",
           "named": true
         }
       ]
@@ -4852,22 +4862,6 @@
           "named": true
         }
       ]
-    }
-  },
-  {
-    "type": "preproc_region",
-    "named": true,
-    "fields": {
-      "content": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "preproc_arg",
-            "named": true
-          }
-        ]
-      }
     }
   },
   {


### PR DESCRIPTION
Hello! First time messing with `tree-sitter`, so apologies if my changes are too drastic.

I've noticed recently while using [nvim-treesitter] that there are no folds for `#region` directives, unlike [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c/blob/master/grammar.js#L1409).

This is due to the fact that the `tree-sitter-c-sharp` parser has no rule that encapsulates the content of the directive alongside itself, only the directives themselves through `preproc_region` and `preproc_endregion`.

If I am meant to implement this rule in [nvim-treesitter], I apologise in advance! Like I mentioned, first time messing with this.

[nvim-treesitter]: https://github.com/nvim-treesitter/nvim-treesitter