### PR TITLE
Fix generics

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -741,7 +741,7 @@ export default grammar({
 
     constructor_initializer: $ => seq(
       ':',
-      choice('base', $.this),
+      choice($.base, $.this),
       $.argument_list,
     ),
 
@@ -1417,7 +1417,7 @@ export default grammar({
     ),
 
     non_lvalue_expression: $ => choice(
-      'base',
+      $.base,
       $.binary_expression,
       $.interpolated_string_expression,
       $.conditional_expression,
@@ -2161,6 +2161,7 @@ export default grammar({
     ),
 
     this: _ => 'this',
+    base: _ => 'base',
 
     // Preprocessor
 

--- a/grammar.js
+++ b/grammar.js
@@ -829,7 +829,7 @@ export default grammar({
       field('name', $._simple_name),
     )),
 
-    generic_name: $ => seq($.identifier, $.type_argument_list),
+    generic_name: $ => prec.dynamic(PREC.GENERIC, seq($.identifier, $.type_argument_list)),
 
     type_argument_list: $ => seq(
       '<',

--- a/grammar.js
+++ b/grammar.js
@@ -674,7 +674,7 @@ export default grammar({
       repeat($.modifier),
       field('type', $.type),
       optional($.explicit_interface_specifier),
-      'this',
+      $.this,
       field('parameters', $.bracketed_parameter_list),
       choice(
         field('accessors', $.accessor_list),
@@ -719,7 +719,7 @@ export default grammar({
 
     _parameter_type_with_modifiers: $ => seq(
       repeat(prec.left(alias(
-        choice('this', 'scoped', 'ref', 'out', 'in', 'readonly'),
+        choice($.this, 'scoped', 'ref', 'out', 'in', 'readonly'),
         $.modifier,
       ))),
       field('type', $.type),
@@ -741,7 +741,7 @@ export default grammar({
 
     constructor_initializer: $ => seq(
       ':',
-      choice('base', 'this'),
+      choice('base', $.this),
       $.argument_list,
     ),
 
@@ -1460,7 +1460,7 @@ export default grammar({
     ),
 
     lvalue_expression: $ => choice(
-      'this',
+      $.this,
       $.member_access_expression,
       $.tuple_expression,
       $._simple_name,
@@ -2159,6 +2159,8 @@ export default grammar({
       'where',
       'yield',
     ),
+
+    this: _ => 'this',
 
     // Preprocessor
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -135,7 +135,7 @@
   "add"
   "alias"
   "as"
-  "base"
+  (base)
   "break"
   "case"
   "catch"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -127,7 +127,7 @@
 
 [
   (modifier)
-  "this"
+  (this)
   (implicit_type)
 ] @keyword
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2680,8 +2680,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "this"
+          "type": "SYMBOL",
+          "name": "this"
         },
         {
           "type": "FIELD",
@@ -2993,8 +2993,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "this"
+                    "type": "SYMBOL",
+                    "name": "this"
                   },
                   {
                     "type": "STRING",
@@ -3129,12 +3129,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "base"
+              "type": "SYMBOL",
+              "name": "base"
             },
             {
-              "type": "STRING",
-              "value": "this"
+              "type": "SYMBOL",
+              "name": "this"
             }
           ]
         },
@@ -3736,17 +3736,21 @@
       }
     },
     "generic_name": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "type_argument_list"
-        }
-      ]
+      "type": "PREC_DYNAMIC",
+      "value": 19,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "type_argument_list"
+          }
+        ]
+      }
     },
     "type_argument_list": {
       "type": "SEQ",
@@ -6728,8 +6732,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "base"
+          "type": "SYMBOL",
+          "name": "base"
         },
         {
           "type": "SYMBOL",
@@ -6887,8 +6891,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "this"
+          "type": "SYMBOL",
+          "name": "this"
         },
         {
           "type": "SYMBOL",
@@ -10746,6 +10750,14 @@
           "value": "yield"
         }
       ]
+    },
+    "this": {
+      "type": "STRING",
+      "value": "this"
+    },
+    "base": {
+      "type": "STRING",
+      "value": "base"
     },
     "preproc_if": {
       "type": "PREC",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -175,7 +175,7 @@
       },
       {
         "type": "this",
-        "named": false
+        "named": true
       },
       {
         "type": "tuple_expression",
@@ -213,7 +213,7 @@
       },
       {
         "type": "base",
-        "named": false
+        "named": true
       },
       {
         "type": "binary_expression",
@@ -1987,11 +1987,19 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
           "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "base",
+          "named": true
+        },
+        {
+          "type": "this",
           "named": true
         }
       ]
@@ -3251,7 +3259,7 @@
     },
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "attribute_list",
@@ -3267,6 +3275,10 @@
         },
         {
           "type": "preproc_if_in_attribute_list",
+          "named": true
+        },
+        {
+          "type": "this",
           "named": true
         }
       ]
@@ -6900,7 +6912,7 @@
   },
   {
     "type": "base",
-    "named": false
+    "named": true
   },
   {
     "type": "break",
@@ -7309,7 +7321,7 @@
   },
   {
     "type": "this",
-    "named": false
+    "named": true
   },
   {
     "type": "throw",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -52,67 +52,96 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity) \
-  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+#define array_reserve(self, new_capacity)        \
+  ((self)->contents = _array__reserve(           \
+    (void *)(self)->contents, &(self)->capacity, \
+    array_elem_size(self), new_capacity)         \
+  )
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self) _array__delete((Array *)(self))
+#define array_delete(self)                           \
+  do {                                               \
+    if ((self)->contents) ts_free((self)->contents); \
+    (self)->contents = NULL;                         \
+    (self)->size = 0;                                \
+    (self)->capacity = 0;                            \
+  } while (0)
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                            \
-  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
-   (self)->contents[(self)->size++] = (element))
+#define array_push(self, element)                                 \
+  do {                                                            \
+    (self)->contents = _array__grow(                              \
+      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
+      1, array_elem_size(self)                                    \
+    );                                                            \
+   (self)->contents[(self)->size++] = (element);                  \
+  } while(0)
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count) \
-  do { \
-    if ((count) == 0) break; \
-    _array__grow((Array *)(self), count, array_elem_size(self)); \
+#define array_grow_by(self, count)                                               \
+  do {                                                                           \
+    if ((count) == 0) break;                                                     \
+    (self)->contents = _array__grow(                                             \
+      (self)->contents, (self)->size, &(self)->capacity,                         \
+      count, array_elem_size(self)                                               \
+    );                                                                           \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count); \
+    (self)->size += (count);                                                     \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other)                                       \
+#define array_push_all(self, other) \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, contents)                    \
-  _array__splice(                                               \
-    (Array *)(self), array_elem_size(self), (self)->size, \
-    0, count,  contents                                        \
+#define array_extend(self, count, other_contents)                 \
+  (self)->contents = _array__splice(                              \
+    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
+    array_elem_size(self), (self)->size, 0, count, other_contents \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents)  \
-  _array__splice(                                                       \
-    (Array *)(self), array_elem_size(self), _index,                \
-    old_count, new_count, new_contents                                 \
+#define array_splice(self, _index, old_count, new_count, new_contents) \
+  (self)->contents = _array__splice(                                   \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
+    array_elem_size(self), _index, old_count, new_count, new_contents  \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element) \
-  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+#define array_insert(self, _index, element)                     \
+  (self)->contents = _array__splice(                            \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
+    array_elem_size(self), _index, 0, 1, &(element)             \
+  )
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((Array *)(self), array_elem_size(self), _index)
+  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other) \
-  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+#define array_assign(self, other)                                   \
+  (self)->contents = _array__assign(                                \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
+    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
+  )
 
 /// Swap one array with another
-#define array_swap(self, other) \
-  _array__swap((Array *)(self), (Array *)(other))
+#define array_swap(self, other)                                     \
+  do {                                                              \
+    void *_array_swap_tmp = (void *)(self)->contents;               \
+    (self)->contents = (other)->contents;                           \
+    (other)->contents = _array_swap_tmp;                            \
+    _array__swap(&(self)->size, &(self)->capacity,                  \
+                 &(other)->size, &(other)->capacity);               \
+  } while (0)
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -157,82 +186,90 @@ extern "C" {
 
 // Private
 
-typedef Array(void) Array;
-
-/// This is not what you're looking for, see `array_delete`.
-static inline void _array__delete(Array *self) {
-  if (self->contents) {
-    ts_free(self->contents);
-    self->contents = NULL;
-    self->size = 0;
-    self->capacity = 0;
-  }
-}
+// Pointers to individual `Array` fields (rather than the entire `Array` itself)
+// are passed to the various `_array__*` functions below to address strict aliasing
+// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
+//
+// The `Array` type itself was not altered as a solution in order to avoid breakage
+// with existing consumers (in particular, parsers with external scanners).
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(Array *self, size_t element_size,
-                                uint32_t index) {
-  assert(index < self->size);
-  char *contents = (char *)self->contents;
+static inline void _array__erase(void* self_contents, uint32_t *size,
+                                size_t element_size, uint32_t index) {
+  assert(index < *size);
+  char *contents = (char *)self_contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (self->size - index - 1) * element_size);
-  self->size--;
+          (*size - index - 1) * element_size);
+  (*size)--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
-  if (new_capacity > self->capacity) {
-    if (self->contents) {
-      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+static inline void *_array__reserve(void *contents, uint32_t *capacity,
+                                  size_t element_size, uint32_t new_capacity) {
+  void *new_contents = contents;
+  if (new_capacity > *capacity) {
+    if (contents) {
+      new_contents = ts_realloc(contents, new_capacity * element_size);
     } else {
-      self->contents = ts_malloc(new_capacity * element_size);
+      new_contents = ts_malloc(new_capacity * element_size);
     }
-    self->capacity = new_capacity;
+    *capacity = new_capacity;
   }
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
-  _array__reserve(self, element_size, other->size);
-  self->size = other->size;
-  memcpy(self->contents, other->contents, self->size * element_size);
+static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
+                                 const void *other_contents, uint32_t other_size, size_t element_size) {
+  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
+  *self_size = other_size;
+  memcpy(new_contents, other_contents, *self_size * element_size);
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(Array *self, Array *other) {
-  Array swap = *other;
-  *other = *self;
-  *self = swap;
+static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
+                               uint32_t *other_size, uint32_t *other_capacity) {
+  uint32_t tmp_size = *self_size;
+  uint32_t tmp_capacity = *self_capacity;
+  *self_size = *other_size;
+  *self_capacity = *other_capacity;
+  *other_size = tmp_size;
+  *other_capacity = tmp_capacity;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
-  uint32_t new_size = self->size + count;
-  if (new_size > self->capacity) {
-    uint32_t new_capacity = self->capacity * 2;
+static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
+                               uint32_t count, size_t element_size) {
+  void *new_contents = contents;
+  uint32_t new_size = size + count;
+  if (new_size > *capacity) {
+    uint32_t new_capacity = *capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    _array__reserve(self, element_size, new_capacity);
+    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
   }
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void _array__splice(Array *self, size_t element_size,
+static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
+                                 size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t new_size = *size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= self->size);
+  assert(old_end <= *size);
 
-  _array__reserve(self, element_size, new_size);
+  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
 
-  char *contents = (char *)self->contents;
-  if (self->size > old_end) {
+  char *contents = (char *)new_contents;
+  if (*size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (self->size - old_end) * element_size
+      (*size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -250,7 +287,9 @@ static inline void _array__splice(Array *self, size_t element_size,
       );
     }
   }
-  self->size += new_count - old_count;
+  *size += new_count - old_count;
+
+  return new_contents;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -275,6 +275,7 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
       (indexer_declaration
         (modifier)
         type: (predefined_type)
+        (this)
         parameters: (bracketed_parameter_list
           (parameter
             type: (predefined_type)
@@ -294,6 +295,7 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
       (indexer_declaration
         (modifier)
         type: (predefined_type)
+        (this)
         parameters: (bracketed_parameter_list
           (parameter
             type: (predefined_type)
@@ -307,6 +309,7 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
       (indexer_declaration
         (modifier)
         type: (predefined_type)
+        (this)
         parameters: (bracketed_parameter_list
           (parameter
             type: (predefined_type)
@@ -331,6 +334,7 @@ public class NoBodyPrimaryWithBase(int x) : Base(x);
       (indexer_declaration
         (modifier)
         type: (predefined_type)
+        (this)
         parameters: (bracketed_parameter_list
           type: (array_type
             type: (predefined_type)
@@ -470,6 +474,7 @@ partial class C {
           (expression_statement
             (assignment_expression
               left: (member_access_expression
+                expression: (this)
                 name: (identifier))
               right: (identifier)))))
       (constructor_declaration

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -486,6 +486,7 @@ partial class C {
             type: (predefined_type)
             name: (identifier)))
         (constructor_initializer
+          (base)
           (argument_list
             (argument
               (identifier)))))
@@ -498,6 +499,7 @@ partial class C {
             type: (predefined_type)
             name: (identifier)))
         (constructor_initializer
+          (base)
           (argument_list
             (argument
               (identifier))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -4365,3 +4365,70 @@ class C { void M() {
                     type: (identifier))
                   value: (prefix_unary_expression
                     (integer_literal)))))))))))
+
+================================================================================
+Assign a comparison
+================================================================================
+
+var c = a < b;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (binary_expression
+            left: (identifier)
+            right: (identifier)))))))
+
+================================================================================
+Assign a container
+================================================================================
+
+var a = new List<PointUi>();
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (object_creation_expression
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            arguments: (argument_list)))))))
+
+================================================================================
+Assign a container initialized
+================================================================================
+
+var a = new List<PointUi>(points) { point };
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (local_declaration_statement
+      (variable_declaration
+        type: (implicit_type)
+        (variable_declarator
+          name: (identifier)
+          (object_creation_expression
+            type: (generic_name
+              (identifier)
+              (type_argument_list
+                (identifier)))
+            arguments: (argument_list
+              (argument
+                (identifier)))
+            initializer: (initializer_expression
+              (identifier))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2812,6 +2812,7 @@ var x = !this.Call();
           (prefix_unary_expression
             (invocation_expression
               function: (member_access_expression
+                expression: (this)
                 name: (identifier))
               arguments: (argument_list))))))))
 

--- a/test/corpus/interfaces.txt
+++ b/test/corpus/interfaces.txt
@@ -159,6 +159,7 @@ private interface NoBody;
                 name: (identifier))))
           (indexer_declaration
             type: (predefined_type)
+            (this)
             parameters: (bracketed_parameter_list
               (parameter
                 type: (predefined_type)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -496,6 +496,7 @@ class A {
             (block
               (return_statement)))
           (lock_statement
+            (this)
             (block
               (return_statement)))
           (yield_statement
@@ -718,6 +719,7 @@ class A {
             body: (block
               (return_statement)))
           (using_statement
+            (this)
             body: (block
               (return_statement))))))))
 


### PR DESCRIPTION
This PR has 2 fixes in 3 commits:

1. Make true nodes for `this` and `base` in many places.
1. Fix generics parsing mentioned in #434. This was inspired by what was done in the java parser.

Fixes #434

Happy to iterate and fix if needed.

Cheers.