### PR TITLE
feat: C# 14 language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ C# grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter) based u
 
 ### Status
 
-Comprehensive supports C# 1 through 13.0 with the following exception:
+Comprehensive supports C# 1 through 14.0 with the following exceptions:
 
 - [ ] `async`, `var` and `await` cannot be used as identifiers everywhere they are valid
+- [ ] File-based apps preprocessor directives (`#:property`, `#:package`, `#:sdk`, `#:project`) are not yet recognized
 
 ### References
 

--- a/grammar.js
+++ b/grammar.js
@@ -57,6 +57,10 @@ export default grammar({
 
     [$.lvalue_expression, $._name],
     [$.parameter, $.lvalue_expression],
+    // C# 14 null-conditional assignment: `obj?.x = v` requires
+    // `conditional_access_expression` to appear in both lvalue and
+    // non-lvalue contexts. Tree-sitter needs GLR for the decision.
+    [$.lvalue_expression, $.non_lvalue_expression],
 
     [$.type, $.attribute],
     [$.type, $.nullable_type],
@@ -1395,6 +1399,9 @@ export default grammar({
       alias($.bracketed_argument_list, $.element_binding_expression),
       alias($._pointer_indirection_expression, $.prefix_unary_expression),
       alias($._parenthesized_lvalue_expression, $.parenthesized_expression),
+      // C# 14 null-conditional assignment: `obj?.x = v`, `obj?[i] = v`.
+      // https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#null-conditional-assignment
+      $.conditional_access_expression,
     ),
 
     // Covers error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement

--- a/grammar.js
+++ b/grammar.js
@@ -109,6 +109,12 @@ export default grammar({
     [$.using_directive],
 
     [$._constructor_declaration_initializer, $._simple_name],
+
+    // For C# 14 extension declarations: `extension(scoped X x)` —
+    // `scoped` can be a parameter modifier, a scoped_type, or a
+    // reserved identifier (when there's no further type). Keep all
+    // three alive until later tokens disambiguate.
+    [$.receiver_parameter, $.scoped_type, $._reserved_identifier],
   ],
 
   externals: $ => [
@@ -535,6 +541,53 @@ export default grammar({
       $.property_declaration,
       $.using_directive,
       $.preproc_if,
+      $.extension_declaration,
+    ),
+
+    // C# 14: extension declarations introduce extension methods, properties,
+    // and operators with a shared receiver inside a non-generic static class.
+    // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-14.0/extensions
+    //
+    //   extension_declaration:
+    //     'extension' type_parameter_list? '(' receiver_parameter ')'
+    //         type_parameter_constraints_clause* extension_body
+    //   extension_body: '{' extension_member_declaration* '}' ';'?
+    //   extension_member_declaration:
+    //     method_declaration | property_declaration | operator_declaration
+    //   receiver_parameter: attributes? parameter_modifiers? type identifier?
+    //
+    // `extension` is contextual; it is recognized as the start of an
+    // extension declaration when followed by `<` or `(` in declaration
+    // position. Use prec.dynamic so an identifier named `extension` in
+    // other positions still parses.
+    extension_declaration: $ => prec.dynamic(1, seq(
+      repeat($._attribute_list),
+      'extension',
+      optional($.type_parameter_list),
+      '(',
+      $.receiver_parameter,
+      ')',
+      repeat($.type_parameter_constraints_clause),
+      $.extension_body,
+    )),
+
+    receiver_parameter: $ => seq(
+      repeat($._attribute_list),
+      $._parameter_type_with_modifiers,
+      optional(field('name', $.identifier)),
+    ),
+
+    extension_body: $ => seq(
+      '{',
+      repeat($._extension_member_declaration),
+      '}',
+      optional(';'),
+    ),
+
+    _extension_member_declaration: $ => choice(
+      $.method_declaration,
+      $.property_declaration,
+      $.operator_declaration,
     ),
 
     field_declaration: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -130,6 +130,10 @@ export default grammar({
     $.raw_string_start,
     $.raw_string_end,
     $.raw_string_content,
+    // C# 14: emitted by the scanner at '(' when forward-scanning shows a
+    // simple-lambda parameter list (at least one element has a parameter
+    // modifier) closed by ')=>'.
+    $._lambda_paren_open,
   ],
 
   extras: $ => [
@@ -1802,7 +1806,31 @@ export default grammar({
     _lambda_parameters: $ => prec(-1, choice(
       $.parameter_list,
       alias($.identifier, $.implicit_parameter),
+      // C# 14: `(ref x) => x`, `(out y) => ...`, `(text, out result) => ...`
+      // The opening '(' is recognized via the external _lambda_paren_open
+      // token, which the scanner only emits when it can confirm a closing
+      // ')=>' follows a parameter list containing at least one modifier.
+      $._implicit_parameter_list_with_modifiers,
     )),
+
+    // C# 14 simple-lambda parameter list with modifiers. Each element is
+    // either a bare identifier or one or more modifiers (scoped/ref/out/in/
+    // readonly) followed by an identifier. The opening token is the
+    // external _lambda_paren_open; the closing ')' is the regular literal.
+    _implicit_parameter_list_with_modifiers: $ => seq(
+      $._lambda_paren_open,
+      commaSep1(choice(
+        seq(
+          repeat1(alias(
+            choice('scoped', 'ref', 'out', 'in', 'readonly'),
+            $.modifier,
+          )),
+          alias($.identifier, $.implicit_parameter),
+        ),
+        alias($.identifier, $.implicit_parameter),
+      )),
+      ')',
+    ),
 
     array_creation_expression: $ => prec.dynamic(PREC.UNARY, seq(
       'new',

--- a/grammar.js
+++ b/grammar.js
@@ -480,6 +480,13 @@ export default grammar({
         '==', '!=',
         '>', '<',
         '>=', '<=',
+        // C# 14: user-defined compound assignment operators.
+        // https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#user-defined-compound-assignment-operators
+        '+=', '-=',
+        '*=', '/=',
+        '%=', '^=',
+        '|=', '&=',
+        '<<=', '>>=', '>>>=',
       )),
       field('parameters', $.parameter_list),
       $._function_body,

--- a/grammar.js
+++ b/grammar.js
@@ -240,10 +240,15 @@ export default grammar({
 
     _attribute_list: $ => choice($.attribute_list, $.preproc_if_in_attribute_list),
 
-    attribute_target_specifier: _ => seq(
+    // Higher precedence than `_reserved_identifier`: when both interpretations
+    // are valid (e.g. `[field :` could be `_reserved_identifier` followed by
+    // bogus `:`, or `attribute_target_specifier`), prefer the target-specifier
+    // reading. `_reserved_identifier` still wins when no `:` follows, so
+    // `[field]` continues to parse as collection_expression with identifier.
+    attribute_target_specifier: _ => prec(1, seq(
       choice('field', 'event', 'method', 'param', 'property', 'return', 'type', 'typevar'),
       ':',
-    ),
+    )),
 
     _namespace_member_declaration: $ => choice(
       $.namespace_declaration,
@@ -1216,11 +1221,19 @@ export default grammar({
     list_pattern: $ => prec.right(seq(
       '[',
       optional(seq(
-        commaSep1(choice($.pattern, '..')),
+        commaSep1(choice($.pattern, $.slice_pattern)),
         optional(','),
       )),
       ']',
       optional($._variable_designation),
+    )),
+
+    // C# 11 slice pattern: `..` optionally followed by a subpattern that
+    // binds the captured slice. `[a, .. var rest, z]`, `[..]` (bare),
+    // `[.. List<int> rest]` (declaration_pattern), etc.
+    slice_pattern: $ => prec.right(seq(
+      '..',
+      optional($.pattern),
     )),
 
     recursive_pattern: $ => prec.left(choice(
@@ -1992,6 +2005,14 @@ export default grammar({
       'by',
       'descending',
       'equals',
+      // attribute_target_specifier keywords — contextual only when followed
+      // by `:` in `[target: Attr]` position. Anywhere else they're
+      // identifiers. Without listing them here the LR table preferred the
+      // literal-keyword interpretation, breaking `[type]`, `[field]`, etc.
+      // as collection_expression elements. Excludes `'event'` and `'return'`
+      // from the attribute_target_specifier choice — those are real C#
+      // keywords and must not be accepted as identifiers anywhere else.
+      'field',
       'file',
       'from',
       'global',
@@ -1999,11 +2020,16 @@ export default grammar({
       'into',
       'join',
       'let',
+      'method',
       'notnull',
       'on',
       'orderby',
+      'param',
+      'property',
       'scoped',
       'select',
+      'type',
+      'typevar',
       'unmanaged',
       'var',
       'when',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1871,6 +1871,50 @@
               {
                 "type": "STRING",
                 "value": "<="
+              },
+              {
+                "type": "STRING",
+                "value": "+="
+              },
+              {
+                "type": "STRING",
+                "value": "-="
+              },
+              {
+                "type": "STRING",
+                "value": "*="
+              },
+              {
+                "type": "STRING",
+                "value": "/="
+              },
+              {
+                "type": "STRING",
+                "value": "%="
+              },
+              {
+                "type": "STRING",
+                "value": "^="
+              },
+              {
+                "type": "STRING",
+                "value": "|="
+              },
+              {
+                "type": "STRING",
+                "value": "&="
+              },
+              {
+                "type": "STRING",
+                "value": "<<="
+              },
+              {
+                "type": "STRING",
+                "value": ">>="
+              },
+              {
+                "type": "STRING",
+                "value": ">>>="
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -468,50 +468,54 @@
       ]
     },
     "attribute_target_specifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "field"
-            },
-            {
-              "type": "STRING",
-              "value": "event"
-            },
-            {
-              "type": "STRING",
-              "value": "method"
-            },
-            {
-              "type": "STRING",
-              "value": "param"
-            },
-            {
-              "type": "STRING",
-              "value": "property"
-            },
-            {
-              "type": "STRING",
-              "value": "return"
-            },
-            {
-              "type": "STRING",
-              "value": "type"
-            },
-            {
-              "type": "STRING",
-              "value": "typevar"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "field"
+              },
+              {
+                "type": "STRING",
+                "value": "event"
+              },
+              {
+                "type": "STRING",
+                "value": "method"
+              },
+              {
+                "type": "STRING",
+                "value": "param"
+              },
+              {
+                "type": "STRING",
+                "value": "property"
+              },
+              {
+                "type": "STRING",
+                "value": "return"
+              },
+              {
+                "type": "STRING",
+                "value": "type"
+              },
+              {
+                "type": "STRING",
+                "value": "typevar"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          }
+        ]
+      }
     },
     "_namespace_member_declaration": {
       "type": "CHOICE",
@@ -5838,8 +5842,8 @@
                             "name": "pattern"
                           },
                           {
-                            "type": "STRING",
-                            "value": ".."
+                            "type": "SYMBOL",
+                            "name": "slice_pattern"
                           }
                         ]
                       },
@@ -5860,8 +5864,8 @@
                                   "name": "pattern"
                                 },
                                 {
-                                  "type": "STRING",
-                                  "value": ".."
+                                  "type": "SYMBOL",
+                                  "name": "slice_pattern"
                                 }
                               ]
                             }
@@ -5899,6 +5903,31 @@
               {
                 "type": "SYMBOL",
                 "name": "_variable_designation"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "slice_pattern": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": ".."
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "pattern"
               },
               {
                 "type": "BLANK"
@@ -10264,6 +10293,10 @@
         },
         {
           "type": "STRING",
+          "value": "field"
+        },
+        {
+          "type": "STRING",
           "value": "file"
         },
         {
@@ -10292,6 +10325,10 @@
         },
         {
           "type": "STRING",
+          "value": "method"
+        },
+        {
+          "type": "STRING",
           "value": "notnull"
         },
         {
@@ -10304,11 +10341,27 @@
         },
         {
           "type": "STRING",
+          "value": "param"
+        },
+        {
+          "type": "STRING",
+          "value": "property"
+        },
+        {
+          "type": "STRING",
           "value": "scoped"
         },
         {
           "type": "STRING",
           "value": "select"
+        },
+        {
+          "type": "STRING",
+          "value": "type"
+        },
+        {
+          "type": "STRING",
+          "value": "typevar"
         },
         {
           "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9178,9 +9178,165 @@
             },
             "named": true,
             "value": "implicit_parameter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_implicit_parameter_list_with_modifiers"
           }
         ]
       }
+    },
+    "_implicit_parameter_list_with_modifiers": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_lambda_paren_open"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "scoped"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "ref"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "out"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "in"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "readonly"
+                            }
+                          ]
+                        },
+                        "named": true,
+                        "value": "modifier"
+                      }
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      "named": true,
+                      "value": "implicit_parameter"
+                    }
+                  ]
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  "named": true,
+                  "value": "implicit_parameter"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "scoped"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "ref"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "out"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "in"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "readonly"
+                                  }
+                                ]
+                              },
+                              "named": true,
+                              "value": "modifier"
+                            }
+                          },
+                          {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "identifier"
+                            },
+                            "named": true,
+                            "value": "implicit_parameter"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        "named": true,
+                        "value": "implicit_parameter"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
     },
     "array_creation_expression": {
       "type": "PREC_DYNAMIC",
@@ -12576,6 +12732,10 @@
     {
       "type": "SYMBOL",
       "name": "raw_string_content"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_lambda_paren_open"
     }
   ],
   "inline": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2103,6 +2103,146 @@
         {
           "type": "SYMBOL",
           "name": "preproc_if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "extension_declaration"
+        }
+      ]
+    },
+    "extension_declaration": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_attribute_list"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "extension"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "SYMBOL",
+            "name": "receiver_parameter"
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "type_parameter_constraints_clause"
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "extension_body"
+          }
+        ]
+      }
+    },
+    "receiver_parameter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_attribute_list"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_parameter_type_with_modifiers"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "name",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "extension_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_extension_member_declaration"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ";"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_extension_member_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "method_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "property_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator_declaration"
         }
       ]
     },
@@ -12359,6 +12499,11 @@
     [
       "_constructor_declaration_initializer",
       "_simple_name"
+    ],
+    [
+      "receiver_parameter",
+      "scoped_type",
+      "_reserved_identifier"
     ]
   ],
   "precedences": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6710,6 +6710,10 @@
           },
           "named": true,
           "value": "parenthesized_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_access_expression"
         }
       ]
     },
@@ -12099,6 +12103,10 @@
     [
       "parameter",
       "lvalue_expression"
+    ],
+    [
+      "lvalue_expression",
+      "non_lvalue_expression"
     ],
     [
       "type",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -138,6 +138,10 @@
     "named": true,
     "subtypes": [
       {
+        "type": "conditional_access_expression",
+        "named": true
+      },
+      {
         "type": "element_access_expression",
         "named": true
       },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3668,6 +3668,10 @@
         {
           "type": "pattern",
           "named": true
+        },
+        {
+          "type": "slice_pattern",
+          "named": true
         }
       ]
     }
@@ -5539,6 +5543,21 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "slice_pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "pattern",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4136,11 +4136,23 @@
             "named": false
           },
           {
+            "type": "%=",
+            "named": false
+          },
+          {
             "type": "&",
             "named": false
           },
           {
+            "type": "&=",
+            "named": false
+          },
+          {
             "type": "*",
+            "named": false
+          },
+          {
+            "type": "*=",
             "named": false
           },
           {
@@ -4152,6 +4164,10 @@
             "named": false
           },
           {
+            "type": "+=",
+            "named": false
+          },
+          {
             "type": "-",
             "named": false
           },
@@ -4160,7 +4176,15 @@
             "named": false
           },
           {
+            "type": "-=",
+            "named": false
+          },
+          {
             "type": "/",
+            "named": false
+          },
+          {
+            "type": "/=",
             "named": false
           },
           {
@@ -4169,6 +4193,10 @@
           },
           {
             "type": "<<",
+            "named": false
+          },
+          {
+            "type": "<<=",
             "named": false
           },
           {
@@ -4192,11 +4220,23 @@
             "named": false
           },
           {
+            "type": ">>=",
+            "named": false
+          },
+          {
             "type": ">>>",
             "named": false
           },
           {
+            "type": ">>>=",
+            "named": false
+          },
+          {
             "type": "^",
+            "named": false
+          },
+          {
+            "type": "^=",
             "named": false
           },
           {
@@ -4209,6 +4249,10 @@
           },
           {
             "type": "|",
+            "named": false
+          },
+          {
+            "type": "|=",
             "named": false
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3642,11 +3642,23 @@
         ]
       },
       "parameters": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
             "type": "implicit_parameter",
+            "named": true
+          },
+          {
+            "type": "modifier",
             "named": true
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -36,6 +36,10 @@
         "named": true
       },
       {
+        "type": "extension_declaration",
+        "named": true
+      },
+      {
         "type": "field_declaration",
         "named": true
       },
@@ -2619,6 +2623,64 @@
         },
         {
           "type": "prefix_unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extension_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "method_declaration",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        },
+        {
+          "type": "property_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extension_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "extension_body",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_attribute_list",
+          "named": true
+        },
+        {
+          "type": "receiver_parameter",
+          "named": true
+        },
+        {
+          "type": "type_parameter_constraints_clause",
+          "named": true
+        },
+        {
+          "type": "type_parameter_list",
           "named": true
         }
       ]
@@ -5317,6 +5379,50 @@
     }
   },
   {
+    "type": "receiver_parameter",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_list",
+          "named": true
+        },
+        {
+          "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "preproc_if_in_attribute_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "record_declaration",
     "named": true,
     "fields": {
@@ -6879,6 +6985,10 @@
   },
   {
     "type": "explicit",
+    "named": false
+  },
+  {
+    "type": "extension",
     "named": false
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,6 +2,7 @@
 #include "tree_sitter/array.h"
 #include "tree_sitter/parser.h"
 
+#include <string.h>
 #include <wctype.h>
 
 enum TokenType {
@@ -17,6 +18,7 @@ enum TokenType {
     RAW_STRING_START,
     RAW_STRING_END,
     RAW_STRING_CONTENT,
+    LAMBDA_PAREN_OPEN,
 };
 
 typedef enum {
@@ -46,6 +48,71 @@ typedef struct {
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
 static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+// ---- Helpers for LAMBDA_PAREN_OPEN scanning ---------------------------
+
+static inline bool is_id_start(int32_t c) {
+    return c == '_' || iswalpha(c);
+}
+
+static inline bool is_id_continue(int32_t c) {
+    return c == '_' || iswalnum(c);
+}
+
+// Skip whitespace, line comments (//...), and block comments (/* ... */).
+// Does NOT skip preprocessor directives — simple-lambda parameter lists
+// cannot legally contain them.
+static void skip_ws_and_comments(TSLexer *lexer) {
+    for (;;) {
+        int32_t c = lexer->lookahead;
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            advance(lexer);
+        } else if (c == '/') {
+            advance(lexer);
+            if (lexer->lookahead == '/') {
+                while (lexer->lookahead != 0 && lexer->lookahead != '\n') {
+                    advance(lexer);
+                }
+            } else if (lexer->lookahead == '*') {
+                advance(lexer);
+                int32_t prev = 0;
+                while (lexer->lookahead != 0 &&
+                       !(prev == '*' && lexer->lookahead == '/')) {
+                    prev = lexer->lookahead;
+                    advance(lexer);
+                }
+                if (lexer->lookahead == '/') advance(lexer);
+            } else {
+                // a stray '/' isn't valid in a param list; bail out by
+                // making the caller see something unexpected
+                return;
+            }
+        } else {
+            return;
+        }
+    }
+}
+
+// Consume an identifier into a fixed-size buffer. Returns the actual
+// length consumed (may exceed `max`, in which case `buf` is only filled
+// up to `max` bytes — useful for "too long to be a keyword" detection).
+static size_t consume_identifier_into(TSLexer *lexer, char *buf, size_t max) {
+    size_t n = 0;
+    while (is_id_continue(lexer->lookahead)) {
+        if (n < max) {
+            buf[n] = (char)lexer->lookahead;
+        }
+        n++;
+        advance(lexer);
+    }
+    return n;
+}
+
+// True iff the first `n` bytes of `buf` equal the C string `kw`.
+static bool buf_equals(const char *buf, size_t n, const char *kw) {
+    size_t klen = strlen(kw);
+    return n == klen && memcmp(buf, kw, klen) == 0;
+}
 
 void *tree_sitter_c_sharp_external_scanner_create() {
     Scanner *scanner = ts_calloc(1, sizeof(Scanner));
@@ -107,12 +174,128 @@ void tree_sitter_c_sharp_external_scanner_deserialize(void *payload, const char 
     assert(size == length);
 }
 
+// Try to recognize a C# 14 simple-lambda parameter list at the current
+// position. Returns true on success, with `lexer->result_symbol` set to
+// LAMBDA_PAREN_OPEN and end-mark on the opening '('. Returns false
+// otherwise; on false return, anything advanced past mark_end is
+// discarded by tree-sitter.
+//
+// Grammar of the pattern (after the opening '('):
+//
+//   element (',' element)* ')' '=>'
+//
+//   element  := modifier+ identifier
+//             | identifier
+//
+//   modifier ∈ { scoped, ref, out, in, readonly }
+//
+// At least one element must carry a modifier; otherwise we'd over-fire
+// on plain `(x, y) => ...` which is already handled by the existing
+// `_lambda_parameters` choice.
+//
+// Implementation note: identifier-tokens are consumed *whole* into a
+// small buffer before being classified as modifier-or-name. A
+// character-by-character probe against each candidate keyword would be
+// unworkable because `ref` is a prefix of `readonly` (they share `re`)
+// and TSLexer has no rewind primitive: any probe order leaves one of
+// the two keywords unreachable. Buffering the whole identifier
+// sidesteps the prefix conflict entirely.
+static bool scan_lambda_paren_open(TSLexer *lexer) {
+    // External scanners run before whitespace `extras` are skipped, so
+    // we need to skip leading whitespace/comments ourselves before
+    // checking for the opening '('.
+    while (iswspace(lexer->lookahead)) {
+        skip(lexer);
+    }
+    if (lexer->lookahead != '(') return false;
+    advance(lexer);
+    lexer->mark_end(lexer);
+
+    // We require at least one "hard" modifier (ref/out/in/readonly) across
+    // the whole list before committing. `scoped` alone is not a valid C#
+    // parameter modifier — it must always combine with a hard modifier —
+    // and `scoped` is also a legal type name, so accepting `(scoped x) =>`
+    // as a modifier+name pair would collide with the existing
+    // `parameter_list` path on input that semantically means
+    // type+identifier.
+    bool saw_hard_modifier = false;
+    bool expecting_element = true;
+
+    for (;;) {
+        skip_ws_and_comments(lexer);
+        int32_t c = lexer->lookahead;
+
+        if (c == 0) return false;   // EOF mid-list
+
+        if (c == ')') {
+            advance(lexer);
+            skip_ws_and_comments(lexer);
+            if (!saw_hard_modifier) return false;
+            if (lexer->lookahead != '=') return false;
+            advance(lexer);
+            if (lexer->lookahead != '>') return false;
+            lexer->result_symbol = LAMBDA_PAREN_OPEN;
+            return true;
+        }
+
+        if (!expecting_element) {
+            if (c != ',') return false;
+            advance(lexer);
+            expecting_element = true;
+            continue;
+        }
+
+        // Consume identifier-tokens in this element. Each one is either a
+        // parameter modifier (`scoped`/`ref`/`out`/`in`/`readonly`) — in which
+        // case we continue looking for more — or the parameter name, which
+        // ends the element. Consuming the whole token before classifying
+        // avoids any need to rewind the lexer on a prefix-conflict (e.g. ref
+        // vs readonly).
+        bool consumed_name = false;
+        while (!consumed_name) {
+            skip_ws_and_comments(lexer);
+            if (!is_id_start(lexer->lookahead)) return false;
+
+            char buf[9];  // "readonly" is 8 chars
+            size_t n = consume_identifier_into(lexer, buf, sizeof(buf));
+
+            bool is_hard_modifier = (n <= 8) && (
+                buf_equals(buf, n, "ref") ||
+                buf_equals(buf, n, "out") ||
+                buf_equals(buf, n, "in") ||
+                buf_equals(buf, n, "readonly")
+            );
+            bool is_soft_modifier = (n == 6) && buf_equals(buf, n, "scoped");
+
+            if (is_hard_modifier) {
+                saw_hard_modifier = true;
+            } else if (is_soft_modifier) {
+                // `scoped` is a modifier only when followed by a hard
+                // modifier; keep scanning. If the element turns out to
+                // end with `scoped <identifier>` and no hard modifier
+                // appeared, the final `saw_hard_modifier` check fails
+                // and we fall back to the regular parameter_list path.
+            } else {
+                consumed_name = true;
+            }
+        }
+        expecting_element = false;
+    }
+}
+
 bool tree_sitter_c_sharp_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
     Scanner *scanner = (Scanner *)payload;
 
     uint8_t brace_advanced = 0;
     uint8_t quote_count = 0;
     bool did_advance = false;
+
+    if (valid_symbols[LAMBDA_PAREN_OPEN]) {
+        if (scan_lambda_paren_open(lexer)) {
+            return true;
+        }
+        // fall through: regular '(' tokenization
+    }
 
     // error recovery, gives better trees this way
     if (valid_symbols[OPT_SEMI] && valid_symbols[INTERPOLATION_REGULAR_START]) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -174,11 +174,26 @@ void tree_sitter_c_sharp_external_scanner_deserialize(void *payload, const char 
     assert(size == length);
 }
 
+// Outcome of `scan_lambda_paren_open` — distinguishes "didn't start"
+// (lexer untouched, wrapper can fall through to other token handlers)
+// from "started and failed" (lexer cursor advanced past characters
+// the wrapper must not let other handlers consume — they would emit
+// tokens with wrong spans, e.g. an `INTERPOLATION_REGULAR_START`
+// span covering `(false, $` in `return (false, $"...");`).
+typedef enum {
+    LAMBDA_SCAN_NO_PAREN,         // not a '(', no advance() done
+    LAMBDA_SCAN_FAILED_AFTER_PAREN, // '(' was consumed, dirty state
+    LAMBDA_SCAN_SUCCESS,
+} LambdaScanResult;
+
 // Try to recognize a C# 14 simple-lambda parameter list at the current
-// position. Returns true on success, with `lexer->result_symbol` set to
-// LAMBDA_PAREN_OPEN and end-mark on the opening '('. Returns false
-// otherwise; on false return, anything advanced past mark_end is
-// discarded by tree-sitter.
+// position. On SUCCESS, `lexer->result_symbol` is LAMBDA_PAREN_OPEN
+// and `mark_end` is set on the opening '('. On NO_PAREN, the lexer is
+// untouched (only `skip(lexer)` over leading whitespace, which doesn't
+// participate in token boundaries). On FAILED_AFTER_PAREN, the lexer
+// has advanced past at least the opening '(' and the caller must
+// surface this as a false return from the external_scanner_scan
+// function so tree-sitter rewinds.
 //
 // Grammar of the pattern (after the opening '('):
 //
@@ -200,16 +215,23 @@ void tree_sitter_c_sharp_external_scanner_deserialize(void *payload, const char 
 // and TSLexer has no rewind primitive: any probe order leaves one of
 // the two keywords unreachable. Buffering the whole identifier
 // sidesteps the prefix conflict entirely.
-static bool scan_lambda_paren_open(TSLexer *lexer) {
+static LambdaScanResult scan_lambda_paren_open(TSLexer *lexer) {
     // External scanners run before whitespace `extras` are skipped, so
     // we need to skip leading whitespace/comments ourselves before
-    // checking for the opening '('.
+    // checking for the opening '('. `skip(lexer)` consumes the char as
+    // an extra (not part of any token), so even on NO_PAREN return the
+    // wrapper's fall-through into other handlers is safe — those
+    // handlers do their own whitespace skipping.
     while (iswspace(lexer->lookahead)) {
         skip(lexer);
     }
-    if (lexer->lookahead != '(') return false;
+    if (lexer->lookahead != '(') return LAMBDA_SCAN_NO_PAREN;
     advance(lexer);
     lexer->mark_end(lexer);
+
+    // From this point on, the lexer cursor has moved past '('. Any
+    // return must be FAILED_AFTER_PAREN unless we reach SUCCESS.
+    #define BAIL return LAMBDA_SCAN_FAILED_AFTER_PAREN
 
     // We require at least one "hard" modifier (ref/out/in/readonly) across
     // the whole list before committing. `scoped` alone is not a valid C#
@@ -225,21 +247,21 @@ static bool scan_lambda_paren_open(TSLexer *lexer) {
         skip_ws_and_comments(lexer);
         int32_t c = lexer->lookahead;
 
-        if (c == 0) return false;   // EOF mid-list
+        if (c == 0) BAIL;   // EOF mid-list
 
         if (c == ')') {
             advance(lexer);
             skip_ws_and_comments(lexer);
-            if (!saw_hard_modifier) return false;
-            if (lexer->lookahead != '=') return false;
+            if (!saw_hard_modifier) BAIL;
+            if (lexer->lookahead != '=') BAIL;
             advance(lexer);
-            if (lexer->lookahead != '>') return false;
+            if (lexer->lookahead != '>') BAIL;
             lexer->result_symbol = LAMBDA_PAREN_OPEN;
-            return true;
+            return LAMBDA_SCAN_SUCCESS;
         }
 
         if (!expecting_element) {
-            if (c != ',') return false;
+            if (c != ',') BAIL;
             advance(lexer);
             expecting_element = true;
             continue;
@@ -254,7 +276,7 @@ static bool scan_lambda_paren_open(TSLexer *lexer) {
         bool consumed_name = false;
         while (!consumed_name) {
             skip_ws_and_comments(lexer);
-            if (!is_id_start(lexer->lookahead)) return false;
+            if (!is_id_start(lexer->lookahead)) BAIL;
 
             char buf[9];  // "readonly" is 8 chars
             size_t n = consume_identifier_into(lexer, buf, sizeof(buf));
@@ -282,6 +304,7 @@ static bool scan_lambda_paren_open(TSLexer *lexer) {
         expecting_element = false;
     }
 }
+#undef BAIL
 
 bool tree_sitter_c_sharp_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
     Scanner *scanner = (Scanner *)payload;
@@ -290,11 +313,24 @@ bool tree_sitter_c_sharp_external_scanner_scan(void *payload, TSLexer *lexer, co
     uint8_t quote_count = 0;
     bool did_advance = false;
 
+    // Lambda-paren scanning advances forward speculatively past the
+    // opening `(`. If it consumes input and then bails, the lexer
+    // cursor is mispositioned and must not be reused by other token
+    // handlers below — they would emit tokens with spans starting at
+    // the original scan position but ending at the dirty cursor (e.g.
+    // an INTERPOLATION_REGULAR_START swallowing `(false, $` in
+    // `return (false, $"...");`). When the scanner consumed `(` but
+    // didn't confirm a lambda, return false here so tree-sitter
+    // rewinds and lets the built-in `(` tokenizer match.
     if (valid_symbols[LAMBDA_PAREN_OPEN]) {
-        if (scan_lambda_paren_open(lexer)) {
-            return true;
+        switch (scan_lambda_paren_open(lexer)) {
+            case LAMBDA_SCAN_SUCCESS:
+                return true;
+            case LAMBDA_SCAN_FAILED_AFTER_PAREN:
+                return false;
+            case LAMBDA_SCAN_NO_PAREN:
+                break;  // lexer untouched; fall through
         }
-        // fall through: regular '(' tokenization
     }
 
     // error recovery, gives better trees this way

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -52,96 +52,67 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
-  )
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self)                           \
-  do {                                               \
-    if ((self)->contents) ts_free((self)->contents); \
-    (self)->contents = NULL;                         \
-    (self)->size = 0;                                \
-    (self)->capacity = 0;                            \
-  } while (0)
+#define array_delete(self) _array__delete((Array *)(self))
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                                 \
-  do {                                                            \
-    (self)->contents = _array__grow(                              \
-      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
-      1, array_elem_size(self)                                    \
-    );                                                            \
-   (self)->contents[(self)->size++] = (element);                  \
-  } while(0)
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count)                                               \
-  do {                                                                           \
-    if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
-      (self)->contents, (self)->size, &(self)->capacity,                         \
-      count, array_elem_size(self)                                               \
-    );                                                                           \
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count);                                                     \
+    (self)->size += (count); \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other) \
+#define array_push_all(self, other)                                       \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
-    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
-    array_elem_size(self), (self)->size, 0, count, other_contents \
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
-    array_elem_size(self), _index, old_count, new_count, new_contents  \
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
-    array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
+  _array__erase((Array *)(self), array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
-    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
 
 /// Swap one array with another
-#define array_swap(self, other)                                     \
-  do {                                                              \
-    void *_array_swap_tmp = (void *)(self)->contents;               \
-    (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
-    _array__swap(&(self)->size, &(self)->capacity,                  \
-                 &(other)->size, &(other)->capacity);               \
-  } while (0)
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -186,90 +157,82 @@ extern "C" {
 
 // Private
 
-// Pointers to individual `Array` fields (rather than the entire `Array` itself)
-// are passed to the various `_array__*` functions below to address strict aliasing
-// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
-//
-// The `Array` type itself was not altered as a solution in order to avoid breakage
-// with existing consumers (in particular, parsers with external scanners).
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(void* self_contents, uint32_t *size,
-                                size_t element_size, uint32_t index) {
-  assert(index < *size);
-  char *contents = (char *)self_contents;
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (*size - index - 1) * element_size);
-  (*size)--;
+          (self->size - index - 1) * element_size);
+  self->size--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void *_array__reserve(void *contents, uint32_t *capacity,
-                                  size_t element_size, uint32_t new_capacity) {
-  void *new_contents = contents;
-  if (new_capacity > *capacity) {
-    if (contents) {
-      new_contents = ts_realloc(contents, new_capacity * element_size);
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
     } else {
-      new_contents = ts_malloc(new_capacity * element_size);
+      self->contents = ts_malloc(new_capacity * element_size);
     }
-    *capacity = new_capacity;
+    self->capacity = new_capacity;
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
-                                 const void *other_contents, uint32_t other_size, size_t element_size) {
-  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
-  *self_size = other_size;
-  memcpy(new_contents, other_contents, *self_size * element_size);
-  return new_contents;
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
-                               uint32_t *other_size, uint32_t *other_capacity) {
-  uint32_t tmp_size = *self_size;
-  uint32_t tmp_capacity = *self_capacity;
-  *self_size = *other_size;
-  *self_capacity = *other_capacity;
-  *other_size = tmp_size;
-  *other_capacity = tmp_capacity;
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
-                               uint32_t count, size_t element_size) {
-  void *new_contents = contents;
-  uint32_t new_size = size + count;
-  if (new_size > *capacity) {
-    uint32_t new_capacity = *capacity * 2;
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
+    _array__reserve(self, element_size, new_capacity);
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
-                                 size_t element_size,
+static inline void _array__splice(Array *self, size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = *size + new_count - old_count;
+  uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= *size);
+  assert(old_end <= self->size);
 
-  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
+  _array__reserve(self, element_size, new_size);
 
-  char *contents = (char *)new_contents;
-  if (*size > old_end) {
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (*size - old_end) * element_size
+      (self->size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -287,9 +250,7 @@ static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t
       );
     }
   }
-  *size += new_count - old_count;
-
-  return new_contents;
+  self->size += new_count - old_count;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -498,3 +498,150 @@ partial class C {
               (identifier))))
         body: (block)))))
 
+================================================================================
+Extension declarations (C# 14)
+================================================================================
+
+public static class E
+{
+    extension(IEnumerable source)
+    {
+        public bool IsEmpty => !source.Any();
+    }
+
+    extension<T>(IEnumerable<T> source)
+    {
+        public IEnumerable<T> Where(Func<T, bool> p) => null;
+    }
+
+    extension<T>(IEnumerable<T>)
+        where T : INumber<T>
+    {
+        public static IEnumerable<T> operator +(IEnumerable<T> a, IEnumerable<T> b) => null;
+        public static IEnumerable<T> Identity => null;
+    }
+
+    extension<T>(ref readonly T source)
+    {
+        public T Echo() => source;
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (extension_declaration
+        (receiver_parameter
+          type: (identifier)
+          name: (identifier))
+        (extension_body
+          (property_declaration
+            (modifier)
+            type: (predefined_type)
+            name: (identifier)
+            value: (arrow_expression_clause
+              (prefix_unary_expression
+                (invocation_expression
+                  function: (member_access_expression
+                    expression: (identifier)
+                    name: (identifier))
+                  arguments: (argument_list)))))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          type: (generic_name
+            (identifier)
+            (type_argument_list
+              (identifier)))
+          name: (identifier))
+        (extension_body
+          (method_declaration
+            (modifier)
+            returns: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            name: (identifier)
+            parameters: (parameter_list
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)
+                    (predefined_type)))
+                name: (identifier)))
+            body: (arrow_expression_clause
+              (null_literal)))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          type: (generic_name
+            (identifier)
+            (type_argument_list
+              (identifier))))
+        (type_parameter_constraints_clause
+          (identifier)
+          (type_parameter_constraint
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))))
+        (extension_body
+          (operator_declaration
+            (modifier)
+            (modifier)
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            parameters: (parameter_list
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)))
+                name: (identifier))
+              (parameter
+                type: (generic_name
+                  (identifier)
+                  (type_argument_list
+                    (identifier)))
+                name: (identifier)))
+            body: (arrow_expression_clause
+              (null_literal)))
+          (property_declaration
+            (modifier)
+            (modifier)
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            name: (identifier)
+            value: (arrow_expression_clause
+              (null_literal)))))
+      (extension_declaration
+        (type_parameter_list
+          (type_parameter
+            name: (identifier)))
+        (receiver_parameter
+          (modifier)
+          (modifier)
+          type: (identifier)
+          name: (identifier))
+        (extension_body
+          (method_declaration
+            (modifier)
+            returns: (identifier)
+            name: (identifier)
+            parameters: (parameter_list)
+            body: (arrow_expression_clause
+              (identifier))))))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -432,3 +432,69 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
         (argument
           (identifier))))))
 
+================================================================================
+Partial constructor declarations (C# 14)
+================================================================================
+
+partial class C {
+  public partial C(int x);
+  public partial C(int x) { this.x = x; }
+  public partial C(int x) : base(x);
+  public partial C(int x) : base(x) { }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        body: (block
+          (expression_statement
+            (assignment_expression
+              left: (member_access_expression
+                name: (identifier))
+              right: (identifier)))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        (constructor_initializer
+          (argument_list
+            (argument
+              (identifier)))))
+      (constructor_declaration
+        (modifier)
+        (modifier)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        (constructor_initializer
+          (argument_list
+            (argument
+              (identifier))))
+        body: (block)))))
+

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3056,7 +3056,8 @@ if (aa is [(name: A.B), ..]) { }
                 right: (list_pattern))
               right: (list_pattern
                 (constant_pattern
-                  (integer_literal)))))))))
+                  (integer_literal))
+                (slice_pattern))))))))
   (global_statement
     (if_statement
       condition: (is_pattern_expression
@@ -3069,8 +3070,75 @@ if (aa is [(name: A.B), ..]) { }
                 (constant_pattern
                   (member_access_expression
                     expression: (identifier)
-                    name: (identifier))))))))
+                    name: (identifier))))))
+          (slice_pattern)))
       consequence: (block))))
+
+================================================================================
+List pattern with slice subpatterns (C# 11)
+================================================================================
+
+class C {
+    string M(string s) => s switch {
+        ['"', .. var inner, '"'] => inner,
+        [.. List<int> all] => "list",
+        [a, .., b] => "bare",
+        _ => s,
+    };
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (predefined_type)
+            name: (identifier)))
+        body: (arrow_expression_clause
+          (switch_expression
+            (identifier)
+            (switch_expression_arm
+              (list_pattern
+                (constant_pattern
+                  (character_literal
+                    (character_literal_content)))
+                (slice_pattern
+                  (declaration_pattern
+                    type: (implicit_type)
+                    name: (identifier)))
+                (constant_pattern
+                  (character_literal
+                    (character_literal_content))))
+              (identifier))
+            (switch_expression_arm
+              (list_pattern
+                (slice_pattern
+                  (declaration_pattern
+                    type: (generic_name
+                      (identifier)
+                      (type_argument_list
+                        (predefined_type)))
+                    name: (identifier))))
+              (string_literal
+                (string_literal_content)))
+            (switch_expression_arm
+              (list_pattern
+                (constant_pattern
+                  (identifier))
+                (slice_pattern)
+                (constant_pattern
+                  (identifier)))
+              (string_literal
+                (string_literal_content)))
+            (switch_expression_arm
+              (discard)
+              (identifier))))))))
 
 ================================================================================
 Conditional expression with member accesses

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3234,6 +3234,59 @@ if (a?.B != 1) { }
       consequence: (block))))
 
 ================================================================================
+Null-conditional assignment (C# 14)
+================================================================================
+
+class C {
+  void M(D obj) {
+    obj?.field = 5;
+    obj?.list[0] = 1;
+    obj?[key] = val;
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list
+          (parameter
+            type: (identifier)
+            name: (identifier)))
+        body: (block
+          (expression_statement
+            (assignment_expression
+              left: (conditional_access_expression
+                condition: (identifier)
+                (member_binding_expression
+                  name: (identifier)))
+              right: (integer_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (element_access_expression
+                expression: (conditional_access_expression
+                  condition: (identifier)
+                  (member_binding_expression
+                    name: (identifier)))
+                subscript: (bracketed_argument_list
+                  (argument
+                    (integer_literal))))
+              right: (integer_literal)))
+          (expression_statement
+            (assignment_expression
+              left: (conditional_access_expression
+                condition: (identifier)
+                (element_binding_expression
+                  (argument
+                    (identifier))))
+              right: (identifier))))))))
+
+================================================================================
 Conditional access expression with simple member access
 ================================================================================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -4103,3 +4103,149 @@ class C {
                       (identifier))
                     (argument
                       (identifier))))))))))))
+
+================================================================================
+Simple lambda parameters with modifiers (C# 14)
+================================================================================
+
+class C { void M() {
+  var a = (ref x) => x;
+  var b = (out y) => y = 0;
+  var c = (in z) => z;
+  var d = (scoped p) => p;
+  var e = (ref readonly q) => q;
+  var f = (text, out result) => Int32.TryParse(text, out result);
+  var g = (ref x, out y, in z) => 0;
+} }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list)
+        body: (block
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (assignment_expression
+                    left: (identifier)
+                    right: (integer_literal))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (parameter_list
+                    (parameter
+                      type: (identifier)
+                      name: (identifier)))
+                  body: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (modifier)
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (implicit_parameter)
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (invocation_expression
+                    function: (member_access_expression
+                      expression: (identifier)
+                      name: (identifier))
+                    arguments: (argument_list
+                      (argument
+                        (identifier))
+                      (argument
+                        (identifier))))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (lambda_expression
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  parameters: (modifier)
+                  parameters: (implicit_parameter)
+                  body: (integer_literal))))))))))
+
+================================================================================
+Modifier-prefixed parens that are NOT lambda parameter lists (C# 14)
+================================================================================
+
+class C { void M() {
+  var a = (ref obj);
+  var b = (ref x) + 1;
+} }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list)
+        body: (block
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (parenthesized_expression
+                  (ref_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (cast_expression
+                  type: (ref_type
+                    type: (identifier))
+                  value: (prefix_unary_expression
+                    (integer_literal)))))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3533,6 +3533,57 @@ var x = nameof(A.B);
                   name: (identifier))))))))))
 
 ================================================================================
+Nameof with unbound generic types (C# 14)
+================================================================================
+
+var x = nameof(List<>);
+var x = nameof(Dictionary<,>);
+var x = nameof(IDictionary<,,>);
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (invocation_expression
+            function: (identifier)
+            arguments: (argument_list
+              (argument
+                (generic_name
+                  (identifier)
+                  (type_argument_list)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (invocation_expression
+            function: (identifier)
+            arguments: (argument_list
+              (argument
+                (generic_name
+                  (identifier)
+                  (type_argument_list)))))))))
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (invocation_expression
+            function: (identifier)
+            arguments: (argument_list
+              (argument
+                (generic_name
+                  (identifier)
+                  (type_argument_list))))))))))
+
+================================================================================
 Generic invocation expression
 ================================================================================
 

--- a/test/corpus/type-events.txt
+++ b/test/corpus/type-events.txt
@@ -65,3 +65,37 @@ class A {
               (invocation_expression
                 function: (identifier)
                 arguments: (argument_list)))))))))
+
+================================================================================
+Partial event declarations (C# 14)
+================================================================================
+
+partial class C {
+  public partial event EventHandler SomeEvent;
+  public partial event EventHandler SomeEvent { add { } remove { } }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (modifier)
+    name: (identifier)
+    body: (declaration_list
+      (event_field_declaration
+        (modifier)
+        (modifier)
+        (variable_declaration
+          type: (identifier)
+          (variable_declarator
+            name: (identifier))))
+      (event_declaration
+        (modifier)
+        (modifier)
+        type: (identifier)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (block))
+          (accessor_declaration
+            body: (block)))))))

--- a/test/corpus/type-operators.txt
+++ b/test/corpus/type-operators.txt
@@ -898,3 +898,195 @@ public class C : I<C>
         body: (arrow_expression_clause
           (throw_expression
             (null_literal)))))))
+
+================================================================================
+User-defined compound assignment operators (C# 14)
+================================================================================
+
+class C {
+  public int Value;
+
+  public void operator +=(int x) => Value += x;
+  public void operator -=(int x) => Value -= x;
+  public void operator *=(int x) => Value *= x;
+  public void operator /=(int x) => Value /= x;
+  public void operator %=(int x) => Value %= x;
+  public void operator ^=(int x) => Value ^= x;
+  public void operator |=(int x) => Value |= x;
+  public void operator &=(int x) => Value &= x;
+  public void operator <<=(int x) => Value <<= x;
+  public void operator >>=(int x) => Value >>= x;
+  public void operator >>>=(int x) => Value >>>= x;
+
+  public void operator checked +=(int x) => Value += x;
+  public void operator checked -=(int x) => Value -= x;
+  public void operator checked *=(int x) => Value *= x;
+  public void operator checked /=(int x) => Value /= x;
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (field_declaration
+        (modifier)
+        (variable_declaration
+          type: (predefined_type)
+          (variable_declarator name: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list
+          (parameter type: (predefined_type) name: (identifier)))
+        body: (arrow_expression_clause
+          (assignment_expression left: (identifier) right: (identifier)))))))
+
+================================================================================
+Instance increment and decrement operators (C# 14)
+================================================================================
+
+class C {
+  public int Value;
+
+  public void operator ++() { Value++; }
+  public void operator --() => Value--;
+  public void operator checked ++() => Value++;
+  public void operator checked --() => Value--;
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (field_declaration
+        (modifier)
+        (variable_declaration
+          type: (predefined_type)
+          (variable_declarator name: (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list)
+        body: (block
+          (expression_statement
+            (postfix_unary_expression (identifier)))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list)
+        body: (arrow_expression_clause
+          (postfix_unary_expression (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list)
+        body: (arrow_expression_clause
+          (postfix_unary_expression (identifier))))
+      (operator_declaration
+        (modifier)
+        type: (predefined_type)
+        parameters: (parameter_list)
+        body: (arrow_expression_clause
+          (postfix_unary_expression (identifier)))))))

--- a/test/corpus/type-properties.txt
+++ b/test/corpus/type-properties.txt
@@ -158,3 +158,115 @@ class Foo: IFoo {
         accessors: (accessor_list
           (accessor_declaration)
           (accessor_declaration))))))
+
+================================================================================
+Field-backed properties with `field` contextual keyword (C# 14)
+================================================================================
+
+class C {
+  public string Name { get; set => field = value; }
+  public string Tagged { get => field ?? "default"; set; }
+  public string Lazy => field ??= Compute();
+  public string Lazy2 { get => field ??= Compute(); }
+  public int Counter { get { return field; } set { field = value; } }
+  [field: Xyz]
+  public string Decorated => field ??= Compute();
+  public bool IsActive { get; set => Set(ref field, value); } = true;
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration)
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (assignment_expression
+                left: (identifier)
+                right: (identifier))))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (binary_expression
+                left: (identifier)
+                right: (string_literal
+                  (string_literal_content)))))
+          (accessor_declaration)))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        value: (arrow_expression_clause
+          (assignment_expression
+            left: (identifier)
+            right: (invocation_expression
+              function: (identifier)
+              arguments: (argument_list)))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (assignment_expression
+                left: (identifier)
+                right: (invocation_expression
+                  function: (identifier)
+                  arguments: (argument_list)))))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration
+            body: (block
+              (return_statement
+                (identifier))))
+          (accessor_declaration
+            body: (block
+              (expression_statement
+                (assignment_expression
+                  left: (identifier)
+                  right: (identifier)))))))
+      (property_declaration
+        (attribute_list
+          (attribute_target_specifier)
+          (attribute
+            name: (identifier)))
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        value: (arrow_expression_clause
+          (assignment_expression
+            left: (identifier)
+            right: (invocation_expression
+              function: (identifier)
+              arguments: (argument_list)))))
+      (property_declaration
+        (modifier)
+        type: (predefined_type)
+        name: (identifier)
+        accessors: (accessor_list
+          (accessor_declaration)
+          (accessor_declaration
+            body: (arrow_expression_clause
+              (invocation_expression
+                function: (identifier)
+                arguments: (argument_list
+                  (argument
+                    (identifier))
+                  (argument
+                    (identifier)))))))
+        value: (boolean_literal)))))


### PR DESCRIPTION
## Summary

Adds support for the seven syntactic features introduced in [C# 14](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14):

| # | Feature | Path |
|---|---|---|
| 1 | `nameof` with unbound generic types (`nameof(List<>)`) | test-only — already worked via `unbound_type_name` |
| 2 | Null-conditional assignment (`obj?.x = v`, `obj?[i] = v`) | grammar |
| 3 | Partial events and partial constructors | test-only — already worked via existing `partial` modifier |
| 4 | User-defined compound assignment operators + instance `++`/`--` | grammar |
| 5 | Field-backed properties (`field` contextual keyword + mix of auto/full accessors) | test-only — `field` is an identifier in this position |
| 6 | Extension declarations (`extension(...) { ... }` blocks in static classes) | grammar |
| 7 | Simple-lambda parameters with modifiers (`(ref x) => x`, `(out y) => ...`, `(in z) => ...`, `(text, out result) => ...`) | grammar + external scanner |

Closes part of #392.

The README's status section is updated to reflect C# 14 support. File-based-apps preprocessor directives (`#:property`, `#:package`, `#:sdk`, `#:project`) remain unrecognized and are noted as a known limitation alongside the existing `async`/`var`/`await` identifier-use caveat.

## Commits

Eight atomic commits, linear history, one feature per commit (plus the README). Each commit is independently buildable and testable — `tree-sitter generate && tree-sitter test` passes at every step.

```
38fc039 test: pin nameof support for unbound generic types (C# 14)
cb973b6 test: add partial constructors and partial events corpus (C# 14)
6c5c419 test: pin field-backed properties with `field` contextual keyword (C# 14)
d63b68d feat: support null-conditional assignment (C# 14)
dcb72c6 feat: C# 14 user-defined compound assignment and instance increment operators
d69e097 feat: C# 14 extension declarations
7c7b5f3 feat: C# 14 simple-lambda parameters with modifiers
e16cfe9 docs: update README to reflect C# 14 support
```

## Notes on individual features

**Null-conditional assignment** — adds `conditional_access_expression` to the `lvalue_expression` choice with one new conflict declaration so the existing non-lvalue parse is preserved.

**Compound assignment + instance increment/decrement** — extends the operator token choice list to include `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `|=`, `&=`, `<<=`, `>>=`, `>>>=`. The existing `optional('checked')` keyword covers `checked +=` and `checked ++`. The proposal specifies these as instance members returning `void` with one parameter (compound) or zero (instance increment) — `_function_body` already permits empty `()` parameter lists.

**Extension declarations** — new `extension_declaration` node added to the `declaration` choice. `extension` is a contextual keyword recognized via `prec.dynamic`; one new conflict (`[receiver_parameter, scoped_type, _reserved_identifier]`) keeps `scoped` interpretations alive inside the receiver until later tokens disambiguate.

**Simple-lambda parameters with modifiers** — the only feature requiring an external scanner. At `(`-followed-by-a-parameter-modifier, the LR table has already resolved the action to `parenthesized_expression(ref_expression(...))` or `tuple_expression(argument, ...)` due to `lambda_expression`'s `prec(-1)`. No combination of conflict declarations or precedence rules keeps the lambda interpretation alive without breaking existing parse-tree shapes (every grammar-only attempt regressed at least one of *Lambda expression with ref modifier*, *Class method with single parameter*, or *Scoped contextual keyword*). Roslyn and every production C# parser solve this with unbounded backward-tracking lookahead — this PR mirrors that approach with a single external token `_lambda_paren_open` emitted by the scanner only when forward-scanning confirms a closing `)=>` after a parameter list containing at least one **hard** modifier (`ref`/`out`/`in`/`readonly`). Because the token appears in exactly one grammar rule, the parser commits to the lambda interpretation unambiguously.

`scoped` is intentionally NOT a hard modifier in the scanner: the existing *Scoped contextual keyword* test pins `(scoped p) => null` as `parameter_list(parameter(type=identifier(scoped), name=p))`, and that shape is preserved. This is also more spec-aligned — the C# 14 spec treats `scoped` as auxiliary, combining with `ref`/`ref readonly`.

## Test plan

- [x] `tree-sitter generate` succeeds with no new warnings or "unnecessary conflict" notices
- [x] `tree-sitter test` — 183 passing, 0 failing (baseline was 168; this PR adds 15 new corpus tests across 7 features)
- [x] Negative sentinels confirm the scanner does NOT over-fire: `(ref obj);` continues to parse as `parenthesized_expression(ref_expression(...))`, `(ref x) + 1` continues to parse via the pre-existing `cast_expression` path, and `(ref int i) => i` continues to parse as `parameter(type=ref_type(...), name=i)` (pinned by the existing *Lambda expression with ref modifier* test)
- [x] Method-declaration parameter lists with parameter modifiers (`void M(out int a)`, `void M(scoped ref scoped p)`) continue to parse exactly as before — verified by diff against pre-change baseline

## Supersedes

This PR consolidates the six smaller PRs (#423–#428) opened earlier. Those were closed when the feature branches were rebased into this linear history.