### PR TITLE
 fix: add missing typevar to attribute_target_specifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -233,7 +233,7 @@ module.exports = grammar({
     _attribute_list: $ => choice($.attribute_list, $.preproc_if_in_attribute_list),
 
     attribute_target_specifier: _ => seq(
-      choice('field', 'event', 'method', 'param', 'property', 'return', 'type'),
+      choice('field', 'event', 'method', 'param', 'property', 'return', 'type', 'typevar'),
       ':',
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -492,6 +492,10 @@
             {
               "type": "STRING",
               "value": "type"
+            },
+            {
+              "type": "STRING",
+              "value": "typevar"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7027,6 +7027,10 @@
     "named": false
   },
   {
+    "type": "typevar",
+    "named": false
+  },
+  {
     "type": "unchecked",
     "named": false
   },

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -1,5 +1,5 @@
 ================================================================================
-Global attributes
+Attribute targets
 ================================================================================
 
 [assembly: Single]
@@ -17,6 +17,7 @@ Global attributes
     (attribute
       name: (identifier)
       (attribute_argument_list))))
+
 
 ================================================================================
 Attributes
@@ -270,6 +271,90 @@ class Zzz {
               (attribute
                 name: (identifier)))
             body: (block)))))))
+
+================================================================================
+Attribute targets (non-global)
+================================================================================
+
+[type: Obsolete]
+class A<[typevar: B] TC>
+{
+  [field:JsonIgnore]
+  [property: JsonIgnore]
+  public int D { get; set; }
+
+  [method: Obsolete]
+  [return: MaybeNull]
+  public void E([param: AllowNull] int f) { }
+
+  [event: Obsolete]
+  public event EventHandler OnG;
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (attribute_list
+      (attribute_target_specifier)
+      (attribute
+        (identifier)))
+    (identifier)
+    (type_parameter_list
+      (type_parameter
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (identifier)))
+    (declaration_list
+      (property_declaration
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (modifier)
+        (predefined_type)
+        (identifier)
+        (accessor_list
+          (accessor_declaration)
+          (accessor_declaration)))
+      (method_declaration
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (modifier)
+        (predefined_type)
+        (identifier)
+        (parameter_list
+          (parameter
+            (attribute_list
+              (attribute_target_specifier)
+              (attribute
+                (identifier)))
+            (predefined_type)
+            (identifier)))
+        (block))
+      (event_field_declaration
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            (identifier)))
+        (modifier)
+        (variable_declaration
+          (identifier)
+          (variable_declarator
+            (identifier)))))))
+
 
 ================================================================================
 Attribute quirks


### PR DESCRIPTION
Rebase of #352 with added corpus tests to allow "typevar" target for attributes by @sharpchen 