### PR TITLE
test: pin partial constructors and partial events (C# 14)

### DIFF
--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -432,3 +432,69 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
         (argument
           (identifier))))))
 
+================================================================================
+Partial constructor declarations (C# 14)
+================================================================================
+
+partial class C {
+  public partial C(int x);
+  public partial C(int x) { this.x = x; }
+  public partial C(int x) : base(x);
+  public partial C(int x) : base(x) { }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        body: (block
+          (expression_statement
+            (assignment_expression
+              left: (member_access_expression
+                name: (identifier))
+              right: (identifier)))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        (constructor_initializer
+          (argument_list
+            (argument
+              (identifier)))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        (constructor_initializer
+          (argument_list
+            (argument
+              (identifier))))
+        body: (block)))))
+

--- a/test/corpus/type-events.txt
+++ b/test/corpus/type-events.txt
@@ -65,3 +65,37 @@ class A {
               (invocation_expression
                 function: (identifier)
                 arguments: (argument_list)))))))))
+
+================================================================================
+Partial event declarations (C# 14)
+================================================================================
+
+partial class C {
+  public partial event EventHandler SomeEvent;
+  public partial event EventHandler SomeEvent { add { } remove { } }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (event_field_declaration
+        (modifier)
+        (modifier)
+        (variable_declaration
+          type: (identifier)
+          (variable_declarator
+            name: (identifier))))
+      (event_declaration
+        (modifier)
+        (modifier)
+        type: (identifier)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (block))
+          (accessor_declaration
+            body: (block)))))))


### PR DESCRIPTION
## Summary

C# 14 [allows partial events and partial constructors](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#partial-events-and-constructors): both a defining declaration (no body) and an implementing declaration (with body) can be written in two halves of a partial type.

The existing grammar already accepts these forms because:
- `partial` is in the shared `modifier` choice list, and
- `constructor_declaration` / `event_declaration` / `event_field_declaration` already consume `repeat(modifier)`, and
- `_function_body` already permits a trailing `;` for declarations without a body.

This PR adds corpus tests so the support cannot silently regress, covering:
- `partial constructor;` and `partial constructor : base(x);`
- `partial constructor(...) { ... }` and `partial constructor(...) : base(x) { }`
- `partial event T E;`
- `partial event T E { add { } remove { } }`

Part of #392.

## Test plan
- [x] `tree-sitter test` — both new tests pass, all existing tests continue to pass