### PR TITLE
Expose TAGS_QUERY

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -39,7 +39,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
+pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
 Expose TAGS_QUERY so the library users can use it directly.