### PR TITLE
feat: C# 14 extension declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -105,6 +105,12 @@ export default grammar({
     [$.using_directive],
 
     [$._constructor_declaration_initializer, $._simple_name],
+
+    // For C# 14 extension declarations: `extension(scoped X x)` —
+    // `scoped` can be a parameter modifier, a scoped_type, or a
+    // reserved identifier (when there's no further type). Keep all
+    // three alive until later tokens disambiguate.
+    [$.receiver_parameter, $.scoped_type, $._reserved_identifier],
   ],
 
   externals: $ => [
@@ -519,6 +525,53 @@ export default grammar({
       $.property_declaration,
       $.using_directive,
       $.preproc_if,
+      $.extension_declaration,
+    ),
+
+    // C# 14: extension declarations introduce extension methods, properties,
+    // and operators with a shared receiver inside a non-generic static class.
+    // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-14.0/extensions
+    //
+    //   extension_declaration:
+    //     'extension' type_parameter_list? '(' receiver_parameter ')'
+    //         type_parameter_constraints_clause* extension_body
+    //   extension_body: '{' extension_member_declaration* '}' ';'?
+    //   extension_member_declaration:
+    //     method_declaration | property_declaration | operator_declaration
+    //   receiver_parameter: attributes? parameter_modifiers? type identifier?
+    //
+    // `extension` is contextual; it is recognized as the start of an
+    // extension declaration when followed by `<` or `(` in declaration
+    // position. Use prec.dynamic so an identifier named `extension` in
+    // other positions still parses.
+    extension_declaration: $ => prec.dynamic(1, seq(
+      repeat($._attribute_list),
+      'extension',
+      optional($.type_parameter_list),
+      '(',
+      $.receiver_parameter,
+      ')',
+      repeat($.type_parameter_constraints_clause),
+      $.extension_body,
+    )),
+
+    receiver_parameter: $ => seq(
+      repeat($._attribute_list),
+      $._parameter_type_with_modifiers,
+      optional(field('name', $.identifier)),
+    ),
+
+    extension_body: $ => seq(
+      '{',
+      repeat($._extension_member_declaration),
+      '}',
+      optional(';'),
+    ),
+
+    _extension_member_declaration: $ => choice(
+      $.method_declaration,
+      $.property_declaration,
+      $.operator_declaration,
     ),
 
     field_declaration: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2055,6 +2055,146 @@
         {
           "type": "SYMBOL",
           "name": "preproc_if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "extension_declaration"
+        }
+      ]
+    },
+    "extension_declaration": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_attribute_list"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "extension"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "SYMBOL",
+            "name": "receiver_parameter"
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "type_parameter_constraints_clause"
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "extension_body"
+          }
+        ]
+      }
+    },
+    "receiver_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_attribute_list"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_parameter_type_with_modifiers"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "extension_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_extension_member_declaration"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_extension_member_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "method_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "property_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator_declaration"
         }
       ]
     },
@@ -12254,6 +12394,11 @@
     [
       "_constructor_declaration_initializer",
       "_simple_name"
+    ],
+    [
+      "receiver_parameter",
+      "scoped_type",
+      "_reserved_identifier"
     ]
   ],
   "precedences": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,6 +36,10 @@
         "named": true
       },
       {
+        "type": "extension_declaration",
+        "named": true
+      },
+      {
         "type": "field_declaration",
         "named": true
       },
@@ -2615,6 +2619,64 @@
         },
         {
           "type": "prefix_unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extension_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "method_declaration",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        },
+        {
+          "type": "property_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extension_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "extension_body",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_attribute_list",
+          "named": true
+        },
+        {
+          "type": "receiver_parameter",
+          "named": true
+        },
+        {
+          "type": "type_parameter_constraints_clause",
+          "named": true
+        },
+        {
+          "type": "type_parameter_list",
           "named": true
         }
       ]
@@ -5265,6 +5327,50 @@
     }
   },
   {
+    "type": "receiver_parameter",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_attribute_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "record_declaration",
     "named": true,
     "fields": {
@@ -6812,6 +6918,10 @@
   },
   {
     "type": "explicit",
+    "named": false
+  },
+  {
+    "type": "extension",
     "named": false
   },
   {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -52,96 +52,67 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
-  )
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self)                           \
-  do {                                               \
-    if ((self)->contents) ts_free((self)->contents); \
-    (self)->contents = NULL;                         \
-    (self)->size = 0;                                \
-    (self)->capacity = 0;                            \
-  } while (0)
+#define array_delete(self) _array__delete((Array *)(self))
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                                 \
-  do {                                                            \
-    (self)->contents = _array__grow(                              \
-      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
-      1, array_elem_size(self)                                    \
-    );                                                            \
-   (self)->contents[(self)->size++] = (element);                  \
-  } while(0)
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count)                                               \
-  do {                                                                           \
-    if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
-      (self)->contents, (self)->size, &(self)->capacity,                         \
-      count, array_elem_size(self)                                               \
-    );                                                                           \
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count);                                                     \
+    (self)->size += (count); \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other) \
+#define array_push_all(self, other)                                       \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
-    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
-    array_elem_size(self), (self)->size, 0, count, other_contents \
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
-    array_elem_size(self), _index, old_count, new_count, new_contents  \
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
-    array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
+  _array__erase((Array *)(self), array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
-    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
 
 /// Swap one array with another
-#define array_swap(self, other)                                     \
-  do {                                                              \
-    void *_array_swap_tmp = (void *)(self)->contents;               \
-    (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
-    _array__swap(&(self)->size, &(self)->capacity,                  \
-                 &(other)->size, &(other)->capacity);               \
-  } while (0)
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -186,90 +157,82 @@ extern "C" {
 
 // Private
 
-// Pointers to individual `Array` fields (rather than the entire `Array` itself)
-// are passed to the various `_array__*` functions below to address strict aliasing
-// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
-//
-// The `Array` type itself was not altered as a solution in order to avoid breakage
-// with existing consumers (in particular, parsers with external scanners).
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(void* self_contents, uint32_t *size,
-                                size_t element_size, uint32_t index) {
-  assert(index < *size);
-  char *contents = (char *)self_contents;
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (*size - index - 1) * element_size);
-  (*size)--;
+          (self->size - index - 1) * element_size);
+  self->size--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void *_array__reserve(void *contents, uint32_t *capacity,
-                                  size_t element_size, uint32_t new_capacity) {
-  void *new_contents = contents;
-  if (new_capacity > *capacity) {
-    if (contents) {
-      new_contents = ts_realloc(contents, new_capacity * element_size);
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
     } else {
-      new_contents = ts_malloc(new_capacity * element_size);
+      self->contents = ts_malloc(new_capacity * element_size);
     }
-    *capacity = new_capacity;
+    self->capacity = new_capacity;
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
-                                 const void *other_contents, uint32_t other_size, size_t element_size) {
-  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
-  *self_size = other_size;
-  memcpy(new_contents, other_contents, *self_size * element_size);
-  return new_contents;
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
-                               uint32_t *other_size, uint32_t *other_capacity) {
-  uint32_t tmp_size = *self_size;
-  uint32_t tmp_capacity = *self_capacity;
-  *self_size = *other_size;
-  *self_capacity = *other_capacity;
-  *other_size = tmp_size;
-  *other_capacity = tmp_capacity;
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
-                               uint32_t count, size_t element_size) {
-  void *new_contents = contents;
-  uint32_t new_size = size + count;
-  if (new_size > *capacity) {
-    uint32_t new_capacity = *capacity * 2;
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
+    _array__reserve(self, element_size, new_capacity);
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
-                                 size_t element_size,
+static inline void _array__splice(Array *self, size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = *size + new_count - old_count;
+  uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= *size);
+  assert(old_end <= self->size);
 
-  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
+  _array__reserve(self, element_size, new_size);
 
-  char *contents = (char *)new_contents;
-  if (*size > old_end) {
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (*size - old_end) * element_size
+      (self->size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -287,9 +250,7 @@ static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t
       );
     }
   }
-  *size += new_count - old_count;
-
-  return new_contents;
+  self->size += new_count - old_count;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -432,3 +432,151 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
         (argument
           (identifier))))))
 
+
+================================================================================
+Extension declarations (C# 14)
+================================================================================
+
+public static class E
+{
+    extension(IEnumerable source)
+    {
+        public bool IsEmpty => !source.Any();
+    }
+
+    extension<T>(IEnumerable<T> source)
+    {
+        public IEnumerable<T> Where(Func<T, bool> p) => null;
+    }
+
+    extension<T>(IEnumerable<T>)
+        where T : INumber<T>
+    {
+        public static IEnumerable<T> operator +(IEnumerable<T> a, IEnumerable<T> b) => null;
+        public static IEnumerable<T> Identity => null;
+    }
+
+    extension<T>(ref readonly T source)
+    {
+        public T Echo() => source;
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (extension_declaration
+        (receiver_parameter
+          type: (identifier)
+          name: (identifier))
+        (extension_body
+          (property_declaration
+            (modifier)
+            type: (predefined_type)
+            name: (identifier)
+            value: (arrow_expression_clause
+              (prefix_unary_expression
+                (invocation_expression
+                  function: (member_access_expression
+                    expression: (identifier)
+                    name: (identifier))
+                  arguments: (argument_list)))))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          type: (generic_name
+            (identifier)
+            (type_argument_list
+              (identifier)))
+          name: (identifier))
+        (extension_body
+          (method_declaration
+            (modifier)
+            returns: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            name: (identifier)
+            parameters: (parameter_list
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)
+                    (predefined_type)))
+                name: (identifier)))
+            body: (arrow_expression_clause
+              (null_literal)))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          type: (generic_name
+            (identifier)
+            (type_argument_list
+              (identifier))))
+        (type_parameter_constraints_clause
+          (identifier)
+          (type_parameter_constraint
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))))
+        (extension_body
+          (operator_declaration
+            (modifier)
+            (modifier)
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            parameters: (parameter_list
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)))
+                name: (identifier))
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)))
+                name: (identifier)))
+            body: (arrow_expression_clause
+              (null_literal)))
+          (property_declaration
+            (modifier)
+            (modifier)
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            name: (identifier)
+            value: (arrow_expression_clause
+              (null_literal)))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          (modifier)
+          (modifier)
+          type: (identifier)
+          name: (identifier))
+        (extension_body
+          (method_declaration
+            (modifier)
+            returns: (identifier)
+            name: (identifier)
+            parameters: (parameter_list)
+            body: (arrow_expression_clause
+              (identifier))))))))


### PR DESCRIPTION
## Summary

C# 14 introduces a [new `extension` declaration form](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-14.0/extensions) for declaring extension methods, properties, and operators with a shared receiver inside a non-generic static class:

\`\`\`csharp
public static class Enumerable
{
    extension<T>(IEnumerable<T> source)
    {
        public bool IsEmpty => !source.Any();
        public IEnumerable<T> Where(Func<T, bool> p) => ...;
    }

    extension<T>(IEnumerable<T>) where T : INumber<T>
    {
        public static IEnumerable<T> operator +(IEnumerable<T> a, IEnumerable<T> b) => ...;
        public static IEnumerable<T> Identity => ...;
    }
}
\`\`\`

This PR adds a new \`extension_declaration\` node and wires it into the \`declaration\` choice so it can appear in class bodies. Per the proposal grammar:

\`\`\`antlr
extension_declaration:
    'extension' type_parameter_list? '(' receiver_parameter ')'
    type_parameter_constraints_clause* extension_body
extension_body: '{' extension_member_declaration* '}' ';'?
extension_member_declaration:
    method_declaration | property_declaration | operator_declaration
receiver_parameter: attributes? parameter_modifiers? type identifier?
\`\`\`

\`extension\` is a contextual keyword — it is recognized as the start of an extension declaration only when followed by an optional type parameter list and a parenthesized receiver in class-member position. \`prec.dynamic\` biases ambiguous parses toward the declaration form when the context fits, so an identifier named \`extension\` in other positions still parses as a regular identifier.

One new conflict is registered (\`[receiver_parameter, scoped_type, _reserved_identifier]\`) to keep the parameter-modifier, scoped-type, and reserved-identifier interpretations of \`scoped\` alive inside a receiver until later tokens disambiguate.

Part of #392.

## Test plan
- [x] \`tree-sitter generate\` succeeds with one new conflict declared
- [x] \`tree-sitter test\` — new test passes, all existing tests continue to pass