### PR TITLE
fix: parse `(IDENT) && EXPR` as logical-AND, not cast

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1439,6 +1439,11 @@ export default grammar({
       $.typeof_expression,
       $.makeref_expression,
       $.ref_expression,
+      // Address-of (see `_address_of_expression` below): aliased to
+      // `prefix_unary_expression` to preserve the public AST shape.
+      // Parallels `_pointer_indirection_expression` (the `*` operator),
+      // which is similarly aliased back into `lvalue_expression`.
+      alias($._address_of_expression, $.prefix_unary_expression),
       $.reftype_expression,
       $.refvalue_expression,
       $.stackalloc_expression,
@@ -1543,12 +1548,35 @@ export default grammar({
     )),
 
     prefix_unary_expression: $ => prec(PREC.UNARY, seq(
-      choice('++', '--', '+', '-', '!', '~', '&', '^'),
+      // `&` and `*` are intentionally NOT in this choice list:
+      //   * `&` → `_address_of_expression` (operand restricted to lvalue
+      //           — see comment on that rule for the #413 rationale)
+      //   * `*` → `_pointer_indirection_expression` (same shape,
+      //           restricted to lvalue, surfaced in `lvalue_expression`)
+      // Both are aliased back to `prefix_unary_expression` so the
+      // public AST is unaffected.
+      choice('++', '--', '+', '-', '!', '~', '^'),
       $.expression,
     )),
 
     _pointer_indirection_expression: $ => prec.right(PREC.UNARY, seq(
       '*',
+      $.lvalue_expression,
+    )),
+
+    // Address-of is split out from `prefix_unary_expression` so that
+    // `&` can't act as a fallback when the lexer would otherwise
+    // emit `&&`. Its operand is restricted to an lvalue (same shape
+    // as the spec's `address-of-expression`). This is the fix for
+    // tree-sitter#413: `(a) && (b > 0)` was misparsed as
+    // `cast(a, &(&(b > 0)))` because the cast state accepted `&` as
+    // a unary start and the lexer split `&&` into two `&` tokens.
+    // With this split, `&` is only valid before an lvalue, which
+    // `(b > 0)` is not — so the cast interpretation can no longer
+    // consume the trailing parenthesized expression and `&&` must
+    // be emitted as a single token for the binary path to succeed.
+    _address_of_expression: $ => prec.right(PREC.UNARY, seq(
+      '&',
       $.lvalue_expression,
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6816,6 +6816,15 @@
           "name": "ref_expression"
         },
         {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_address_of_expression"
+          },
+          "named": true,
+          "value": "prefix_unary_expression"
+        },
+        {
           "type": "SYMBOL",
           "name": "reftype_expression"
         },
@@ -7775,10 +7784,6 @@
               },
               {
                 "type": "STRING",
-                "value": "&"
-              },
-              {
-                "type": "STRING",
                 "value": "^"
               }
             ]
@@ -7799,6 +7804,23 @@
           {
             "type": "STRING",
             "value": "*"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "lvalue_expression"
+          }
+        ]
+      }
+    },
+    "_address_of_expression": {
+      "type": "PREC_RIGHT",
+      "value": 17,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "&"
           },
           {
             "type": "SYMBOL",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3605,25 +3605,140 @@ MyFunction<A,B>(1);
             (integer_literal)))))))
 
 ================================================================================
-Dereference versus logical and
+Logical AND vs cast disambiguation with parenthesized LHS (#413)
 ================================================================================
 
-bool c = (a) && b;
+class C {
+  void M() {
+    bool a = (x) && y;
+    bool b = (x) && (y > 0);
+    bool c = (x) && (y) && (z);
+    bool d = (x) && (y) || (z);
+    bool e = !(x) && (y);
+    bool g = (MyType<T>) && c;
+    bool h = (i) && &j;
+    int k = (l) & m;
+    var p1 = (IntPtr) &x;
+    var p2 = &x;
+  }
+}
 
 --------------------------------------------------------------------------------
 
 (compilation_unit
-  (global_statement
-    (local_declaration_statement
-      (variable_declaration
-        type: (predefined_type)
-        (variable_declarator
-          name: (identifier)
-          (cast_expression
-            type: (identifier)
-            value: (prefix_unary_expression
-              (prefix_unary_expression
-                (identifier)))))))))
+  (class_declaration
+    name: (identifier)
+    body: (declaration_list
+      (method_declaration
+        returns: (predefined_type)
+        name: (identifier)
+        parameters: (parameter_list)
+        body: (block
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (parenthesized_expression
+                    (identifier))
+                  right: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (parenthesized_expression
+                    (identifier))
+                  right: (parenthesized_expression
+                    (binary_expression
+                      left: (identifier)
+                      right: (integer_literal)))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (binary_expression
+                    left: (parenthesized_expression
+                      (identifier))
+                    right: (parenthesized_expression
+                      (identifier)))
+                  right: (parenthesized_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (binary_expression
+                    left: (parenthesized_expression
+                      (identifier))
+                    right: (parenthesized_expression
+                      (identifier)))
+                  right: (parenthesized_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (prefix_unary_expression
+                    (parenthesized_expression
+                      (identifier)))
+                  right: (parenthesized_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (parenthesized_expression
+                    (generic_name
+                      (identifier)
+                      (type_argument_list
+                        (identifier))))
+                  right: (identifier)))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (binary_expression
+                  left: (parenthesized_expression
+                    (identifier))
+                  right: (prefix_unary_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (predefined_type)
+              (variable_declarator
+                name: (identifier)
+                (cast_expression
+                  type: (identifier)
+                  value: (prefix_unary_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (cast_expression
+                  type: (identifier)
+                  value: (prefix_unary_expression
+                    (identifier))))))
+          (local_declaration_statement
+            (variable_declaration
+              type: (implicit_type)
+              (variable_declarator
+                name: (identifier)
+                (prefix_unary_expression
+                  (identifier))))))))))
 
 ================================================================================
 With expression typical basic form


### PR DESCRIPTION
## Summary

`(a) && (b > 0)` is misparsed as `cast(a, &(&(b > 0)))`: a cast of `a` whose value is two unary address-of operators applied to a parenthesized expression. The expected parse is `binary_expression` between two parenthesized expressions.

## Reproduction

```
$ echo 'res = (a) && (b > 0);' | tree-sitter parse --no-ranges
(compilation_unit
  (global_statement
    (expression_statement
      (assignment_expression
        left: (identifier)
        right: (cast_expression                  ← should be binary_expression
          type: (identifier)
          value: (prefix_unary_expression
            (prefix_unary_expression             ← `&&` got split into two `&`
              (parenthesized_expression
                (binary_expression
                  left: (identifier)
                  right: (integer_literal))))))))))
```

## Root cause

Tree-sitter's state-aware lexer was splitting `&&` into two `&` tokens when the parser was exploring the cast-expression interpretation of `(IDENT)`. With `&` listed as a prefix unary operator and `cast_expression` accepting any expression as its value, the cast state always preferred a unary `&` over the binary `&&` — which isn't valid as an expression-start token. The cast interpretation won under `prec.dynamic(1)`, producing the misparse.

## Fix

Split address-of out of `prefix_unary_expression` into a separate `_address_of_expression` rule whose operand is restricted to an `lvalue_expression` (matching the C# spec's `address-of-expression`).

`(b > 0)` is not an lvalue, so once the lexer would otherwise split `&&` the inner `& (b > 0)` no longer matches and the cast interpretation fails. The parser then takes the parenthesized-expression path and the lexer emits `&&` as a single token, giving the correct logical-AND parse.

The shape mirrors the existing `_pointer_indirection_expression` (the `*` operator): both restrict their operand to an lvalue, and both alias back to the public `prefix_unary_expression` node so the AST shape is preserved for downstream consumers. The intentional omission of `&` and `*` from `prefix_unary_expression`'s choice list is now documented inline.

## Known consequences

`(int) && b` (and other predefined-type LHS forms) now produce an `ERROR` node where they previously misparsed as a cast. This is **correct** — `(int) && b` is not valid C# (you can't logical-AND a type with a value), so the previous "cast" parse was producing misleading output. The parenthesized-expression fallback isn't available for predefined types because they aren't expressions, so there's no clean non-cast interpretation. Producing `ERROR` matches Roslyn's behavior.

The single-`&` cast-vs-bitwise-AND ambiguity (`(l) & m`) is left as cast — that interpretation matches the C# spec's syntactic disambiguation rule, and resolving it would require semantic information that tree-sitter does not have.

## Tests

The existing `Dereference versus logical and` corpus test was pinning the buggy behavior. It is renamed to `Logical AND vs cast disambiguation with parenthesized LHS (#413)` and expanded from 1 to 10 cases:

| Case | Asserts |
|---|---|
| `(x) && y` | basic — `&&` between parenthesized and bare identifier |
| `(x) && (y > 0)` | the issue's exact case |
| `(x) && (y) && (z)` | chained `&&`, left-associative |
| `(x) && (y) \|\| (z)` | mixed `&&`/`\|\|` with correct precedence |
| `!(x) && (y)` | negation on the left |
| `(MyType<T>) && c` | generic-type LHS — falls through to parenthesized + binary |
| `(i) && &j` | RHS is a legitimate address-of |
| `(l) & m` | single-`&` — intentionally still cast |
| `(IntPtr) &x` | **preservation sentinel** — legitimate cast with address-of value |
| `&x` | **preservation sentinel** — bare address-of of an lvalue |

## Test plan
- [x] `tree-sitter generate` succeeds with no new conflicts or warnings
- [x] `tree-sitter test` — 173 passing, 0 failing (master baseline was 168 corpus + 5 highlight = 173; the renamed test counts as 1 in both)
- [x] Address-of preserved over identifiers, member access, element access, and the legitimate `(IntPtr) &x` cast (verified manually against pre-change baseline; same `prefix_unary_expression` node name preserved via alias)
- [x] No regressions in any existing corpus test

Closes #413.