### PR TITLE
test: pin field-backed properties with `field` contextual keyword (C# 14)

### DIFF
--- a/test/corpus/type-properties.txt
+++ b/test/corpus/type-properties.txt
@@ -158,3 +158,115 @@ class Foo: IFoo {
         accessors: (accessor_list
           (accessor_declaration)
           (accessor_declaration))))))
+
+================================================================================
+Field-backed properties with `field` contextual keyword (C# 14)
+================================================================================
+
+class C {
+  public string Name { get; set => field = value; }
+  public string Tagged { get => field ?? "default"; set; }
+  public string Lazy => field ??= Compute();
+  public string Lazy2 { get => field ??= Compute(); }
+  public int Counter { get { return field; } set { field = value; } }
+  [field: Xyz]
+  public string Decorated => field ??= Compute();
+  public bool IsActive { get; set => Set(ref field, value); } = true;
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration)
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (assignment_expression
+                left: (identifier)
+                right: (identifier))))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (binary_expression
+                left: (identifier)
+                right: (string_literal
+                  (string_literal_content)))))
+          (accessor_declaration)))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        value: (arrow_expression_clause
+          (assignment_expression
+            left: (identifier)
+            right: (invocation_expression
+              function: (identifier)
+              arguments: (argument_list)))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (assignment_expression
+                left: (identifier)
+                right: (invocation_expression
+                  function: (identifier)
+                  arguments: (argument_list)))))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (block
+              (return_statement
+                (identifier))))
+          (accessor_declaration
+            body: (block
+              (expression_statement
+                (assignment_expression
+                  left: (identifier)
+                  right: (identifier)))))))
+      (property_declaration
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            name: (identifier)))
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        value: (arrow_expression_clause
+          (assignment_expression
+            left: (identifier)
+            right: (invocation_expression
+              function: (identifier)
+              arguments: (argument_list)))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration)
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (invocation_expression
+                function: (identifier)
+                arguments: (argument_list
+                  (argument
+                    (identifier))
+                  (argument
+                    (identifier)))))))
+        value: (boolean_literal)))))


### PR DESCRIPTION
## Summary

C# 14 [introduces the `field` contextual keyword](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-14.0/field-keyword) to refer to the auto-generated backing field inside property accessor bodies, and permits a property to **mix an auto-accessor with a full accessor**:

```csharp
{ get; set => field = value?.Trim(); }
{ get => field ?? "default"; set; }
Lazy => field ??= Compute();
[field: Xyz] public string D => field ??= Compute();
IsActive { get; set => Set(ref field, value); } = true;
```

Per the spec, `field` is a contextual keyword (a primary expression inside property accessor bodies), not a reserved word. Tree-sitter's existing identifier rule and `accessor_declaration` / `property_declaration` rules already accept every example in the proposal — disambiguating `field`-as-backing-field vs `field`-as-local is a semantic concern. This PR adds a corpus test so the syntactic coverage cannot regress.

Part of #392.

## Test plan
- [x] `tree-sitter test` — new test passes, all existing tests continue to pass