### PR TITLE
feat: support null-conditional assignment (C# 14)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -57,6 +57,10 @@ export default grammar({
 
     [$.lvalue_expression, $._name],
     [$.parameter, $.lvalue_expression],
+    // C# 14 null-conditional assignment: `obj?.x = v` requires
+    // `conditional_access_expression` to appear in both lvalue and
+    // non-lvalue contexts. Tree-sitter needs GLR for the decision.
+    [$.lvalue_expression, $.non_lvalue_expression],
 
     [$.type, $.attribute],
     [$.type, $.nullable_type],
@@ -1382,6 +1386,9 @@ export default grammar({
       alias($.bracketed_argument_list, $.element_binding_expression),
       alias($._pointer_indirection_expression, $.prefix_unary_expression),
       alias($._parenthesized_lvalue_expression, $.parenthesized_expression),
+      // C# 14 null-conditional assignment: `obj?.x = v`, `obj?[i] = v`.
+      // https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#null-conditional-assignment
+      $.conditional_access_expression,
     ),
 
     // Covers error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6710,6 +6710,10 @@
           },
           "named": true,
           "value": "parenthesized_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_access_expression"
         }
       ]
     },
@@ -12099,6 +12103,10 @@
     [
       "parameter",
       "lvalue_expression"
+    ],
+    [
+      "lvalue_expression",
+      "non_lvalue_expression"
     ],
     [
       "type",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -138,6 +138,10 @@
     "named": true,
     "subtypes": [
       {
+        "type": "conditional_access_expression",
+        "named": true
+      },
+      {
         "type": "element_access_expression",
         "named": true
       },

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3166,6 +3166,59 @@ if (a?.B != 1) { }
       consequence: (block))))
 
 ================================================================================
+Null-conditional assignment (C# 14)
+================================================================================
+
+class C {
+  void M(D obj) {
+    obj?.field = 5;
+    obj?.list[0] = 1;
+    obj?[key] = val;
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (identifier)
+            name: (identifier)))
+        body: (block
+          (expression_statement
+            (assignment_expression
+              left: (conditional_access_expression
+                condition: (identifier)
+                (member_binding_expression
+                  name: (identifier)))
+              right: (integer_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (element_access_expression
+                expression: (conditional_access_expression
+                  condition: (identifier)
+                  (member_binding_expression
+                    name: (identifier)))
+                subscript: (bracketed_argument_list
+                  (argument
+                    (integer_literal))))
+              right: (integer_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (conditional_access_expression
+                condition: (identifier)
+                (element_binding_expression
+                  (argument
+                    (identifier))))
+              right: (identifier))))))))
+
+================================================================================
 Conditional access expression with simple member access
 ================================================================================
 


### PR DESCRIPTION
## Summary

C# 14 [introduces null-conditional assignment](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#null-conditional-assignment): `obj?.Property = value` and `arr?[i] = value` are now legal lvalues. The expression evaluates the assignment only when the receiver is non-null.

Tree-sitter-c-sharp already parses the access expressions, but they are exposed as `non_lvalue_expression` (via `conditional_access_expression`) so they cannot appear on the left-hand side of `assignment_expression`. This PR adds `conditional_access_expression` to `lvalue_expression` and registers the corresponding conflict so existing parses are preserved.

Part of #392.

## Test plan
- [x] `tree-sitter generate` succeeds with no new conflicts
- [x] `tree-sitter test` — new test passes, all existing tests continue to pass