### PR TITLE
Pointer indirection expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -95,8 +95,8 @@ module.exports = grammar({
     [$.using_directive, $.modifier],
     [$.using_directive],
 
-
     [$._constructor_declaration_initializer, $._simple_name],
+    [$.expression, $.assignment_expression],
   ],
 
   externals: $ => [
@@ -1390,10 +1390,12 @@ module.exports = grammar({
       $.expression,
     )),
 
-    _pointer_indirection_expression: $ => prec.right(PREC.UNARY, seq(
-      '*',
-      $.lvalue_expression,
-    )),
+    _pointer_indirection_expression: $ => prec.dynamic(1,
+      prec.right(PREC.UNARY, seq(
+        '*',
+        $.expression,
+      )),
+    ),
 
     query_expression: $ => seq($.from_clause, $._query_body),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7325,20 +7325,24 @@
       }
     },
     "_pointer_indirection_expression": {
-      "type": "PREC_RIGHT",
-      "value": 17,
+      "type": "PREC_DYNAMIC",
+      "value": 1,
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "*"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "lvalue_expression"
-          }
-        ]
+        "type": "PREC_RIGHT",
+        "value": 17,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          ]
+        }
       }
     },
     "query_expression": {
@@ -9109,62 +9113,8 @@
             "value": "with"
           },
           {
-<<<<<<< HEAD
             "type": "SYMBOL",
             "name": "_with_body"
-=======
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "with_initializer"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "with_initializer"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "}"
->>>>>>> b88a7e0 (Accept trailing comma on with_expression)
           }
         ]
       }
@@ -11798,10 +11748,6 @@
       "subpattern"
     ],
     [
-      "_simple_name",
-      "subpattern"
-    ],
-    [
       "tuple_element",
       "type_pattern"
     ],
@@ -11956,6 +11902,10 @@
     [
       "_constructor_declaration_initializer",
       "_simple_name"
+    ],
+    [
+      "expression",
+      "assignment_expression"
     ]
   ],
   "precedences": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11744,6 +11744,10 @@
       "subpattern"
     ],
     [
+      "_simple_name",
+      "subpattern"
+    ],
+    [
       "tuple_element",
       "type_pattern"
     ],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9109,8 +9109,62 @@
             "value": "with"
           },
           {
+<<<<<<< HEAD
             "type": "SYMBOL",
             "name": "_with_body"
+=======
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "with_initializer"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "with_initializer"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+>>>>>>> b88a7e0 (Accept trailing comma on with_expression)
           }
         ]
       }

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,7 +14,6 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
-#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -279,7 +278,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#pragma warning(default : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3574,3 +3574,52 @@ var x = [ y, ];
           (element_binding_expression
             (argument
               (identifier))))))))
+
+================================================================================
+Pointer indirection expressions
+================================================================================
+
+var f = *(A.B*)pointer;
+*ptr = v;
+*(ptr + 1) = v;
+a = *b = 7;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        (implicit_type)
+        (variable_declarator
+          (identifier)
+          (prefix_unary_expression
+            (cast_expression
+              (pointer_type
+                (qualified_name
+                  (identifier)
+                  (identifier)))
+              (identifier)))))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (prefix_unary_expression
+          (identifier))
+        (identifier))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (prefix_unary_expression
+          (parenthesized_expression
+            (binary_expression
+              (identifier)
+              (integer_literal))))
+        (identifier))))
+  (global_statement
+    (expression_statement
+      (assignment_expression
+        (identifier)
+        (assignment_expression
+          (prefix_unary_expression
+            (identifier))
+          (integer_literal))))))


### PR DESCRIPTION
This [PR](https://github.com/tree-sitter/tree-sitter-c-sharp/pull/333/files#diff-919ac210accac9ecc55a76d10a7590e3d85ca3f0e165b52d30f08faee486d0cbL1434) changed `_pointer_indirection_expression` to accept only `lvalue_expression` instead of `expression`. This led to a few parsing issues as described here #363.
This PR changes `_pointer_indirection_expression` back.