### PR TITLE
feat: add highlighting for unsafe block statement

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -193,6 +193,7 @@
   "init"
   "with"
   "let"
+  "unsafe"
 ] @keyword
 
 ;; Attribute


### PR DESCRIPTION
So far, the `unsafe` keyword is highlighted when it's used as a member modifier, however the highlighting is missing for an unsafe code block

Before:
<img width="382" height="184" alt="image" src="https://github.com/user-attachments/assets/bccf3d65-a62f-4232-ad3f-f9947bdc71f3" />

After:
<img width="378" height="184" alt="image" src="https://github.com/user-attachments/assets/1c990b04-6403-48d4-a350-b868c2e78fcd" />
