### PR TITLE
Add attribute-list support to local-declaration-stmt 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1113,6 +1113,7 @@ module.exports = grammar({
     ),
 
     local_declaration_statement: $ => seq(
+      repeat($._attribute_list),
       optional('await'),
       optional('using'),
       repeat($.modifier),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5414,6 +5414,13 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_attribute_list"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3581,7 +3581,15 @@
       "required": true,
       "types": [
         {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
           "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_attribute_list",
           "named": true
         },
         {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,7 +14,6 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
-#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -279,7 +278,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#pragma warning(default : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
GitLab issue for reference - https://gitlab.com/gitlab-org/gitlab/-/issues/548351 

This PR adds support for attributes on local_declaration_stmt in the C# tree-sitter parser, addressing the limitation where property-level attributes like [BindProperty] were not being captured in the AST.

Example - 

```csharp
[BindProperty]
public string UserInput { get; set; }
```

The parser currently fails to parse attributes on local declaration statements, causing crashes and preventing proper security analysis of ASP.NET applications that use property-level model binding attributes.

Extended the grammar to capture attribute information for local_declaration_stmt, matching the existing implementation for class-level attributes.

